### PR TITLE
Enable themes to specify empty text masks for password entry (plus doc bug fixes)

### DIFF
--- a/core/connect.js
+++ b/core/connect.js
@@ -78,7 +78,7 @@ function prepareTerminal(term) {
 
 function displayBanner(term) {
 	term.pipeWrite(
-		'|06Conected to |02EN|10i|02GMA|10½ |06BBS version |12|VN\n'	+
+		'|06Connected to |02EN|10i|02GMA|10½ |06BBS version |12|VN\n'	+
 		'|06Copyright (c) 2014-2015 Bryan Ashby |14- |12http://l33t.codes/\n'	+ 
 		'|06Updates & source |14- |12https://github.com/NuSkooler/enigma-bbs/\n'			+
 		'|00');
@@ -118,7 +118,7 @@ function connectEntry(client, nextMenu) {
 		prepareTerminal(term);
 
 		//
-		//	Always show a ENiGMA½ banner
+		//	Always show an ENiGMA½ banner
 		//
 		displayBanner(term);
 

--- a/core/edit_text_view.js
+++ b/core/edit_text_view.js
@@ -68,8 +68,9 @@ EditTextView.prototype.onKeyPress = function(ch, key) {
 			} else {
 				this.cursorPos.col += 1;
 
-				if(this.textMaskChar) {
-					this.client.term.write(this.textMaskChar);
+				if(_.isString(this.textMaskChar)) {
+					if(this.textMaskChar.length > 0)
+						this.client.term.write(this.textMaskChar);
 				} else {
 					this.client.term.write(ch);
 				}

--- a/core/view_controller.js
+++ b/core/view_controller.js
@@ -533,7 +533,7 @@ ViewController.prototype.loadFromPromptConfig = function(options, cb) {
 							//
 							//	Locate matching action block
 							//
-							//	:TODO: this is bacially the same as for menus -- DRY it up!
+							//	:TODO: this is basically the same as for menus -- DRY it up!
 							for(var c = 0; c < menuSubmit.length; ++c) {
 								var actionBlock = menuSubmit[c];
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,7 +46,7 @@ The main system configuration is handled via `~/.config/enigma-bbs/config.hjson`
 ### Via oputil.js
 `oputil.js` can be utilized to generate your **initial** configuration. **This is the recommended way for all new users**:
 
-    optutil.js config --new
+   ./oputil.js config --new
 
 You wil be asked a series of basic questions.
 

--- a/docs/menu_system.md
+++ b/docs/menu_system.md
@@ -69,6 +69,6 @@ matrix: {
 }
 ```
 
-In the above entry, you'll notice `form`. This defines a form(s) object. In this case, a single form by ID of `0`. The system is then told to use a block only when the resulting art provides a `VM` (*VerticalMenuView*) MCI entry. `VM1` is then setup to to `submit` and start focused via `focus: true` as well as have some menu entries ("login", "apply", ...) defined.
+In the above entry, you'll notice `form`. This defines a form(s) object. In this case, a single form by ID of `0`. The system is then told to use a block only when the resulting art provides a `VM` (*VerticalMenuView*) MCI entry. `VM1` is then setup to `submit` and start focused via `focus: true` as well as have some menu entries ("login", "apply", ...) defined.
 
 The `submit` object tells the system to attempt to apply provided match entries from any view ID (`*`). Upon submit, the first match will be executed. For example, if the user selects "login", the first entry with a value of `{ 1: 0 }` or view ID 1, value 0 will match causing `action` of `@menu:login` to be executed (go to `login` menu).


### PR DESCRIPTION
Changes in this request:

* **Themes can now specify empty text masks.** This allows themes to prevent text from being sent during password entry akin to a *nix password prompt. To enable, edit `theme.hjson` and set $.customization.defaults.general.passwordChar to "". e.g.,

```text
{
  ...
  customization: {
    defaults: {
      general: {
        passwordChar: ""
      }
    }
    ...
  }
}
```

* **Documentation edits.** Clarify the *oputil* invocation, plus spelling and grammar fixes.