### PR TITLE
Some installer script tweaks

### DIFF
--- a/misc/install.sh
+++ b/misc/install.sh
@@ -48,6 +48,9 @@ enigma_install_init() {
 
     log "Checking curl installation"
     enigma_install_needs curl
+
+    log "Checking Python installation"
+    enigma_install_needs python
 }
 
 install_nvm() {

--- a/misc/install.sh
+++ b/misc/install.sh
@@ -90,6 +90,7 @@ install_node_packages() {
       log "npm package installation complete"
     else
       log_error "Failed to install ENiGMA½ npm packages. Please report this!"
+      exit 1
     fi
 }
 


### PR DESCRIPTION
Spotted a mistake in the script - if ````npm install```` failed the script didn't exit accordingly. I've also added a check for a Python executable - on Ubuntu Server for the RPi it wasn't there as part of the default build.