### PR TITLE
Small typo in username validation error message

### DIFF
--- a/core/system_view_validate.js
+++ b/core/system_view_validate.js
@@ -40,7 +40,7 @@ function validateUserNameAvail(data, cb) {
 		} else {
 			user.getUserIdAndName(data, function userIdAndName(err) {
 				if(!err) {	//	err is null if we succeeded -- meaning this user exists already
-					return cb(new Error('Userame unavailable'));
+					return cb(new Error('Username unavailable'));
 				}
 				
 				return cb(null);


### PR DESCRIPTION
Fixed a small typo that popped up if a username was already in use.