### PR TITLE
Switch to xxhash

### DIFF
--- a/core/art.js
+++ b/core/art.js
@@ -7,7 +7,7 @@ const miscUtil	= require('./misc_util.js');
 const ansi		= require('./ansi_term.js');
 const aep		= require('./ansi_escape_parser.js');
 const sauce		= require('./sauce.js');
-const farmhash	= require('farmhash');
+const xxhash    = require('xxhash');
 
 //	deps
 const fs		= require('fs');
@@ -280,7 +280,7 @@ function display(client, art, options, cb) {
 
 
 	if(!options.disableMciCache) {		
-		artHash	= farmhash.hash32(art);
+		artHash	= xxhash.hash(new Buffer(art), 0xCAFEBABE);
 
 		//	see if we have a mciMap cached for this art
 		if(client.mciCache) {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "temp": "^0.8.3",
     "inquirer" : "^1.1.0",
     "fs-extra" : "0.26.x",
-    "farmhash"  : "^1.2.0"
+    "xxhash" : "^0.2.4"
   },
   "engines": {
     "node": ">=4.2.0"


### PR DESCRIPTION
xxhash works nicely on the RPi3, have switched the mci cache over to that. Only slightly different things are that xxhash wants a seed, so I used the nice example from the docs :-) The input also needs to be a buffer...

Have checked through the trace logs, and it's definitely reusing the mci cache when loading artwork....and it works on the RPi! :+1: 