### PR TITLE
Upgrade farmhash to v1.2.1 to fix RPi3 native extension compile errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "temp": "^0.8.3",
     "inquirer" : "^1.1.0",
     "fs-extra" : "0.26.x",
-    "farmhash"  : "^1.2.0"
+    "farmhash"  : "^1.2.1"
   },
   "engines": {
     "node": ">=4.2.0"


### PR DESCRIPTION
Updates to farmhash to v1.2.1 which includes the RPi3 fix.