### PR TITLE
Fixed error: property 'get' of undefined

### DIFF
--- a/core/config.js
+++ b/core/config.js
@@ -99,11 +99,15 @@ function init(configPath, options, cb) {
 			}
 		],
 		function complete(err, mergedConfig) {
-			exports.config = mergedConfig;
-
-			exports.config.get = function(path) {
-				return _.get(exports.config, path);
-			};
+                        if (typeof(mergedConfig) == 'undefined') {
+                                exports.config = {};
+                        } else {
+                                exports.config = Object.assign(mergedConfig, {
+                                        "get": function(path) {
+                                                return _.get(exports.config, path);
+                                        }
+                                });
+                        }
 
 			return cb(err);
 		}


### PR DESCRIPTION
Fixed error: property 'get' of undefined (TypeError)

```
TypeError: Cannot set property 'get' of undefined
    at complete (/home/gosomi/enigma-bbs/core/config.js:104:23)
    at /home/gosomi/enigma-bbs/node_modules/async/dist/async.js:421:16
    at next (/home/gosomi/enigma-bbs/node_modules/async/dist/async.js:5302:29)
    at /home/gosomi/enigma-bbs/node_modules/async/dist/async.js:906:16
    at ReadFileContext.fs.readFile.e (/home/gosomi/enigma-bbs/core/config.js:59:14)
    at ReadFileContext.callback (/home/gosomi/enigma-bbs/node_modules/graceful-fs/graceful-fs.js:78:16)
    at FSReqWrap.readFileAfterOpen [as oncomplete] (fs.js:367:13)
gosomi@gosomi:~/enigma-bbs$ nano /home/gosomi/enigma-bbs/core/config.js
gosomi@gosomi:~/enigma-bbs$ nano /home/gosomi/enigma-bbs/core/config.js
gosomi@gosomi:~/enigma-bbs$ ./main.js
/home/gosomi/enigma-bbs/core/config.js:104
                        exports.config.get = function(path) {
```