### PR TITLE
Support npm start

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,8 @@
   "description": "ENiGMA½ Bulletin Board System",
   "author": "Bryan Ashby <bryan@l33t.codes>",
   "license": "BSD-2-Clause",
-  "main": "./core/bbs",
   "scripts": {
-    "start": "node main"
+    "start": "node main.js"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,10 @@
   "description": "ENiGMA½ Bulletin Board System",
   "author": "Bryan Ashby <bryan@l33t.codes>",
   "license": "BSD-2-Clause",
+  "main": "./core/bbs",
+  "scripts": {
+    "start": "node main"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/NuSkooler/enigma-bbs.git"


### PR DESCRIPTION
Fill-in the missing pieces in the package.json file. From now on `npm start` just works like all other nodejs apps.