### PR TITLE
[DOCS] Invalid JSON - Missing Comma

### DIFF
--- a/docs/servers/websocket.md
+++ b/docs/servers/websocket.md
@@ -64,7 +64,7 @@ webserver, and unpack it to a temporary directory.
     ````javascript
     var vtxdata = {
         sysName: "Your Awesome BBS",
-        wsConnect: "wss://your-hostname.here:8811" 
+        wsConnect: "wss://your-hostname.here:8811",
         term: "ansi-bbs",
         codePage: "CP437",
         fontName: "UVGA16",


### PR DESCRIPTION
Was missing the ending comma on the wsConnect line in the websocket docs. This just adds it.