### PR TITLE
Add mb "command" in oputil help

### DIFF
--- a/core/oputil/oputil_help.js
+++ b/core/oputil/oputil_help.js
@@ -19,6 +19,7 @@ commands:
   user                      user utilities
   config                    config file management
   fb                        file base management
+  mb                        message base management
 `,
 	User : 
 `usage: optutil.js user --user USERNAME <args>


### PR DESCRIPTION
The general help for optutil.js didn't list `mb` as a management tool. This adds this to the list.