### PR TITLE
Missing mb command in oputil.js help

### DIFF
--- a/core/oputil/oputil_help.js
+++ b/core/oputil/oputil_help.js
@@ -19,6 +19,7 @@ commands:
   user                      user utilities
   config                    config file management
   fb                        file base management
+  mb                        message base management
 `,
 	User : 
 `usage: optutil.js user --user USERNAME <args>


### PR DESCRIPTION
The `mb` sub-command was missing from the general help output from oputil.js - this add it.