### PR TITLE
Force no compression

### DIFF
--- a/core/servers/login/ssh.js
+++ b/core/servers/login/ssh.js
@@ -248,6 +248,7 @@ exports.getModule = class SSHServerModule extends LoginServerModule {
 					Log.trace(`SSH: ${sshDebugLine}`);
 				}
 			},
+			algorithms: { compress: ['none'] },
 		};
 
 		this.server = ssh2.Server(serverConf);


### PR DESCRIPTION
It appears as tho there is a problem with compression and the upstream library. This PR forces no compression mode, making a work around for #181. 

This work around is derived from https://github.com/mscdex/ssh2/issues/594 which may be the cause for #181 as well.