### PR TITLE
Remove -Wait for Powershell comment

### DIFF
--- a/misc/config_template.in.hjson
+++ b/misc/config_template.in.hjson
@@ -67,7 +67,7 @@
         //
         //  Remember you can pipe logs through Bunyan to pretty-print:
         //  Linux      : tail -F ./logs/enigma-bbs.log | bunyan
-        //  PowerShell : Get-Content .\enigma-bbs.log -Wait -Tail 15 | bunyan.cmd
+        //  PowerShell : Get-Content .\enigma-bbs.log -Tail 15 | bunyan.cmd
         //
         //  (npm install -g bunyan to get the binary)
         //


### PR DESCRIPTION
-Wait doesn't work. It sits there waiting for completion before forwarding.