### PR TITLE
Update docker.md

### DIFF
--- a/docs/installation/docker.md
+++ b/docs/installation/docker.md
@@ -11,7 +11,7 @@ Download and run the ENiGMA½ BBS image:
 
     docker run -d \
       -p 8888:8888 \
-      davestephens\enigma-bbs
+      davestephens/enigma-bbs:latest
 
 As no config has been supplied the container will use a basic one so that it starts successfully. Note that as no persistence 
 directory has been supplied, once the container stops any changes made will be lost!


### PR DESCRIPTION
Updated the command to reflect current syntax. The previously-listed version had a backslash in the container reference which caused a failure to run. The `:latest` tag is added for a reminder to the user that it is going to pull the latest image.