### PR TITLE
Minor Documentation Updates

### DIFF
--- a/docs/installation/network.md
+++ b/docs/installation/network.md
@@ -2,5 +2,12 @@
 layout: page
 title: Network Setup
 ---
-:zap: This page is to describe general information on how to set your router to forward traffic to ENiGMA. It
-needs fleshing out, please submit a PR if you'd like to help!
+## Hosting an ENIGMA instance from your Home Network
+
+If you are hosting your ENGIMA instance from inside your local network, you'll need to open your chosen ports on your router, so people outside your local area network can access the BBS.
+
+Each router has a different way of doing this, but this [comprehensive resource](https://portforward.com/) explains how to port forward on most common brand routers.
+
+Secondly, it is likely that your public facing server IP is a [Dynamic Address](https://support.opendns.com/hc/en-us/articles/227987827-What-is-a-Dynamic-IP-Address-) automatically provisoned to you by your ISP. You can contact your ISP and request a static IP, but in some areas this isn't available to consumers, only businesses.
+
+Using a tool like [Duck DNS](https://www.duckdns.org/) will give you a free subdomain that automatically adjusts its records whenever your IP Address changes.

--- a/docs/servers/web-server.md
+++ b/docs/servers/web-server.md
@@ -5,18 +5,19 @@ title: Web Server
 ENiGMA½ comes with a built in *content server* for supporting both HTTP and HTTPS. Currently the [File Bases](../modding/file-base-web-download-manager.md) registers routes for file downloads, password reset email links are handled via the server, and static files can also be served for your BBS. Other features will likely come in the future or you can easily write your own!
 
 # Configuration
+
 By default the web server is not enabled. To enable it, you will need to at a minimum configure two keys in the `contentServers.web` section of `config.hjson`:
 
 ```hjson
 contentServers: {
-	web: {
-		domain: bbs.yourdomain.com
+ web: {
+  domain: bbs.yourdomain.com
 
-		http: {
-			enabled: true
-			port: 8080
-		}
-	}
+  http: {
+   enabled: true
+   port: 8080
+  }
+ }
 }
 ```
 
@@ -28,6 +29,7 @@ The following is a table of all configuration keys available under `contentServe
 | `overrideUrlPrefix` | :-1: | Instructs the system to be explicit when handing out URLs. Useful if your server is behind a transparent proxy. |
 
 ### HTTP Configuration
+
 Entries available under `contentServers.web.http`:
 
 | Key | Required | Description |
@@ -37,6 +39,7 @@ Entries available under `contentServers.web.http`:
 | `address` | :-1: | Sets an explicit bind address. |
 
 ### HTTPS Configuration
+
 Entries available under `contentServers.web.https`:
 
 | Key | Required | Description |
@@ -48,10 +51,19 @@ Entries available under `contentServers.web.https`:
 | `keyPem` | :+1: | Overrides the default certificate key path of `/config/https_cert_key.pem`. Key must be in PEM format. See **Certificates** below. |
 
 #### Certificates
+
 If you don't have a TLS certificate for your domain, a good source for a certificate can be [LetsEncrypt](https://letsencrypt.org/) who supplies free and trusted TLS certificates.
 
 ## Static Routes
+
 Static files live relative to the `contentServers.web.staticRoot` path which defaults to `enigma-bbs/www`.
 
+`index.html, favicon.ico`, and any error pages like `404.html` are accessible from the route path. Other static assets hosted by the web server must be referenced from `/static/`, for example:
+
+```html
+<a href="/static/about.html"> Example Link
+```
+
 ## Custom Error Pages
+
 Customized error pages can be created for [HTTP error codes](https://en.wikipedia.org/wiki/List_of_HTTP_status_codes#4xx_Client_Error) by providing a `<error_code>.html` file in the *static routes* area. For example: `404.html`.

--- a/docs/servers/web-server.md
+++ b/docs/servers/web-server.md
@@ -54,6 +54,8 @@ Entries available under `contentServers.web.https`:
 
 If you don't have a TLS certificate for your domain, a good source for a certificate can be [LetsEncrypt](https://letsencrypt.org/) who supplies free and trusted TLS certificates.
 
+Keep in mind that the SSL certificate provided by Let's Encrypt's Certbot is by default stored in a privileged location; if your ENIGMA instance is not running as root (which it should not be!), you'll need to copy the SSL certificate somewhere else in order for ENIGMA to use it.
+
 ## Static Routes
 
 Static files live relative to the `contentServers.web.staticRoot` path which defaults to `enigma-bbs/www`.


### PR DESCRIPTION
Added some things that were missing in the documentation that hindered me when I was setting up my own install.

These changes are:

1. Filling out the Networking page to include information on port forwarding and DynDNS. It's sparse, but a good foot hold for people unfamiliar with the topics.
2. Mentioning that files served by the web server are available by default from the "/static/" route
3. Mentioning that CertBot requires a privilege adjustment to work with a instance running as non-route.

Thanks for the great tool, NuSkooler!