### PR TITLE
add cascading delete to multiple keys within file db

### DIFF
--- a/core/database.js
+++ b/core/database.js
@@ -421,7 +421,8 @@ const DB_INIT_TABLE = {
                 hash_tag_id     INTEGER NOT NULL,
                 file_id         INTEGER NOT NULL,
 
-                UNIQUE(hash_tag_id, file_id)
+                UNIQUE(hash_tag_id, file_id),
+                FOREIGN KEY(file_id) REFERENCES file(file_id) ON DELETE CASCADE
             );`
         );
 
@@ -431,7 +432,8 @@ const DB_INIT_TABLE = {
                 user_id         INTEGER NOT NULL,
                 rating          INTEGER NOT NULL,
 
-                UNIQUE(file_id, user_id)
+                UNIQUE(file_id, user_id),
+                FOREIGN KEY(file_id) REFERENCES file(file_id) ON DELETE CASCADE
             );`
         );
 
@@ -447,7 +449,8 @@ const DB_INIT_TABLE = {
                 hash_id     VARCHAR NOT NULL,
                 file_id     INTEGER NOT NULL,
 
-                UNIQUE(hash_id, file_id)
+                UNIQUE(hash_id, file_id),
+                FOREIGN KEY(file_id) REFERENCES file(file_id) ON DELETE CASCADE
             );`
         );
 


### PR DESCRIPTION
Added cascading delete to file_id fk in multiple places. should resolve bugs related to #333. existing users will need a way to update their existing db if they don't want to delete it to have it recreated.