### PR TITLE
stop showing 'MRC_Watchdog@MRC_Watchdog_Process just left the server'…

### DIFF
--- a/core/mrc.js
+++ b/core/mrc.js
@@ -325,8 +325,10 @@ exports.getModule = class mrcModule extends MenuModule {
                     }
 
                     default:
-                        this.addMessageToChatLog(message.body);
-                        break;
+                        if(!message.body.includes("MRC_Watchdog")) {
+                            this.addMessageToChatLog(message.body);
+                            break;
+                        }
                 }
 
             } else {


### PR DESCRIPTION
… in message window every time MRC server sends a watchdog

![image](https://user-images.githubusercontent.com/40481087/151680188-f30d0bdf-4a23-42a6-a896-8743e86fc0a7.png)
