### PR TITLE
 FIX: Neither Backspace or Delete work in mTCP Telnet #412

### DIFF
--- a/core/edit_text_view.js
+++ b/core/edit_text_view.js
@@ -6,10 +6,16 @@ const TextView      = require('./text_view.js').TextView;
 const miscUtil      = require('./misc_util.js');
 const strUtil       = require('./string_util.js');
 
+const VIEW_SPECIAL_KEY_MAP_DEFAULT = require('./view').VIEW_SPECIAL_KEY_MAP_DEFAULT;
+
 //  deps
 const _             = require('lodash');
 
 exports.EditTextView    = EditTextView;
+
+const EDIT_TEXT_VIEW_KEY_MAP = Object.assign({}, VIEW_SPECIAL_KEY_MAP_DEFAULT, {
+    delete : [ 'delete', 'ctrl + d' ],  //  https://www.tecmint.com/linux-command-line-bash-shortcut-keys/
+});
 
 function EditTextView(options) {
     options.acceptsFocus    = miscUtil.valueWithDefault(options.acceptsFocus, true);
@@ -17,16 +23,28 @@ function EditTextView(options) {
     options.cursorStyle     = miscUtil.valueWithDefault(options.cursorStyle, 'steady block');
     options.resizable       = false;
 
+    if(!_.isObject(options.specialKeyMap)) {
+        options.specialKeyMap = EDIT_TEXT_VIEW_KEY_MAP;
+    }
+
     TextView.call(this, options);
 
     this.initDefaultWidth();
-
     this.cursorPos = { row : 0, col : 0 };
 
     this.clientBackspace = function() {
-        const fillCharSGR = this.getStyleSGR(1) || this.getSGR();
-        this.client.term.write(`\b${fillCharSGR}${this.fillChar}\b${this.getFocusSGR()}`);
-    };
+        this.text = this.text.substr(0, this.text.length - 1);
+
+        if(this.text.length >= this.dimens.width) {
+            this.redraw();
+        } else {
+            this.cursorPos.col -= 1;
+            if(this.cursorPos.col >= 0) {
+                const fillCharSGR = this.getStyleSGR(1) || this.getSGR();
+                this.client.term.write(`\b${fillCharSGR}${this.fillChar}\b${this.getFocusSGR()}`);
+            }
+        }
+    }
 }
 
 require('util').inherits(EditTextView, TextView);
@@ -35,19 +53,16 @@ EditTextView.prototype.onKeyPress = function(ch, key) {
     if(key) {
         if(this.isKeyMapped('backspace', key.name)) {
             if(this.text.length > 0) {
-                this.text = this.text.substr(0, this.text.length - 1);
-
-                if(this.text.length >= this.dimens.width) {
-                    this.redraw();
-                } else {
-                    this.cursorPos.col -= 1;
-                    if(this.cursorPos.col >= 0) {
-                        this.clientBackspace();
-                    }
-                }
+                this.clientBackspace();
             }
 
             return EditTextView.super_.prototype.onKeyPress.call(this, ch, key);
+        } else if (this.isKeyMapped('delete', key.name)) {
+            //  Some (mostly older) terms send 'delete' for Backspace.
+            //  if we're at the end of the line, go ahead and treat them the same
+            if (this.text.length > 0 && this.cursorPos.col === this.text.length) {
+                this.clientBackspace();
+            }
         } else if(this.isKeyMapped('clearLine', key.name)) {
             this.text           = '';
             this.cursorPos.col  = 0;

--- a/core/multi_line_edit_text_view.js
+++ b/core/multi_line_edit_text_view.js
@@ -65,7 +65,7 @@ const _             = require('lodash');
 const SPECIAL_KEY_MAP_DEFAULT = {
     'line feed'     : [ 'return' ],
     exit            : [ 'esc' ],
-    backspace       : [ 'backspace' ],
+    backspace       : [ 'backspace', 'ctrl + d' ],  //  https://www.tecmint.com/linux-command-line-bash-shortcut-keys/
     delete          : [ 'delete' ],
     tab             : [ 'tab' ],
     up              : [ 'up arrow' ],
@@ -74,7 +74,7 @@ const SPECIAL_KEY_MAP_DEFAULT = {
     home            : [ 'home' ],
     left            : [ 'left arrow' ],
     right           : [ 'right arrow' ],
-    'delete line'   : [ 'ctrl + y' ],
+    'delete line'   : [ 'ctrl + y', 'ctrl + u' ],   //  https://en.wikipedia.org/wiki/Backspace
     'page up'       : [ 'page up' ],
     'page down'     : [ 'page down' ],
     insert          : [ 'insert', 'ctrl + v' ],

--- a/core/view.js
+++ b/core/view.js
@@ -17,7 +17,7 @@ exports.View                            = View;
 const VIEW_SPECIAL_KEY_MAP_DEFAULT = {
     accept      : [ 'return' ],
     exit        : [ 'esc' ],
-    backspace   : [ 'backspace', 'del' ],
+    backspace   : [ 'backspace', 'del', 'ctrl + d'],    //  https://www.tecmint.com/linux-command-line-bash-shortcut-keys/
     del         : [ 'del' ],
     next        : [ 'tab' ],
     up          : [ 'up arrow' ],


### PR DESCRIPTION
 * Add CTRL-D as a default additional backspace key
 * Kludge 'delete' treated the same as 'backspace' in EditTextView if at the EOL