### PR TITLE
Ssh server updates with ssh2

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -30,7 +30,7 @@ Report your issue on Xibalba BBS, hop in #enigma-bbs on FreeNode and chat, or
 
 
 # 0.0.12-beta to 0.0.13-beta
-
+* :exclamation: The SSH server's `ssh2` module has gone through a major upgrade. Existing users will need to comment out two SSH KEX algorithms from their `config.hjson` if present else clients such as NetRunner will not be able to connect over SSH. Comment out `diffie-hellman-group-exchange-sha256` and `diffie-hellman-group-exchange-sha1`
 * All features and changes are backwards compatible. There are a few new configuration options in a new `term` section in the configuration. These are all optional, but include the following options in case you use them:
 
 ```hjson

--- a/core/config_default.js
+++ b/core/config_default.js
@@ -184,10 +184,11 @@ module.exports = () => {
                         'ecdh-sha2-nistp256',
                         'ecdh-sha2-nistp384',
                         'ecdh-sha2-nistp521',
-                        'diffie-hellman-group-exchange-sha256',
                         'diffie-hellman-group14-sha1',
-                        'diffie-hellman-group-exchange-sha1',
                         'diffie-hellman-group1-sha1',
+                        //  Group exchange not currnetly supported
+                        //  'diffie-hellman-group-exchange-sha256',
+                        //  'diffie-hellman-group-exchange-sha1',
                     ],
                     cipher : [
                         'aes128-ctr',

--- a/core/servers/login/ssh.js
+++ b/core/servers/login/ssh.js
@@ -357,7 +357,9 @@ exports.getModule = class SSHServerModule extends LoginServerModule {
         //  However, as of this writing, NetRunner and SyncTERM both
         //  fail to respond to OpenSSH keep-alive pings (keepalive@openssh.com)
         //
-        ssh2.Server.KEEPALIVE_INTERVAL = 0;
+        //  See also #399
+        //
+        ssh2.Server.KEEPALIVE_CLIENT_INTERVAL = 0;
 
         this.server = new ssh2.Server(serverConf);
         this.server.on('connection', (conn, info) => {

--- a/core/servers/login/ssh.js
+++ b/core/servers/login/ssh.js
@@ -359,7 +359,7 @@ exports.getModule = class SSHServerModule extends LoginServerModule {
         //
         ssh2.Server.KEEPALIVE_INTERVAL = 0;
 
-        this.server = ssh2.Server(serverConf);
+        this.server = new ssh2.Server(serverConf);
         this.server.on('connection', (conn, info) => {
             Log.info(info, 'New SSH connection');
             this.handleNewClient(new SSHClient(conn), conn._sock, ModuleInfo);

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "sanitize-filename": "^1.6.3",
     "sqlite3": "^4.2.0",
     "sqlite3-trans": "^1.2.2",
-    "ssh2": "0.8.9",
+    "ssh2": "^1.9.0",
     "telnet-socket": "^0.2.3",
     "temptmp": "^1.1.0",
     "uuid": "8.3.2",


### PR DESCRIPTION
I think this is ready to go. The NR off-by-one isn't something new (NR providing bad term info). Disabling the keep-alive in the new SSH module like was previously done in the older version does the trick at fixing NR hanging.
