### PR TITLE
SyncTERM Font Support Detection

### DIFF
--- a/core/ansi_term.js
+++ b/core/ansi_term.js
@@ -59,8 +59,8 @@ exports.resetScreen                 = resetScreen;
 exports.normal                      = normal;
 exports.goHome                      = goHome;
 exports.disableVT100LineWrapping    = disableVT100LineWrapping;
-exports.setSyncTERMFont             = setSyncTERMFont;
-exports.getSyncTERMFontFromAlias    = getSyncTERMFontFromAlias;
+exports.setSyncTermFont             = setSyncTermFont;
+exports.getSyncTermFontFromAlias    = getSyncTermFontFromAlias;
 exports.setSyncTermFontWithAlias    = setSyncTermFontWithAlias;
 exports.setCursorStyle              = setCursorStyle;
 exports.setEmulatedBaudRate         = setEmulatedBaudRate;
@@ -320,7 +320,7 @@ const FONT_ALIAS_TO_SYNCTERM_MAP = {
 
 };
 
-function setSyncTERMFont(name, fontPage) {
+function setSyncTermFont(name, fontPage) {
     const p1 = miscUtil.valueWithDefault(fontPage, 0);
 
     assert(p1 >= 0 && p1 <= 3);
@@ -333,13 +333,13 @@ function setSyncTERMFont(name, fontPage) {
     return '';
 }
 
-function getSyncTERMFontFromAlias(alias) {
+function getSyncTermFontFromAlias(alias) {
     return FONT_ALIAS_TO_SYNCTERM_MAP[alias.toLowerCase().replace(/ /g, '_')];
 }
 
 function setSyncTermFontWithAlias(nameOrAlias) {
-    nameOrAlias = getSyncTERMFontFromAlias(nameOrAlias) || nameOrAlias;
-    return setSyncTERMFont(nameOrAlias);
+    nameOrAlias = getSyncTermFontFromAlias(nameOrAlias) || nameOrAlias;
+    return setSyncTermFont(nameOrAlias);
 }
 
 const DEC_CURSOR_STYLE = {

--- a/core/art.js
+++ b/core/art.js
@@ -351,23 +351,25 @@ function display(client, art, options, cb) {
     });
 
     let initSeq = '';
-    if(options.font) {
-        initSeq = ansi.setSyncTermFontWithAlias(options.font);
-    } else if(options.sauce) {
-        let fontName = getFontNameFromSAUCE(options.sauce);
-        if(fontName) {
-            fontName = ansi.getSyncTERMFontFromAlias(fontName);
-        }
+    if (client.term.syncTermFontsEnabled) {
+        if(options.font) {
+            initSeq = ansi.setSyncTermFontWithAlias(options.font);
+        } else if(options.sauce) {
+            let fontName = getFontNameFromSAUCE(options.sauce);
+            if(fontName) {
+                fontName = ansi.getSyncTermFontFromAlias(fontName);
+            }
 
-        //
-        //  Set SyncTERM font if we're switching only. Most terminals
-        //  that support this ESC sequence can only show *one* font
-        //  at a time. This applies to detection only (e.g. SAUCE).
-        //  If explicit, we'll set it no matter what (above)
-        //
-        if(fontName && client.term.currentSyncFont != fontName) {
-            client.term.currentSyncFont = fontName;
-            initSeq = ansi.setSyncTERMFont(fontName);
+            //
+            //  Set SyncTERM font if we're switching only. Most terminals
+            //  that support this ESC sequence can only show *one* font
+            //  at a time. This applies to detection only (e.g. SAUCE).
+            //  If explicit, we'll set it no matter what (above)
+            //
+            if(fontName && client.term.currentSyncFont != fontName) {
+                client.term.currentSyncFont = fontName;
+                initSeq = ansi.setSyncTermFont(fontName);
+            }
         }
     }
 

--- a/core/client_term.js
+++ b/core/client_term.js
@@ -21,6 +21,8 @@ function ClientTerminal(output) {
     //  convert line feeds such as \n -> \r\n
     this.convertLF      = true;
 
+    this.syncTermFontsEnabled = false;
+
     //
     //  Some terminal we handle specially
     //  They can also be found in this.env{}

--- a/core/telnet_bridge.js
+++ b/core/telnet_bridge.js
@@ -199,7 +199,8 @@ exports.getModule = class TelnetBridgeModule extends MenuModule {
                         self.client.removeListener('key press', connectionKeyPressHandler);
                         self.client.log.info(connectOpts, 'Telnet bridge connection established');
 
-                        if(self.config.font) {
+                        //  put the font back how it was prior, if fonts are enabled
+                        if(self.client.term.syncTermFontsEnabled && self.config.font) {
                             self.client.term.rawWrite(setSyncTermFontWithAlias(self.config.font));
                         }
 


### PR DESCRIPTION
* Attempt to detect SyncTERM font support using DSR/CPR
* If a terminal doesn't support DSR/CPR, assume it doesn't support SyncTERM fonts, either.
* Support is also disabled if term simply doesn't ignore the ESC sequence, either