### PR TITLE
Remove MCI cache

### DIFF
--- a/core/art.js
+++ b/core/art.js
@@ -15,7 +15,6 @@ const paths     = require('path');
 const assert    = require('assert');
 const iconv     = require('iconv-lite');
 const _         = require('lodash');
-const xxhash    = require('xxhash');
 
 exports.getArt                          = getArt;
 exports.getArtFromPath                  = getArtFromPath;
@@ -250,8 +249,7 @@ function display(client, art, options, cb) {
         return cb(Errors.Invalid('No art supplied!'));
     }
 
-    options.mciReplaceChar  = options.mciReplaceChar || ' ';
-    options.disableMciCache = options.disableMciCache || false;
+    options.mciReplaceChar = options.mciReplaceChar || ' ';
 
     //  :TODO: this is going to be broken into two approaches controlled via options:
     //  1) Standard - use internal tracking of locations for MCI -- no CPR's/etc.
@@ -272,82 +270,45 @@ function display(client, art, options, cb) {
         startRow        : options.startRow,
     });
 
-    let parseComplete = false;
-    let mciMap;
-    const mciCprQueue = [];
-    let artHash;
-    let mciMapFromCache;
+    const mciMap = {};
+    let generatedId = 100;
 
-    function completed() {
+    ansiParser.on('mci', mciInfo => {
+        //  :TODO: ensure generatedId's do not conflict with any existing |id|
+        const id        = _.isNumber(mciInfo.id) ? mciInfo.id : generatedId;
+        const mapKey    = `${mciInfo.mci}${id}`;
+        const mapEntry  = mciMap[mapKey];
 
-        if(!options.disableMciCache && !mciMapFromCache) {
-            //  cache our MCI findings...
-            client.mciCache[artHash] = mciMap;
-            client.log.trace( { artHash : artHash.toString(16), mciMap : mciMap }, 'Added MCI map to cache');
+        if(mapEntry) {
+            mapEntry.focusSGR   = mciInfo.SGR;
+            mapEntry.focusArgs  = mciInfo.args;
+        } else {
+            mciMap[mapKey] = {
+                position : mciInfo.position,
+                args     : mciInfo.args,
+                SGR      : mciInfo.SGR,
+                code     : mciInfo.mci,
+                id       : id,
+            };
+
+            if(!mciInfo.id) {
+                ++generatedId;
+            }
         }
 
-        ansiParser.removeAllListeners();    //  :TODO: Necessary???
+    });
+
+    ansiParser.on('literal', literal => client.term.write(literal, false) );
+    ansiParser.on('control', control => client.term.rawWrite(control) );
+
+    ansiParser.on('complete', () => {
+        ansiParser.removeAllListeners();
 
         const extraInfo = {
             height : ansiParser.row - 1,
         };
 
         return cb(null, mciMap, extraInfo);
-    }
-
-    if(!options.disableMciCache) {
-        artHash = xxhash.hash(Buffer.from(art), 0xCAFEBABE);
-
-        //  see if we have a mciMap cached for this art
-        if(client.mciCache) {
-            mciMap  = client.mciCache[artHash];
-        }
-    }
-
-    if(mciMap) {
-        mciMapFromCache = true;
-        client.log.trace( { artHash : artHash.toString(16), mciMap : mciMap }, 'Loaded MCI map from cache');
-    } else {
-        //  no cached MCI info
-        mciMap = {};
-
-        let generatedId = 100;
-
-        ansiParser.on('mci', mciInfo => {
-            //  :TODO: ensure generatedId's do not conflict with any existing |id|
-            const id        = _.isNumber(mciInfo.id) ? mciInfo.id : generatedId;
-            const mapKey    = `${mciInfo.mci}${id}`;
-            const mapEntry  = mciMap[mapKey];
-
-            if(mapEntry) {
-                mapEntry.focusSGR   = mciInfo.SGR;
-                mapEntry.focusArgs  = mciInfo.args;
-            } else {
-                mciMap[mapKey] = {
-                    position : mciInfo.position,
-                    args     : mciInfo.args,
-                    SGR      : mciInfo.SGR,
-                    code     : mciInfo.mci,
-                    id       : id,
-                };
-
-                if(!mciInfo.id) {
-                    ++generatedId;
-                }
-            }
-
-        });
-    }
-
-    ansiParser.on('literal', literal => client.term.write(literal, false) );
-    ansiParser.on('control', control => client.term.rawWrite(control) );
-
-    ansiParser.on('complete', () => {
-        parseComplete = true;
-
-        if(0 === mciCprQueue.length) {
-            return completed();
-        }
     });
 
     let initSeq = '';

--- a/core/client.js
+++ b/core/client.js
@@ -87,12 +87,7 @@ function Client(/*input, output*/) {
     this.lastActivityTime   = Date.now();
     this.menuStack          = new MenuStack(this);
     this.acs                = new ACS( { client : this, user : this.user } );
-    this.mciCache           = {};
     this.interruptQueue     = new UserInterruptQueue(this);
-
-    this.clearMciCache = function() {
-        this.mciCache = {};
-    };
 
     Object.defineProperty(this, 'currentTheme', {
         get : () => {

--- a/core/servers/login/ssh.js
+++ b/core/servers/login/ssh.js
@@ -231,8 +231,6 @@ function SSHClient(clientConn) {
         if(termHeight > 0 && termWidth > 0) {
             self.term.termHeight = termHeight;
             self.term.termWidth = termWidth;
-
-            self.clearMciCache();   //  term size changes = invalidate cache
         }
 
         if(_.isString(info.term) && info.term.length > 0 && 'unknown' === self.term.termType) {

--- a/core/servers/login/telnet.js
+++ b/core/servers/login/telnet.js
@@ -128,7 +128,7 @@ class TelnetClient {
                                 const value = parseInt(getValue(what));
                                 if (value) {
                                     this.term[what === 'ROWS' ? 'termHeight' : 'termWidth'] = value;
-                                    this.clearMciCache();
+
                                     this._logDebug(
                                         { [ what ] : value, source : 'NEW-ENVIRON' },
                                         'Window size updated'
@@ -156,8 +156,6 @@ class TelnetClient {
                         if (height) {
                             this.term.env.ROWS = height;
                         }
-
-                        this.clearMciCache();
 
                         this._logDebug(
                             { width, height, source : 'NAWS' },

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "uuid": "8.3.2",
     "uuid-parse": "1.1.0",
     "ws": "7.4.3",
-    "xxhash": "^0.3.0",
     "yazl": "^2.5.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1231,7 +1231,7 @@ nan@^2.10.0:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.11.1.tgz#90e22bccb8ca57ea4cd37cc83d3819b52eea6766"
   integrity sha512-iji6k87OSXa0CcrLl9z+ZiYSuR2o+c0bGuNmXdrhTQTakxytAFsC56SArGYoiHlJlFoHSnvmhpceZJaXkVuOtA==
 
-nan@^2.12.1, nan@^2.13.2, nan@^2.14.0:
+nan@^2.12.1, nan@^2.14.0:
   version "2.14.0"
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.0.tgz#7818f722027b2459a86f0295d434d1fc2336c52c"
   integrity sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==
@@ -2014,13 +2014,6 @@ xtend@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.1.tgz#a5c6d532be656e23db820efb943a1f04998d63af"
   integrity sha1-pcbVMr5lbiPbgg77lDofBJmNY68=
-
-xxhash@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/xxhash/-/xxhash-0.3.0.tgz#d20893a62c5b0f7260597dd55859b12a1e02c559"
-  integrity sha512-1ud2yyPiR1DJhgyF1ZVMt+Ijrn0VNS/wzej1Z8eSFfkNfRPp8abVZNV2u9tYy9574II0ZayZYZgJm8KJoyGLCw==
-  dependencies:
-    nan "^2.13.2"
 
 yallist@^3.0.0, yallist@^3.0.2:
   version "3.0.2"


### PR DESCRIPTION
The MCI cache was a kludge to cache positions of MCI codes after a DSR/CPR. Since we now track positioning internally like the gods intended, this is no longer needed.