### PR TITLE
Updated ssh documentation

### DIFF
--- a/docs/_docs/servers/loginservers/ssh.md
+++ b/docs/_docs/servers/loginservers/ssh.md
@@ -11,14 +11,18 @@ Entries available under `config.loginServers.ssh`:
 | Item | Required | Description |
 |------|----------|-------------|
 | `privateKeyPem` | :-1: | Path to private key file. If not set, defaults to `./config/ssh_private_key.pem` |
-| `privateKeyPass` | :+1: | Password to private key file.
+| `privateKeyPass` | :+1: | Password to private key file. *
 | `firstMenu` | :-1: | First menu an SSH connected user is presented with. Defaults to `sshConnected`. |
-| `firstMenuNewUser` | :-1: | Menu presented to user when logging in with one of the usernames found within `users.newUserNames` in your `config.hjson`. Examples include `new` and `apply`. |
+| `firstMenuNewUser` | :-1: | Menu presented to user when logging in with one of the usernames found within `users.newUserNames` in your `config.hjson`. Examples include `new` and `apply`.|
 | `enabled` | :+1: | Set to `true` to enable the SSH server. |
 | `port` | :-1: | Override the default port of `8443`. |
 | `address` | :-1: | Sets an explicit bind address. |
 | `algorithms` | :-1: | Configuration block for SSH algorithms. Includes keys of `kex`, `cipher`, `hmac`, and `compress`. See the algorithms section in the [ssh2-streams](https://github.com/mscdex/ssh2-streams#ssh2stream-methods) documentation for details. For defaults set by ENiGMA½, see `core/config_default.js`.
 | `traceConnections` | :-1: | Set to `true` to enable full trace-level information on SSH connections.
+
+
+* *IMPORTANT* With the `privateKeyPass` option set, make sure that you verify that the config file is not readable by other users!
+
 
 ### Example Configuration
 
@@ -36,17 +40,13 @@ Entries available under `config.loginServers.ssh`:
 ```
 
 ## Generate a SSH Private Key
-To utilize the SSH server, an SSH Private Key (PK) will need generated. OpenSSL can be used for this task:
+To utilize the SSH server, an SSH Private Key (PK) will need generated. OpenSSH can be used for this task:
 
-### Modern OpenSSL
+### OpenSSH
 ```bash
-openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -pkeyopt rsa_keygen_pubexp:65537 | openssl rsa -out ./config/ssh_private_key.pem -aes128
+ssh-keygen -m PEM -h -f config/ssh_private_key.pem
 ```
 
-### Legacy OpenSSL
-```bash
-openssl genrsa -aes128 -out ./config/ssh_private_key.pem 2048
-```
+## Prompt
 
-Note that you may need `-3des` for every old implementations or SSH clients!
-
+The keyboard interactive prompt can be customized using a `SSHPMPT.ASC` art file. See [art](../../art/general.md) for more information on configuring. This prompt includes a `newUserNames` variable to show the list of allowed new user names (see `firstMenuNewUser` above.) See [mci](../../art/mci.md) for information about formatting this string. Note: Regardless of the content of the `SSHPMPT.ASC` file, the prompt is surrounded by "Access denied", a newline, the prompt, another newline, and then the string "\[username]'s password: ". This normally occurs after the first password prompt (no art is shown before the first password attempt is made.)

--- a/docs/_docs/servers/loginservers/ssh.md
+++ b/docs/_docs/servers/loginservers/ssh.md
@@ -47,6 +47,17 @@ To utilize the SSH server, an SSH Private Key (PK) will need generated. OpenSSH 
 ssh-keygen -m PEM -h -f config/ssh_private_key.pem
 ```
 
+Option descriptions:
+
+| Option | Description |
+|------|-------------|
+| `-m PEM` | Set the output format to `PEM`, compatible with the `ssh2` library |
+| `-h` | Generate a host key |
+| `-f config/ssh_private_key.pem` | Filename for the private key. Used in the `privateKeyPem` option in the configuration |
+
+When you execute the `ssh-keygen` command it will ask for a passphrase (and a confirmation.) This should then be used as the value for `privateKeyPass` in the configuration.
+
+
 ## Prompt
 
 The keyboard interactive prompt can be customized using a `SSHPMPT.ASC` art file. See [art](../../art/general.md) for more information on configuring. This prompt includes a `newUserNames` variable to show the list of allowed new user names (see `firstMenuNewUser` above.) See [mci](../../art/mci.md) for information about formatting this string. Note: Regardless of the content of the `SSHPMPT.ASC` file, the prompt is surrounded by "Access denied", a newline, the prompt, another newline, and then the string "\[username]'s password: ". This normally occurs after the first password prompt (no art is shown before the first password attempt is made.)

--- a/docs/_docs/servers/loginservers/ssh.md
+++ b/docs/_docs/servers/loginservers/ssh.md
@@ -40,9 +40,10 @@ Entries available under `config.loginServers.ssh`:
 ```
 
 ## Generate a SSH Private Key
-To utilize the SSH server, an SSH Private Key (PK) will need generated. OpenSSH can be used for this task:
+To utilize the SSH server, an SSH Private Key (PK) will need generated. OpenSSH or (with some versions) OpenSSL can be used for this task:
 
 ### OpenSSH
+
 ```bash
 ssh-keygen -m PEM -h -f config/ssh_private_key.pem
 ```
@@ -56,6 +57,24 @@ Option descriptions:
 | `-f config/ssh_private_key.pem` | Filename for the private key. Used in the `privateKeyPem` option in the configuration |
 
 When you execute the `ssh-keygen` command it will ask for a passphrase (and a confirmation.) This should then be used as the value for `privateKeyPass` in the configuration.
+
+
+### OpenSSL
+
+If you do not have OpenSSH installed or if you have trouble with the above OpenSSH commands, using some versions for OpenSSL (before version 3) the following commands may work as well:
+
+
+```bash
+openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -pkeyopt rsa_keygen_pubexp:65537 | openssl rsa -out ./config/ssh_private_key.pem -aes128
+```
+
+Or for even older OpenSSL versions:
+
+```bash
+openssl genrsa -aes128 -out ./config/ssh_private_key.pem 2048
+```
+
+Note that you may need `-3des` for every old implementations or SSH clients!
 
 
 ## Prompt

--- a/docs/_docs/servers/loginservers/ssh.md
+++ b/docs/_docs/servers/loginservers/ssh.md
@@ -74,7 +74,7 @@ Or for even older OpenSSL versions:
 openssl genrsa -aes128 -out ./config/ssh_private_key.pem 2048
 ```
 
-Note that you may need `-3des` for every old implementations or SSH clients!
+Note that you may need `-3des` for very old implementations or SSH clients!
 
 
 ## Prompt


### PR DESCRIPTION
It looks like the previous suggestion of using OpenSSL no longer works. Using the OpenSSL method results in:

```
Error initializing: Error: Cannot parse privateKey: Unsupported key format
```

However, using ssh-keygen does appear to work well, at least under my testing. While I was at it I added a bit more documentation on the ssh module. Additional improvements are incoming.