### PR TITLE
Rumorz display bugfix

### DIFF
--- a/core/rumorz.js
+++ b/core/rumorz.js
@@ -172,7 +172,7 @@ exports.getModule = class RumorzModule extends MenuModule {
 
                     StatLog.getSystemLogEntries(
                         SystemLogKeys.UserAddedRumorz,
-                        StatLog.Order.Timestamp,
+                        StatLog.Order.TimestampDesc,
                         (err, entries) => {
                             return callback(err, entriesView, entries);
                         }


### PR DESCRIPTION
Noticed the rumorz module was always displaying the first "N" entries, rather than the "N" latest entries. Updated ordering to display the N latest rumors, so that the newest entries are always visible.