### PR TITLE
Fix to display ANSI files with implicit new lines on wide terminals

### DIFF
--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -9,6 +9,7 @@ This document attempts to track **major** changes and additions in ENiGMA½. For
     * Finally, the system will search for `index.html` and `index.htm` in that order, if another suitable route cannot be established.
 * CombatNet has shut down, so the module (`combatnet.js`) has been removed.
 * The Menu Flag `popParent` has been removed and `noHistory` has been updated to work as expected. In general things should "Just Work", but check your `menu.hjson` entries if you see menu stack issues.
+* Art handling has been changed to respect the art width contained in SAUCE when present in the case where the terminal width is greater than the art width. This fixes art files that assume wrapping at 80 columns on wide (mostly new utf8) terminals.
 
 ## 0.0.13-beta
 * **Note for contributors**: ENiGMA has switched to [Prettier](https://prettier.io) for formatting/style. Please see [CONTRIBUTING](CONTRIBUTING.md) and the Prettier website for more information.

--- a/core/ansi_escape_parser.js
+++ b/core/ansi_escape_parser.js
@@ -37,6 +37,10 @@ function ANSIEscapeParser(options) {
     this.mciReplaceChar = miscUtil.valueWithDefault(options.mciReplaceChar, '');
     this.termHeight = miscUtil.valueWithDefault(options.termHeight, 25);
     this.termWidth = miscUtil.valueWithDefault(options.termWidth, 80);
+    this.breakWidth = this.termWidth;
+    if(!(_.isNil(options.artWidth)) && options.artWidth > 0 && options.artWidth < this.breakWidth) {
+        this.breakWidth = options.artWidth;
+    }
     this.trailingLF = miscUtil.valueWithDefault(options.trailingLF, 'default');
 
     this.row = Math.min(options?.startRow ?? 1, this.termHeight);
@@ -90,8 +94,8 @@ function ANSIEscapeParser(options) {
 
             switch (charCode) {
                 case CR:
-                    self.emit('literal', text.slice(start, pos));
-                    start = pos;
+                    self.emit('literal', text.slice(start, pos + 1));
+                    start = pos + 1;
 
                     self.column = 1;
 
@@ -105,8 +109,8 @@ function ANSIEscapeParser(options) {
                         self.column = 1;
                     }
 
-                    self.emit('literal', text.slice(start, pos));
-                    start = pos;
+                    self.emit('literal', text.slice(start, pos + 1));
+                    start = pos + 1;
 
                     self.row += 1;
 
@@ -114,13 +118,16 @@ function ANSIEscapeParser(options) {
                     break;
 
                 default:
-                    if (self.column === self.termWidth) {
+                    if (self.column === self.breakWidth) {
                         self.emit('literal', text.slice(start, pos + 1));
                         start = pos + 1;
 
+                        // If the art is terminal, then we need to force the terminal to go to the next line.
+                        if(self.column < self.termWidth) {
+                            self.emit('literal', '\r\n');
+                        }
                         self.column = 1;
                         self.row += 1;
-
                         self.positionUpdated();
                     } else {
                         self.column += 1;
@@ -135,7 +142,7 @@ function ANSIEscapeParser(options) {
         //
         //  Finalize this chunk
         //
-        if (self.column > self.termWidth) {
+        if (self.column > self.breakWidth) {
             self.column = 1;
             self.row += 1;
 

--- a/core/ansi_escape_parser.js
+++ b/core/ansi_escape_parser.js
@@ -38,7 +38,9 @@ function ANSIEscapeParser(options) {
     this.termHeight = miscUtil.valueWithDefault(options.termHeight, 25);
     this.termWidth = miscUtil.valueWithDefault(options.termWidth, 80);
     this.breakWidth = this.termWidth;
-    if(!(_.isNil(options.artWidth)) && options.artWidth > 0 && options.artWidth < this.breakWidth) {
+    // toNumber takes care of null, undefined etc as well.
+    let artWidth = _.toNumber(options.artWidth);
+    if(!(_.isNaN(artWidth)) && artWidth > 0 && artWidth < this.breakWidth) {
         this.breakWidth = options.artWidth;
     }
     this.trailingLF = miscUtil.valueWithDefault(options.trailingLF, 'default');
@@ -122,7 +124,7 @@ function ANSIEscapeParser(options) {
                         self.emit('literal', text.slice(start, pos + 1));
                         start = pos + 1;
 
-                        // If the art is terminal, then we need to force the terminal to go to the next line.
+                        // If we hit breakWidth before termWidth then we need to force the terminal to go to the next line.
                         if(self.column < self.termWidth) {
                             self.emit('literal', '\r\n');
                         }

--- a/core/art.js
+++ b/core/art.js
@@ -280,18 +280,11 @@ function display(client, art, options, cb) {
         }
     }
 
-    // Use width from SAUCE if available - if the width is less than the term width,
-    // we need to set that as the width for the parser so that wide terminals
-    // display correctly
-    let parseWidth = getWidthFromSAUCE(options.sauce);
-    if(_.isNil(parseWidth) || parseWidth > client.term.termWidth) {
-        parseWidth = client.term.termWidth;
-    }
-
     const ansiParser = new aep.ANSIEscapeParser({
         mciReplaceChar: options.mciReplaceChar,
         termHeight: client.term.termHeight,
-        termWidth: parseWidth,
+        termWidth: client.term.termWidth,
+        artWidth: getWidthFromSAUCE(options.sauce),
         trailingLF: options.trailingLF,
         startRow: options.startRow,
     });

--- a/core/art.js
+++ b/core/art.js
@@ -46,6 +46,16 @@ function getFontNameFromSAUCE(sauce) {
     }
 }
 
+function getWidthFromSAUCE(sauce) {
+    if (sauce.Character) {
+        let sauceWidth = _.toNumber(sauce.Character.characterWidth);
+        if(!(_.isNaN(sauceWidth) && sauceWidth > 0)) {
+            return sauceWidth;
+        }
+    }
+    return null;
+}
+
 function sliceAtEOF(data, eofMarker) {
     let eof = data.length;
     const stopPos = Math.max(data.length - 256, 0); //  256 = 2 * sizeof(SAUCE)
@@ -270,10 +280,18 @@ function display(client, art, options, cb) {
         }
     }
 
+    // Use width from SAUCE if available - if the width is less than the term width,
+    // we need to set that as the width for the parser so that wide terminals
+    // display correctly
+    let parseWidth = getWidthFromSAUCE(options.sauce);
+    if(_.isNil(parseWidth) || parseWidth > client.term.termWidth) {
+        parseWidth = client.term.termWidth;
+    }
+
     const ansiParser = new aep.ANSIEscapeParser({
         mciReplaceChar: options.mciReplaceChar,
         termHeight: client.term.termHeight,
-        termWidth: client.term.termWidth,
+        termWidth: parseWidth,
         trailingLF: options.trailingLF,
         startRow: options.startRow,
     });

--- a/core/art.js
+++ b/core/art.js
@@ -49,7 +49,7 @@ function getFontNameFromSAUCE(sauce) {
 function getWidthFromSAUCE(sauce) {
     if (sauce.Character) {
         let sauceWidth = _.toNumber(sauce.Character.characterWidth);
-        if(!(_.isNaN(sauceWidth) && sauceWidth > 0)) {
+        if(!(_.isNaN(sauceWidth)) && sauceWidth > 0) {
             return sauceWidth;
         }
     }


### PR DESCRIPTION
Some art programs can save ANSI without carriage returns to save a few bytes in the file. This works fine when the terminal width matches the ANSI (since most retro is 80 columns) but on newer terminals, etc, this massively breaks the display.

The issue is discussed in issue #442 .  In order to fix this, we force a newline if the SAUCE is present, newlines are missing in the art file, and the width is less than the terminal width.