### PR TITLE
fixed incorrect reporting of cursor position

### DIFF
--- a/core/fse.js
+++ b/core/fse.js
@@ -1050,7 +1050,7 @@ exports.FullScreenEditorModule =
                     posView.setText(
                         _.padStart(String(pos.row + 1), 2, '0') +
                             ',' +
-                            _.padEnd(String(pos.col + 1), 2, '0')
+                            _.padStart(String(pos.col + 1), 2, '0')
                     );
                     this.client.term.rawWrite(ansi.restorePos());
                 }


### PR DESCRIPTION
Changed the string padding so the leading zero will be affixed to the start of the string, rather than the end of the string.