### PR TITLE
Added code to clear the text

### DIFF
--- a/core/text_view.js
+++ b/core/text_view.js
@@ -179,6 +179,10 @@ TextView.prototype.setText = function (text, redraw) {
 };
 
 TextView.prototype.clearText = function () {
+    if (this.text) {
+        this.setText(this.fillChar.repeat(this.text.length));
+    }
+
     this.setText('');
 };
 


### PR DESCRIPTION
I noticed the text in the error view was not being cleared after the error was corrected.  For example, "Username is too short". 

I can think of a few different ways this could have been fixed.  I try to keep it simple.  If you prefer a different approach to resolving this, please don't hesitate to let me know.

Thanks!