### PR TITLE
Removed extraneous space from private mail config template

### DIFF
--- a/misc/menu_templates/private_mail.in.hjson
+++ b/misc/menu_templates/private_mail.in.hjson
@@ -69,7 +69,7 @@
                             }
                         ]
                     }
-                    actionKeys: @reference: common.escToPrev
+                    actionKeys: @reference:common.escToPrev
                 }
                 1: {
                     mci: {


### PR DESCRIPTION
An extra space in the template was preventing the escape key from functioning within the private mail message header.  This will fix the issue for new installations.  Existing sysops would need to modify their config, since it has already been copied from the template. No biggie.