### PR TITLE
fse err msg display tweak

### DIFF
--- a/core/fse.js
+++ b/core/fse.js
@@ -167,6 +167,7 @@ exports.FullScreenEditorModule =
                     var newFocusViewId;
                     if (errMsgView) {
                         if (err) {
+                            errMsgView.clearText();
                             errMsgView.setText(err.message);
 
                             if (MciViewIds.header.subject === err.view.getId()) {

--- a/core/ftn_address.js
+++ b/core/ftn_address.js
@@ -135,7 +135,7 @@ module.exports = class Address {
     static fromString(addrStr) {
         const m = FTN_ADDRESS_REGEXP.exec(addrStr);
 
-        if (m) {
+        if (m && m[2] && m[3]) {
             //  start with a 2D
             let addr = {
                 net: parseInt(m[2]),

--- a/core/system_view_validate.js
+++ b/core/system_view_validate.js
@@ -91,7 +91,7 @@ function validateGeneralMailAddressedTo(data, cb) {
     //  :TODO: remove hard-coded FTN check here. We need a decent way to register global supported flavors with modules.
     const addressedToInfo = getAddressedToInfo(data);
 
-    if (Message.AddressFlavor.FTN === addressedToInfo.flavor) {
+    if (Message.AddressFlavor.Local !== addressedToInfo.flavor) {
         return cb(null);
     }
 

--- a/core/system_view_validate.js
+++ b/core/system_view_validate.js
@@ -21,8 +21,10 @@ exports.validateEmailAvail = validateEmailAvail;
 exports.validateBirthdate = validateBirthdate;
 exports.validatePasswordSpec = validatePasswordSpec;
 
+const emptyFieldError = () => new Error('Field cannot be empty');
+
 function validateNonEmpty(data, cb) {
-    return cb(data && data.length > 0 ? null : new Error('Field cannot be empty'));
+    return cb(data && data.length > 0 ? null : emptyFieldError);
 }
 
 function validateMessageSubject(data, cb) {
@@ -90,6 +92,10 @@ function validateGeneralMailAddressedTo(data, cb) {
     //
     //  :TODO: remove hard-coded FTN check here. We need a decent way to register global supported flavors with modules.
     const addressedToInfo = getAddressedToInfo(data);
+
+    if (addressedToInfo.name.length === 0) {
+        return cb(emptyFieldError());
+    }
 
     if (Message.AddressFlavor.Local !== addressedToInfo.flavor) {
         return cb(null);


### PR DESCRIPTION
Two changes, here.

1. Clearing old error message text before setting new error message text.  Currently the tail end of a previous error message remains when the length of the new text is shorter.
2. When validating an empty email To field, return "Field cannot be empty" rather than the existing "Invalid username".