### PR TITLE
Small bugfix on dev container startup to lock python version

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -7,7 +7,7 @@
 "features": {
 	"ghcr.io/devcontainers/features/python:1": {
 		"installTools": true,
-		"version": "latest"
+		"version": "3.11"
 	},
 	"ghcr.io/devcontainers-contrib/features/curl-apt-get:1": {},
 	"ghcr.io/jungaretti/features/ripgrep:1": {},


### PR DESCRIPTION
Using dev containers broke because we were using the latest version of python, but this became unstable with the latest version (due to a signing error.) This just locks the version to Python 3.11 (still supported) to allow the dev container to start.