### PR TITLE
🐛 bug: Server no longer crashes if CONFSCR has null values

### DIFF
--- a/core/color_codes.js
+++ b/core/color_codes.js
@@ -98,7 +98,7 @@ function ansiSgrFromCnetStyleColorCode(cc) {
 }
 
 function renegadeToAnsi(s, client) {
-    if (-1 == s.indexOf('|')) {
+    if (s == null || -1 == s.indexOf('|')) {
         return s; //  no pipe codes present
     }
 

--- a/core/string_util.js
+++ b/core/string_util.js
@@ -45,6 +45,9 @@ const SIMPLE_ELITE_MAP = {
 };
 
 function stylizeString(s, style) {
+    if (s == null) {
+        return s;
+    }
     var len = s.length;
     var c;
     var i;
@@ -214,6 +217,9 @@ function containsNonLatinCodepoints(s) {
 }
 
 function stripAllLineFeeds(s) {
+    if (s == null) {
+        return s;
+    }
     return s.replace(/\r?\n|[\r\u2028\u2029]/g, '');
 }
 
@@ -247,7 +253,7 @@ const ANSI_OR_PIPE_REGEXP = new RegExp(
 //
 function renderSubstr(str, start, length) {
     //  shortcut for empty strings
-    if (0 === str.length) {
+    if (str == null || 0 === str.length) {
         return str;
     }
 

--- a/core/text_view.js
+++ b/core/text_view.js
@@ -151,7 +151,7 @@ TextView.prototype.getData = function () {
 TextView.prototype.setText = function (text, redraw) {
     redraw = _.isBoolean(redraw) ? redraw : true;
 
-    if (!_.isString(text)) {
+    if (text != null && !_.isString(text)) {
         //  allow |text| to be numbers/etc.
         text = text.toString();
     }


### PR DESCRIPTION
This Bugfix corrects issue #522 by doing a check for null values anywhere that gets passed the raw values of the (potentially null) config screen.

This works for the bug in question, but I don't have enough experience in this code base to identify if this may have unintended consequences. Let me know if there is anything I've missed and I'll revise my commits.