### PR TITLE
Update install.sh to default to Node v18

### DIFF
--- a/misc/install.sh
+++ b/misc/install.sh
@@ -2,7 +2,7 @@
 
 { # this ensures the entire script is downloaded before execution
 
-ENIGMA_NODE_VERSION=${ENIGMA_NODE_VERSION:=14}
+ENIGMA_NODE_VERSION=${ENIGMA_NODE_VERSION:=18}
 ENIGMA_BRANCH=${ENIGMA_BRANCH:=master}
 ENIGMA_INSTALL_DIR=${ENIGMA_INSTALL_DIR:=$HOME/enigma-bbs}
 ENIGMA_SOURCE=${ENIGMA_SOURCE:=https://github.com/NuSkooler/enigma-bbs.git}


### PR DESCRIPTION
Manual Installation per https://nuskooler.github.io/enigma-bbs/installation/manual.html asks the user to use v18 whereas this script was defaulting to 14.

This caused me some frustration in getting my BBS up and running as I at first depended on the auto-install script.

For the less apt user, this might be a blocker to adopting this BBS Software.