### PR TITLE
Update bbs.js to for Config Init Enhancements

### DIFF
--- a/core/bbs.js
+++ b/core/bbs.js
@@ -85,23 +85,18 @@ function main() {
                     //  then it's a fatal error
                     //
                     if (err) {
+                        errorDisplayed = true;
+                        console.error(`Configuration error: ${err.message}`); //  eslint-disable-line no-console
+
                         if ('ENOENT' === err.code) {
-                            if (configPathSupplied) {
-                                console.error(
-                                    'Configuration file does not exist: ' + configFile
-                                );
-                            } else {
-                                configPathSupplied = null; //  make non-fatal; we'll go with defaults
-                            }
-                        } else {
-                            errorDisplayed = true;
-                            console.error(`Configuration error: ${err.message}`); //  eslint-disable-line no-console
-                            if (err.hint) {
-                                console.error(`Hint: ${err.hint}`);
-                            }
-                            if (err.configPath) {
-                                console.error(`Note: ${err.configPath}`);
-                            }
+                            console.error("\nConfiguration file does not exist: '" + configFile + "'\n\nIf this is a new installation please run './oputil.js config new' from the enigma-bbs directory");
+                        }
+
+                        if (err.hint) {
+                            console.error(`Hint: ${err.hint}`);
+                        }
+                        if (err.configPath) {
+                            console.error(`Note: ${err.configPath}`);
                         }
                     }
                     return callback(err);
@@ -134,7 +129,7 @@ function main() {
 
             if (err && !errorDisplayed) {
                 console.error('Error initializing: ' + util.inspect(err));
-                return process.exit();
+                return process.exit(1);
             }
         }
     );

--- a/core/bbs.js
+++ b/core/bbs.js
@@ -89,7 +89,7 @@ function main() {
                         console.error(`Configuration error: ${err.message}`); //  eslint-disable-line no-console
 
                         if ('ENOENT' === err.code) {
-                            console.error("\nConfiguration file does not exist: '" + configFile + "'\n\nIf this is a new installation please run './oputil.js config new' from the enigma-bbs directory");
+                            console.error("\nConfiguration file does not exist: '{configFile}'\n\nIf this is a new installation please run './oputil.js config new' from the enigma-bbs directory");
                         }
 
                         if (err.hint) {


### PR DESCRIPTION
If a new user of enigma-bbs tries to run ./main.js it will now explain why it can't start and suggest running './oputil.js config new'

In addition, in the event of an error scenario it will exit with exitcode 1 so that systemd / other tools that bring up the service will be able to detect than an error had occurred -- process.exit() defaults to 0, and therefore would not have been caught.