### PR TITLE
Adjust build process to build arm v8 builds

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -31,5 +31,6 @@ jobs:
         with:
           tags: enigmabbs/enigma-bbs:latest
           file: docker/Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v8
           push: true
+


### PR DESCRIPTION
This was needed to run the docker image on raspberry pi 5.