### PR TITLE
Add New "maxConnections" Config Option

### DIFF
--- a/core/config_default.js
+++ b/core/config_default.js
@@ -15,6 +15,7 @@ module.exports = () => {
 
             menuFile: 'menu.hjson', //  'oputil.js config new' will set this appropriately in config.hjson; may be full path
             achievementFile: 'achievements.hjson',
+            maxConnections: 0	// (<= 0) is Unlimited
         },
 
         term: {

--- a/core/config_default.js
+++ b/core/config_default.js
@@ -15,7 +15,7 @@ module.exports = () => {
 
             menuFile: 'menu.hjson', //  'oputil.js config new' will set this appropriately in config.hjson; may be full path
             achievementFile: 'achievements.hjson',
-            maxConnections: 0	// (<= 0) is Unlimited
+            maxConnections: 0 //  0 or less means 'unlimited'
         },
 
         term: {

--- a/core/login_server_module.js
+++ b/core/login_server_module.js
@@ -17,8 +17,6 @@ module.exports = class LoginServerModule extends ServerModule {
         super();
     }
 
-    //  :TODO: we need to max connections -- e.g. from config 'maxConnections'
-
     prepareClient(client, cb) {
         if (client.user.isAuthenticated()) {
             return cb(null);
@@ -58,6 +56,18 @@ module.exports = class LoginServerModule extends ServerModule {
         client.session.isSecure = _.isBoolean(client.isSecure)
             ? client.isSecure
             : modInfo.isSecure || false;
+
+        var {maxConnections} = Config().general;
+
+        if (
+            maxConnections > 0
+            && clientConns.clientConnections.length >= maxConnections
+        )
+        {
+            client.term.write('\nAll nodes are busy. Try again later...\n');
+            client.end();
+            return;
+        }
 
         clientConns.addNewClient(client, clientSock);
 

--- a/core/login_server_module.js
+++ b/core/login_server_module.js
@@ -54,13 +54,14 @@ module.exports = class LoginServerModule extends ServerModule {
             client.session = {};
         }
 
+        client.rawSocket = clientSock;
+
         if (maxConnections > 0 && numConnections >= maxConnections) {
             client.term.write('\nAll nodes are busy. Try again later...\n');
             client.end();
             return;
         }
 
-        client.rawSocket = clientSock;
         client.session.serverName = modInfo.name;
         client.session.isSecure = _.isBoolean(client.isSecure)
             ? client.isSecure

--- a/misc/config_template.in.hjson
+++ b/misc/config_template.in.hjson
@@ -65,6 +65,9 @@
 
         // Short board description
         description     : 'Yet another awesome ENiGMA½ BBS'
+
+        // Max active nodes (0 = unlimited)
+        maxConnections	: 0
     }
 
     term: {


### PR DESCRIPTION
Since I'm running my BBS on a tiny one CPU DigitalOcean droplet, I need to limit the amount of active nodes to 1. (For example: running just two Dosemu doors simultaneously will peg the processor completely.)

I dug around in the code and found that there was already a TODO for this item. Since it seemed fairly simple, I went ahead and implemented it. ¯\_(ツ)_/¯ I've been using it on my BBS for a while now, and it seems to hold up pretty well.

Comments/questions/concerns are always welcome. I'm not used to submitting PRs for public projects, so apologies if I've committed any faux pas.