### PR TITLE
Fix upload workflow navigation after file transfers

### DIFF
--- a/core/file_transfer_protocol_select.js
+++ b/core/file_transfer_protocol_select.js
@@ -42,6 +42,10 @@ exports.getModule = class FileTransferProtocolSelectModule extends MenuModule {
 
         if (_.has(options, 'lastMenuResult.recvFilePaths')) {
             this.recvFilePaths = options.lastMenuResult.recvFilePaths;
+            this.client.log.debug('Protocol select received recv file paths', { 
+                count: this.recvFilePaths.length, 
+                paths: this.recvFilePaths 
+            });
         }
 
         this.fallbackOnly = options.lastMenuResult ? true : false;
@@ -91,9 +95,23 @@ exports.getModule = class FileTransferProtocolSelectModule extends MenuModule {
 
     initSequence() {
         if (this.sentFileIds || this.recvFilePaths) {
-            //  nothing to do here; move along (we're just falling through)
+            //  We have results from a file transfer, handle them
+            if (this.recvFilePaths && this.config.direction === 'recv') {
+                // For uploads, return to the upload module specifically
+                this.client.log.debug('Protocol select returning to upload module with results', {
+                    recvFilePaths: this.recvFilePaths,
+                    tempRecvDirectory: this.extraArgs.recvDirectory
+                });
+                return this.gotoMenu('fileBaseUploadFiles', { 
+                    lastMenuResult: { 
+                        recvFilePaths: this.recvFilePaths,
+                        tempRecvDirectory: this.extraArgs.recvDirectory
+                    } 
+                });
+            }
             this.prevMenu();
         } else {
+            // No results yet, show the protocol selection menu normally
             super.initSequence();
         }
     }

--- a/core/upload.js
+++ b/core/upload.js
@@ -84,6 +84,13 @@ exports.getModule = class UploadModule extends MenuModule {
             this.recvFilePaths = options.lastMenuResult.recvFilePaths;
         }
 
+        if (_.has(options, 'lastMenuResult.tempRecvDirectory')) {
+            this.tempRecvDirectory = options.lastMenuResult.tempRecvDirectory;
+            this.client.log.debug('Restored temp directory from menu result', {
+                tempRecvDirectory: this.tempRecvDirectory
+            });
+        }
+
         this.availAreas = getSortedAvailableFileAreas(this.client, { writeAcs: true });
 
         this.menuMethods = {
@@ -196,6 +203,19 @@ exports.getModule = class UploadModule extends MenuModule {
 
     finishedLoading() {
         if (this.isFileTransferComplete()) {
+            //  When files are already transferred (bypassing options form),
+            //  ensure areaInfo is set to the first available area
+            if (!this.areaInfo && this.availAreas.length > 0) {
+                this.areaInfo = this.availAreas[0];
+                this.uploadType = 'blind'; // Default to blind upload when bypassing form
+                
+                this.client.log.debug('Set default areaInfo for bypassed form', {
+                    areaTag: this.areaInfo.areaTag,
+                    storageTags: this.areaInfo.storageTags,
+                    hasStorageTags: Array.isArray(this.areaInfo.storageTags),
+                    firstStorageTag: this.areaInfo.storageTags ? this.areaInfo.storageTags[0] : 'undefined'
+                });
+            }
             return this.processUploadedFiles();
         }
     }
@@ -439,11 +459,43 @@ exports.getModule = class UploadModule extends MenuModule {
         const areaStorageDir = getAreaDefaultStorageDirectory(this.areaInfo);
         const self = this;
 
+        if (!areaStorageDir) {
+            const error = new Error('Cannot determine storage directory for area');
+            this.client.log.error('Storage directory resolution failed', {
+                areaInfo: this.areaInfo,
+                areaTag: this.areaInfo ? this.areaInfo.areaTag : 'undefined',
+                storageTags: this.areaInfo ? this.areaInfo.storageTags : 'undefined'
+            });
+            return self.handleUploadError(error);
+        }
+
+        this.client.log.debug('Moving files to area storage', {
+            areaStorageDir: areaStorageDir,
+            fileCount: newEntries.length
+        });
+
+        this.client.log.debug('About to process entries', {
+            tempRecvDirectory: self.tempRecvDirectory,
+            entriesCount: newEntries.length,
+            firstEntry: newEntries.length > 0 ? { fileName: newEntries[0].fileName } : 'none'
+        });
+
         async.eachSeries(
             newEntries,
             (newEntry, nextEntry) => {
+                self.client.log.debug('Processing entry', {
+                    fileName: newEntry.fileName,
+                    tempRecvDirectory: self.tempRecvDirectory,
+                    areaStorageDir: areaStorageDir
+                });
+                
                 const src = paths.join(self.tempRecvDirectory, newEntry.fileName);
                 const dst = paths.join(areaStorageDir, newEntry.fileName);
+                
+                self.client.log.debug('File paths constructed', {
+                    src: src,
+                    dst: dst
+                });
 
                 moveFileWithCollisionHandling(src, dst, (err, finalPath) => {
                     if (err) {
@@ -686,7 +738,7 @@ exports.getModule = class UploadModule extends MenuModule {
                     self.cleanupTempFiles(); //  normally called after moveAndPersistUploadsToDatabase() is completed.
                 }
 
-                return self.prevMenu();
+                return self.gotoMenu('fileBaseMainMenu');
             }
         );
     }


### PR DESCRIPTION
  Improves the upload workflow by fixing navigation issues that prevented
  files from being properly processed into file areas after transfer completion.

  Changes:
  1. Protocol selection module now properly navigates back to upload module with transfer results and temp directory information
  2. Upload module navigation improved to return to file base main menu instead of getting stuck in protocol selection loop

  This ensures files are successfully transferred AND processed into file
  areas with proper menu navigation.