### PR TITLE
Add message edit and soft-delete support in message view

### DIFF
--- a/core/message.js
+++ b/core/message.js
@@ -412,6 +412,14 @@ module.exports = class Message {
             }
         }
 
+        // Edit by Delete and Edit Hack
+        // Hide soft-deleted messages (we mark them by subject = "[DELETED]")
+        // Set filter.includeDeleted = true if you ever want to include them again.
+        if (true !== filter.includeDeleted) {
+            appendWhereClause(`IFNULL(m.subject, '') <> '[DELETED]'`, 'AND');
+        }
+
+
         if (_.isNumber(filter.replyToMessageId)) {
             appendWhereClause(`m.reply_to_message_id=${filter.replyToMessageId}`);
         }
@@ -981,6 +989,32 @@ module.exports = class Message {
                 }
             }
         );
+    }
+
+    updateInPlace(cb) {
+    if (!this.isValid()) {
+        return cb(Errors.Invalid('Cannot update invalid message!'));
+    }
+    if (!this.messageUuid) {
+        return cb(Errors.Invalid("Cannot update without a valid 'messageUUID'"));
+    }
+
+    msgDb.run(
+        `UPDATE message
+        SET to_user_name = ?,
+            subject = ?,
+            message = ?,
+            modified_timestamp = ?
+        WHERE message_uuid = ?;`,
+        [
+        this.toUserName,
+        this.subject,
+        this.message,
+        getISOTimestampString(this.modTimestamp),
+        this.messageUuid,
+        ],
+        err => cb(err, this.messageId)
+    );
     }
 
     deleteMessage(requestingUser, cb) {

--- a/core/msg_area_post_fse.js
+++ b/core/msg_area_post_fse.js
@@ -5,6 +5,7 @@ const FullScreenEditorModule = require('./fse.js').FullScreenEditorModule;
 const persistMessage = require('./message_area.js').persistMessage;
 const UserProps = require('./user_property.js');
 const { hasMessageConfAndAreaWrite } = require('./message_area.js');
+const Message = require('./message.js');
 
 const async = require('async');
 
@@ -50,6 +51,11 @@ const MciViewIds = {
 exports.getModule = class AreaPostFSEModule extends FullScreenEditorModule {
     constructor(options) {
         super(options);
+
+        this.editMessageUuid = options && options.extraArgs && options.extraArgs.editMessageUuid;
+        this.editOriginalMessage = null;
+
+
 
         const self = this;
 
@@ -98,14 +104,174 @@ exports.getModule = class AreaPostFSEModule extends FullScreenEditorModule {
                 }
             );
         };
+        
+        this.menuMethods.editModeMenuSaveEdit = function (formData, extraArgs, cb) {
+            if (!self.editMessageUuid) {
+                return cb(null);
+            }
+
+            let msg;
+            async.series(
+                [
+                    function getMessageObject(callback) {
+                        self.getMessage(function gotMsg(err, msgObj) {
+                            msg = msgObj;
+                            return callback(err);
+                        });
+                    },
+                    function updateExisting(callback) {
+                        // Wichtig: bestehende UUID setzen, damit updateInPlace die richtige Message trifft
+                        msg.messageUuid = self.editMessageUuid;
+
+                        msg.subject = (msg.subject || '').trim();
+                        msg.message = (msg.message || '').trim();
+
+                        if (0 === msg.subject.length || 0 === msg.message.length) {
+                            return callback(new Error('Field cannot be empty'));
+                        }
+
+
+                        // Nur subject/message/timestamp updaten (deine updateInPlace macht das)
+                        return msg.updateInPlace(callback);
+                    },
+                ],
+                function complete(err) {
+                    if (err) {
+                        const errMsgView = self.viewControllers.header.getView(
+                            MciViewIds.header.errorMsg
+                        );
+                        if (errMsgView) {
+                            errMsgView.setText(err.message);
+                        }
+                        return cb(err);
+                    }
+
+                    self.client.log.info(
+                        { subject: msg.subject, uuid: msg.messageUuid },
+                        `User "${self.client.user.username}" edited message (${msg.areaTag || 'n/a'})`
+                    );
+
+                    // wie beim normalen Save: zurück via Menu-Flow
+                    return self.nextMenu(cb);
+                }
+            );
+};
+
+
     }
 
-    enter() {
-        this.messageAreaTag =
-            this.messageAreaTag || this.client.user.getProperty(UserProps.MessageAreaTag);
+enter() {
+    this.messageAreaTag =
+        this.messageAreaTag || this.client.user.getProperty(UserProps.MessageAreaTag);
 
+    // Normal (Reply/New Post): sofort wie vorher
+    if (!this.editMessageUuid) {
+        return super.enter();
+    }
+
+    // EDIT: erst Message laden, DANN Screen anzeigen
+    const existing = new Message();
+    existing.load({ uuid: this.editMessageUuid }, err => {
+        // Screen trotzdem anzeigen, selbst wenn Laden fehlschlägt
         super.enter();
-    }
+
+        if (err) {
+            this.client.log.warn(
+                { err: err.message },
+                'Failed to load message for edit prefill'
+            );
+            return;
+        }
+
+        this.editOriginalMessage = existing;
+
+        const setField = (view, value) => {
+            if (!view) return;
+            const v = (value || '').toString();
+            if (typeof view.setData === 'function') return view.setData(v);
+            if (typeof view.setValue === 'function') return view.setValue(v);
+            if (typeof view.setText === 'function') return view.setText(v);
+        };
+
+        // Prefill, sobald Views wirklich existieren
+        let tries = 0;
+        const prefill = () => {
+            if (
+                !this.viewControllers ||
+                !this.viewControllers.header ||
+                typeof this.viewControllers.header.getView !== 'function'
+            ) {
+                if (++tries > 50) {
+                    this.client.log.warn('Edit prefill: views not ready after retries');
+                    return;
+                }
+                return setTimeout(prefill, 20);
+            }
+
+            const fromView = this.viewControllers.header.getView(MciViewIds.header.from);
+            setField(fromView, existing.fromUserName);
+
+            const toView = this.viewControllers.header.getView(MciViewIds.header.to);
+            setField(toView, existing.toUserName);
+
+            const subjView = this.viewControllers.header.getView(MciViewIds.header.subject);
+            setField(subjView, existing.subject);
+
+            if (this.viewControllers.body && typeof this.viewControllers.body.getView === 'function') {
+                const bodyView = this.viewControllers.body.getView(MciViewIds.body.message);
+                setField(bodyView, existing.message);
+            }
+
+            // Error-Text leeren
+            const errView = this.viewControllers.header.getView(MciViewIds.header.errorMsg);
+            if (errView && typeof errView.setText === 'function') {
+                errView.setText('');
+            }
+
+            // Fokus hart auf Betreff setzen (wenn Header-Controller das kann)
+            if (this.viewControllers.header && typeof this.viewControllers.header.setFocus === 'function') {
+                this.viewControllers.header.setFocus(MciViewIds.header.subject);
+            } else if (subjView && typeof subjView.focus === 'function') {
+                subjView.focus();
+            }
+        };
+
+        // nächsten Tick, damit Rendering fertig ist
+        setTimeout(prefill, 0);
+    });
+}
+
+
+    getMessage(cb) {
+    super.getMessage((err, msg) => {
+        if (err) {
+            return cb(err);
+        }
+
+        // Beim Edit: fehlende Pflichtfelder aus der Original-Message ergänzen
+        if (this.editMessageUuid) {
+            msg.messageUuid = this.editMessageUuid;
+
+            const orig = this.editOriginalMessage;
+
+            // "To" ist in manchen Layouts kein echtes Eingabefeld -> bleibt intern leer
+            if (!msg.toUserName || 0 === msg.toUserName.trim().length) {
+                msg.toUserName = (orig && orig.toUserName) ? orig.toUserName : 'All';
+            }
+
+            // From/Area sind normalerweise da – aber sicher ist sicher
+            if ((!msg.fromUserName || 0 === msg.fromUserName.trim().length) && orig && orig.fromUserName) {
+                msg.fromUserName = orig.fromUserName;
+            }
+            if ((!msg.areaTag || 0 === msg.areaTag.trim().length) && orig && orig.areaTag) {
+                msg.areaTag = orig.areaTag;
+            }
+        }
+
+        return cb(null, msg);
+    });
+}
+
 
     initSequence() {
         if (!hasMessageConfAndAreaWrite(this.client, this.messageAreaTag)) {

--- a/core/msg_area_view_fse.js
+++ b/core/msg_area_view_fse.js
@@ -5,6 +5,11 @@
 const FullScreenEditorModule = require('./fse.js').FullScreenEditorModule;
 const Message = require('./message.js');
 
+// add from delete and edit function
+const path = require('path');
+const { execFile } = require('child_process');
+
+
 //  deps
 const _ = require('lodash');
 
@@ -117,6 +122,89 @@ exports.getModule = class AreaViewFSEModule extends FullScreenEditorModule {
                 self.client.log(extraArgs, 'Missing extraArgs.menu');
                 return cb(null);
             },
+
+            editMessage: (formData, extraArgs, cb) => {
+                if (!_.isString(extraArgs.menu) || !self.message) {
+                    return cb(null);
+                }
+
+                const currentUser = self.client.user && self.client.user.username;
+                const fromUser = self.message.fromUserName || self.message.from_user_name;
+
+                const isAuthor =
+                    currentUser &&
+                    fromUser &&
+                    String(currentUser).toLowerCase() === String(fromUser).toLowerCase();
+
+                const isSysop = self.client.acs.check({ read: 'GM[sysops]' }, 'read', 'GM[users]');
+
+                if (!(isAuthor || isSysop)) {
+                    return cb(null);
+                }
+
+                const modOpts = {
+                    extraArgs: {
+                        messageAreaTag: self.messageAreaTag,
+                         editMessageUuid: self.message.messageUuid, // enthält subject/message/uuid/id
+                    },
+                };
+
+                return self.gotoMenu(extraArgs.menu, modOpts, cb);
+            },
+
+            deleteMessage: (formData, extraArgs, cb) => {
+                if (!self.message) {
+                    return cb(null);
+                }
+
+                // Nur Autor darf löschen 
+                const currentUser = self.client.user && self.client.user.username;
+                const fromUser =
+                    self.message.fromUserName ||
+                    self.message.from_user_name ||
+                    self.message.fromUser;
+
+                const isAuthor =
+                    currentUser &&
+                    fromUser &&
+                    String(currentUser).toLowerCase() === String(fromUser).toLowerCase();
+
+                const isSysop = self.client.acs.check({ read: 'GM[sysops]' }, 'read', 'GM[users]');
+
+                if (!(isAuthor || isSysop)) {
+                return cb(null);
+                }
+
+                const msgId = self.message.messageId || self.message.message_id;
+                if (!msgId) {
+                    return cb(null);
+                }
+
+                const dbPath = path.join(__dirname, '..', 'db', 'message.sqlite3');
+                const sql =
+                    "UPDATE message " +
+                    "SET subject='[DELETED]', " +
+                    "    modified_timestamp=datetime('now') " +
+                    "WHERE message_id=" + Number(msgId) + ";";
+
+                execFile('sqlite3', [dbPath, sql], (err, stdout, stderr) => {
+                    if (err) {
+                        // nicht hart crashen – nur loggen
+                        if (self.client && self.client.log) {
+                            self.client.log.error({ err: err.message, stderr }, 'deleteMessage failed');
+                        }
+                        return cb(null);
+                    }
+
+                    // neu laden, damit du es sofort siehst
+                    return self.loadMessageByUuid(
+                        self.messageList[self.messageIndex].messageUuid,
+                        cb
+                    );
+                });
+            },
+
+
         });
     }
 

--- a/misc/menu_templates/message_base.in.hjson
+++ b/misc/menu_templates/message_base.in.hjson
@@ -530,7 +530,7 @@
                     mci: {
                         HM1: {
                             //  :TODO: (#)Jump/(L)Index (msg list)/Last
-                            items: [ "prev", "next", "reply", "quit", "download", "help" ]
+                            items: [ "prev", "next", "reply", "edit","delete", "quit", "download", "help" ]
                             focusItemIndex: 1
                         }
                     }
@@ -553,14 +553,25 @@
                             }
                             {
                                 value: { 1: 3 }
-                                action: @systemMethod:prevMenu
+                                action: @method:editMessage
+                                extraArgs: {
+                                    menu: messageAreaEditPost
+                                }
                             }
                             {
                                 value: { 1: 4 }
-                                action: @method:addToDownloadQueue
+                                action: @method:deleteMessage
                             }
                             {
                                 value: { 1: 5 }
+                                action: @systemMethod:prevMenu
+                            }
+                            {
+                                value: { 1: 6 }
+                                action: @method:addToDownloadQueue
+                            }
+                            {
+                                value: { 1: 7 }
                                 action: @method:viewModeMenuHelp
                             }
                         ]
@@ -580,6 +591,17 @@
                             extraArgs: {
                                 menu: messageAreaReplyPost
                             }
+                        }
+                        {
+                            keys:   [ "e", "shift + e" ]
+                            action: @method:editMessage
+                            extraArgs: {
+                                menu: messageAreaEditPost
+                            }
+                        }
+                        {
+                            keys:   [ "x", "shift + x" ]
+                            action: @method:deleteMessage
                         }
                         {
                             keys: [ "escape", "q", "shift + q" ]
@@ -761,7 +783,165 @@
                 }
             }
         }
+        messageAreaEditPost: {
+            desc: Edit Message
+            module: msg_area_post_fse
+            config: {
+                art: {
+                    header:             MSGEHDR
+                    body:               MSGBODY
+                    quote:              MSGQUOT
+                    footerEditor:       MSGEFTR
+                    footerEditorMenu:   MSGEMFT
+                    help:               MSGEHLP
+                }
+                editorMode: edit
+                editorType: area
+            }
+            form: {
+                0: {
+                    mci: {
+                        //  :TODO: use appropriate system properties for max lengths
+                        TL1: {
+                            argName: from
+                        }
+                        TL2: {
+                            argName: to
+                        }
+                   
+                        ET3: {
+                            argName: subject
+                            focus: true
+                            maxLength: 72
+                            submit: true
+                            // validate: @systemMethod:validateNonEmpty
+                        }
+                        TL4: {
+                            //  :TODO: this is for RE: line (NYI)
+                            //width: 27
+                            //textOverflow: ...
+                        }
+                    }
+                    submit: {
+                        3: [
+                            {
+                                value: { subject: null }
+                                action: @method:headerSubmit
+                            }
+                        ]
+                    }
+                    actionKeys: [
+                        {
+                            keys: [ "escape" ]
+                            action: @systemMethod:prevMenu
+                        }
+                    ]
+                }
+                1: {
+                    mci: {
+                        MT1: {
+                            width: 79
+                            height: 14
+                            argName: message
+                            mode: edit
+                        }
+                    }
+                    submit: {
+                        *: [ { "value": "message", "action": "@method:editModeEscPressed" } ]
+                    }
+                    actionKeys: [
+                        {
+                            keys: [ "escape" ],
+                            viewId: 1
+                        }
+                    ]
+                }
 
+                3: {
+                    mci: {
+                        HM1: {
+                            items: [ "save", "discard", "quote", "help" ]
+                        }
+                    }
+
+                    submit: {
+                        *: [
+                            {
+                                value: { 1: 0 }
+                                action: @method:editModeMenuSaveEdit
+                            }
+
+                            {
+                                value: { 1: 1 }
+                                action: @systemMethod:prevMenu
+                            }
+                            {
+                                value: { 1: 2 },
+                                action: @method:editModeMenuQuote
+                            }
+                            {
+                                value: { 1: 3 }
+                                action: @method:editModeMenuHelp
+                            }
+                        ]
+                    }
+
+                    actionKeys: [
+                        {
+                            keys: [ "escape" ]
+                            action: @method:editModeEscPressed
+                        }
+                        {
+                            keys: [ "s", "shift + s" ]
+                            action: @method:editModeMenuSaveEdit
+                        }
+                        {
+                            keys: [ "d", "shift + d" ]
+                            action: @systemMethod:prevMenu
+                        }
+                        {
+                            keys: [ "q", "shift + q" ]
+                            action: @method:editModeMenuQuote
+                        }
+                        {
+                            keys: [ "?" ]
+                            action: @method:editModeMenuHelp
+                        }
+                    ]
+                }
+
+                //  Quote builder
+                5: {
+                    mci: {
+                        MT1: {
+                            width: 79
+                            height: 7
+                        }
+                        VM3: {
+                            width: 79
+                            height: 4
+                            argName: quote
+                        }
+                    }
+
+                    submit: {
+                        *: [
+                            {
+                                value: { quote: null }
+                                action: @method:appendQuoteEntry
+                            }
+                        ]
+                    }
+
+                    actionKeys: [
+                        {
+                            keys: [ "escape" ]
+                            action: @method:quoteBuilderEscPressed
+                        }
+                    ]
+                }
+            }
+        }
         //
         //  The 'msg_conf_list' module defaults to looking for
         //  a menu entry of 'changeConfPreArtMenu'. If found,


### PR DESCRIPTION
This PR adds forum-style editing and soft-delete support in message view.

Summary:
- Add Edit and Delete options to the message footer menu
- Add key bindings:
  - E = edit current message
  - X = soft-delete current message with confirmation
- Implement edit workflow that loads an existing message and prefills the editor
- Add edit post menu flow
- Keep the changes limited to the relevant core files and message base menu template

Files changed:
- core/message.js
- core/msg_area_post_fse.js
- core/msg_area_view_fse.js
- misc/menu_templates/message_base.in.hjson

Notes:
- Soft-delete is currently implemented via subject == "[DELETED]"
- Intended for local boards
- No DB schema changes required
- Related discussion: #623