### PR TITLE
Fix FileBase upload area persistence and no-results menu handling

### DIFF
--- a/core/upload.js
+++ b/core/upload.js
@@ -2,7 +2,7 @@
 'use strict';
 
 //  enigma-bbs
-const { MenuModule, MenuFlags } = require('./menu_module');
+const { MenuModule } = require('./menu_module');
 const stringFormat = require('./string_format.js');
 const getSortedAvailableFileAreas =
     require('./file_base_area.js').getSortedAvailableFileAreas;
@@ -27,6 +27,7 @@ const async = require('async');
 const _ = require('lodash');
 const temptmp = require('temptmp').createTrackedSession('upload');
 const paths = require('path');
+const fs = require('fs');
 const sanatizeFilename = require('sanitize-filename');
 
 exports.moduleInfo = {
@@ -76,8 +77,6 @@ exports.getModule = class UploadModule extends MenuModule {
     constructor(options) {
         super(options);
 
-        this.setMergedFlag(MenuFlags.NoHistory);
-
         this.interrupt = MenuModule.InterruptTypes.Never;
 
         if (_.has(options, 'lastMenuResult.recvFilePaths')) {
@@ -93,8 +92,17 @@ exports.getModule = class UploadModule extends MenuModule {
 
         this.availAreas = getSortedAvailableFileAreas(this.client, { writeAcs: true });
 
+        if (this.tempRecvDirectory) {
+            this.restorePersistedUploadState();
+        }
+
         this.menuMethods = {
             optionsNavContinue: (formData, extraArgs, cb) => {
+                const areaIdx = this.viewControllers.options
+                    .getView(MciViewIds.options.area)
+                    .getData();
+                this.areaInfo = this.availAreas[areaIdx];
+
                 return this.performUpload(cb);
             },
 
@@ -138,6 +146,78 @@ exports.getModule = class UploadModule extends MenuModule {
                 return cb(null);
             },
         };
+    }
+
+
+    getPersistUploadStatePath() {
+        if (!this.tempRecvDirectory) {
+            return null;
+        }
+
+        const baseTempDir = this.tempRecvDirectory.replace(/[\/]+$/, '');
+        return `${baseTempDir}.upload_state.json`;
+    }
+
+    persistUploadState() {
+        const statePath = this.getPersistUploadStatePath();
+        if (!statePath || !this.areaInfo) {
+            return;
+        }
+
+        const state = {
+            areaTag: this.areaInfo.areaTag,
+            uploadType: this.uploadType,
+        };
+
+        try {
+            fs.writeFileSync(statePath, JSON.stringify(state), 'utf8');
+            this.client.log.debug('Persisted upload state', state);
+        } catch (err) {
+            this.client.log.warn(
+                { path: statePath, error: err.message },
+                'Failed to persist upload state'
+            );
+        }
+    }
+
+    restorePersistedUploadState() {
+        const statePath = this.getPersistUploadStatePath();
+        if (!statePath || !fs.existsSync(statePath)) {
+            return;
+        }
+
+        try {
+            const state = JSON.parse(fs.readFileSync(statePath, 'utf8'));
+            if (!this.areaInfo && state.areaTag) {
+                this.areaInfo =
+                    this.availAreas.find(a => a.areaTag === state.areaTag) ||
+                    getFileAreaByTag(state.areaTag);
+            }
+            if (!this.uploadType && state.uploadType) {
+                this.uploadType = state.uploadType;
+            }
+
+            this.client.log.debug('Restored persisted upload state', {
+                areaTag: this.areaInfo ? this.areaInfo.areaTag : 'none',
+                uploadType: this.uploadType,
+                path: statePath,
+            });
+
+            try {
+                fs.unlinkSync(statePath);
+                this.client.log.debug('Removed persisted upload state file', { path: statePath });
+            } catch (err) {
+                this.client.log.warn(
+                    { path: statePath, error: err.message },
+                    'Failed to remove persisted upload state file'
+                );
+            }
+        } catch (err) {
+            this.client.log.warn(
+                { path: statePath, error: err.message },
+                'Failed to restore persisted upload state'
+            );
+        }
     }
 
     getSaveState() {
@@ -203,6 +283,7 @@ exports.getModule = class UploadModule extends MenuModule {
 
     finishedLoading() {
         if (this.isFileTransferComplete()) {
+            this.restorePersistedUploadState();
             //  When files are already transferred (bypassing options form),
             //  ensure areaInfo is set to the first available area
             if (!this.areaInfo && this.availAreas.length > 0) {
@@ -230,6 +311,7 @@ exports.getModule = class UploadModule extends MenuModule {
 
             //  need a terminator for various external protocols
             this.tempRecvDirectory = pathWithTerminatingSeparator(tempRecvDirectory);
+            this.persistUploadState();
 
             const modOpts = {
                 extraArgs: {


### PR DESCRIPTION
## Summary

This PR fixes two FileBase-related issues:

1. Uploads could end up in the first available file area instead of the user-selected target area.
2. The "no results" screen in FileBase could behave incorrectly and not return cleanly.

## Problem 1: wrong upload target area

When uploading a file through the FileBase UI, the selected target area was not reliably preserved after returning from the protocol transfer module.

As a result, the upload handler could fall back to the first available file area instead of using the selected one.

In local testing, uploads always fell back to the first configured area (`bbs`) even when another area such as `texte` had been selected.

## Root cause

The upload module lost the selected area context during the round-trip through protocol selection and file receive handling.

After returning from the transfer module, the upload workflow resumed with transferred files present, but without a valid selected area in memory, which triggered a fallback to the first available area.

## Fix

### `core/upload.js`
- removed the `NoHistory` behavior from the upload module
- explicitly stored the selected upload area before starting the transfer
- persisted the selected upload area and upload type across the transfer round-trip
- restored the persisted upload state when returning from the transfer module
- stored the temporary upload-state file outside the actual receive directory
- removed the persisted upload-state file immediately after restore

This prevents the helper state file from being processed as an uploaded file.

## Problem 2: FileBase no-results handling

The FileBase "no entries found meeting your filter criteria" screen used outdated menu handling and could fail to return cleanly.

## Fix

### menu configuration
Updated the `fileBaseListEntriesNoResults` menu entry so it no longer uses the problematic old no-history behavior.

## Result

After the patch:
- uploads remain in the selected file area
- the temporary helper state file is no longer imported into the filebase
- the no-results screen returns properly again

## Verified locally

Example successful test:

- selected upload area: `texte`
- resulting storage path:
  `/home/enigma/enigma-bbs/file_base/texte`

Observed log flow:

- persisted upload state with `areaTag: 'texte'`
- restored upload state after transfer
- removed temporary persisted state file
- moved uploaded file to:
  `/home/enigma/enigma-bbs/file_base/texte`

## Files changed

- `core/upload.js`
- menu configuration containing `fileBaseListEntriesNoResults`

## Notes

This was tested locally and resolved both issues in practice.

It may still be worth reviewing whether upload area persistence should be handled more natively inside the upload/module flow, rather than requiring external persistence between menu transitions.