### PR TITLE
Native dos emulation1

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Below are just some of the features ENiGMA½ supports out of the box:
  * Strong [PBKDF2](https://en.wikipedia.org/wiki/PBKDF2) backed password encryption.
  * Support for **2-Factor Authentication** with One-Time-Passwords
  * [Door support](./docs/_docs/modding/door-servers.md) including common dropfile formats for legacy DOS doors. Built in [BBSLink](http://bbslink.net/), [DoorParty](http://forums.throwbackbbs.com/), and [Exodus](https://oddnetwork.org/exodus/)!
+ * **Native x86/DOS door emulation** via [v86](https://github.com/copy/v86) — run classic DOS BBS doors (LORD, PimpWars, TradeWars, etc.) directly inside ENiGMA½ with zero external dependencies. No QEMU, DOSBox, or DOSEMU required. Includes `oputil fat` for managing FreeDOS disk images and `oputil v86` for an interactive browser-based DOS desktop. See [Local Doors — v86](./docs/_docs/modding/local-doors-v86.md).
  * Structured [Bunyan](https://github.com/trentm/node-bunyan) logging!
  * [Message networks](./docs/_docs/messageareas/message-networks.md) with FidoNet Type Network (FTN) + BinkleyTerm Style Outbound (BSO) message import/export
  * Message bases exposed via [Gopher](./docs/_docs/servers/contentservers/gopher.md) and [NNTP](./docs/_docs/servers/contentservers/nntp.md) content servers

--- a/core/exodus.js
+++ b/core/exodus.js
@@ -61,8 +61,8 @@ exports.getModule = class ExodusModule extends MenuModule {
 
         this.config = options.menuConfig.config || {};
         this.config.ticketHost = this.config.ticketHost || 'oddnetwork.org';
-        (this.config.ticketPort = this.config.ticketPort || 1984),
-            (this.config.ticketPath = this.config.ticketPath || '/exodus');
+        ((this.config.ticketPort = this.config.ticketPort || 1984),
+            (this.config.ticketPath = this.config.ticketPath || '/exodus'));
         this.config.rejectUnauthorized = _.get(this.config, 'rejectUnauthorized', true);
         this.config.sshHost = this.config.sshHost || this.config.ticketHost;
         this.config.sshPort = this.config.sshPort || 22;

--- a/core/file_base_area.js
+++ b/core/file_base_area.js
@@ -187,7 +187,6 @@ function getFileAreasByTagWildcardRule(rule) {
     return areaTags.map(areaTag => getFileAreaByTag(areaTag));
 }
 
-
 function isValidStorageTag(storageTag) {
     return storageTag in Config().fileBase.storageTags;
 }
@@ -229,7 +228,6 @@ function getAreaStorageLocations(areaInfo) {
         })
     );
 }
-
 
 function getExistingFileEntriesBySha256(sha256, cb) {
     const entries = [];

--- a/core/file_entry.js
+++ b/core/file_entry.js
@@ -274,15 +274,14 @@ module.exports = class FileEntry {
         const storageDir = paths.resolve(
             FileEntry.getAreaStorageDirectoryByTag(this.storageTag)
         );
-        const resolved = paths.resolve(storageDir, this.relPath || '', this.fileName || '');
+        const resolved = paths.resolve(
+            storageDir,
+            this.relPath || '',
+            this.fileName || ''
+        );
         //  guard against a crafted storage_tag_rel_path escaping the storage root
-        if (
-            resolved !== storageDir &&
-            !resolved.startsWith(storageDir + paths.sep)
-        ) {
-            throw new Error(
-                `Path traversal detected for file_id ${this.fileId}`
-            );
+        if (resolved !== storageDir && !resolved.startsWith(storageDir + paths.sep)) {
+            throw new Error(`Path traversal detected for file_id ${this.fileId}`);
         }
         return resolved;
     }
@@ -615,7 +614,10 @@ module.exports = class FileEntry {
                         },
                     ],
                     err => {
-                        return cb(err, err ? undefined : Array.from(entriesById.values()));
+                        return cb(
+                            err,
+                            err ? undefined : Array.from(entriesById.values())
+                        );
                     }
                 );
             }
@@ -700,7 +702,9 @@ module.exports = class FileEntry {
 
         if (filter.areaTag && filter.areaTag.length > 0) {
             if (Array.isArray(filter.areaTag)) {
-                const areaList = filter.areaTag.map(t => `"${sanitizeString(t)}"`).join(', ');
+                const areaList = filter.areaTag
+                    .map(t => `"${sanitizeString(t)}"`)
+                    .join(', ');
                 appendWhereClause(`f.area_tag IN(${areaList})`);
             } else {
                 appendWhereClause(`f.area_tag = "${sanitizeString(filter.areaTag)}"`);

--- a/core/full_menu_view.js
+++ b/core/full_menu_view.js
@@ -229,8 +229,8 @@ class FullMenuView extends MenuView {
             sgr = this.focusItemFormat
                 ? ''
                 : index === this.focusedItemIndex
-                ? this.getFocusSGR()
-                : this.getSGR();
+                  ? this.getFocusSGR()
+                  : this.getSGR();
         } else {
             text = strUtil.stylizeString(
                 item.text,

--- a/core/horizontal_menu_view.js
+++ b/core/horizontal_menu_view.js
@@ -68,8 +68,8 @@ class HorizontalMenuView extends MenuView {
             sgr = this.focusItemFormat
                 ? ''
                 : index === this.focusedItemIndex
-                ? this.getFocusSGR()
-                : this.getSGR();
+                  ? this.getFocusSGR()
+                  : this.getSGR();
         } else {
             text = strUtil.stylizeString(
                 item.text,

--- a/core/menu_util.js
+++ b/core/menu_util.js
@@ -234,7 +234,11 @@ function handleAction(client, formData, conf, cb) {
             } else {
                 //  local to current module
                 const currentModule = client.currentMenuModule;
-                if (currentModule && currentModule.menuMethods && _.isFunction(currentModule.menuMethods[actionAsset.asset])) {
+                if (
+                    currentModule &&
+                    currentModule.menuMethods &&
+                    _.isFunction(currentModule.menuMethods[actionAsset.asset])
+                ) {
                     return currentModule.menuMethods[actionAsset.asset](
                         formData,
                         conf.extraArgs,
@@ -242,7 +246,9 @@ function handleAction(client, formData, conf, cb) {
                     );
                 }
 
-                const err = Errors.DoesNotExist(`Method does not exist: ${actionAsset.asset}`);
+                const err = Errors.DoesNotExist(
+                    `Method does not exist: ${actionAsset.asset}`
+                );
                 client.log.warn({ method: actionAsset.asset }, err.message);
                 return cb(err);
             }
@@ -328,7 +334,11 @@ function handleNext(client, nextSpec, conf, cb) {
             } else {
                 //  local to current module
                 const currentModule = client.currentMenuModule;
-                if (currentModule && currentModule.menuMethods && _.isFunction(currentModule.menuMethods[nextAsset.asset])) {
+                if (
+                    currentModule &&
+                    currentModule.menuMethods &&
+                    _.isFunction(currentModule.menuMethods[nextAsset.asset])
+                ) {
                     const formData = {}; //   we don't have any
                     return currentModule.menuMethods[nextAsset.asset](
                         formData,
@@ -337,7 +347,9 @@ function handleNext(client, nextSpec, conf, cb) {
                     );
                 }
 
-                const err = Errors.DoesNotExist(`Method does not exist: ${nextAsset.asset}`);
+                const err = Errors.DoesNotExist(
+                    `Method does not exist: ${nextAsset.asset}`
+                );
                 client.log.warn({ method: nextAsset.asset }, err.message);
                 return cb(err);
             }

--- a/core/oputil/oputil_fat.js
+++ b/core/oputil/oputil_fat.js
@@ -1,0 +1,371 @@
+/* jslint node: true */
+/* eslint-disable no-console */
+'use strict';
+
+/**
+ * oputil_fat.js — FAT disk image management commands
+ *
+ * Provides oputil `fat` subcommands for inspecting and modifying raw FAT
+ * disk images without requiring a running ENiGMA instance or database.
+ *
+ * Commands:
+ *   fat ls   <image.img> [DOS-PATH]       List files in image (alias: dir)
+ *   fat cp   <image.img> <src> <dst> ...  Copy local files into image (alias: copy)
+ *   fat read <image.img> <dos-path>       Read a file from image to stdout (alias: cat, type)
+ */
+
+const { printUsageAndSetExitCode, argv, ExitCodes } = require('./oputil_common.js');
+const { getHelpFor } = require('./oputil_help.js');
+
+const { createRequire } = require('module');
+const _require = createRequire(__filename);
+const fatfs = _require('fatfs');
+const { createFileDriverSync } = _require('fatfs-volume-driver');
+
+const fs = require('fs');
+const path = require('path');
+
+exports.handleFatCommand = handleFatCommand;
+
+// ─── Mount helpers ────────────────────────────────────────────────────────────
+
+function mountImage(imagePath, readOnly) {
+    if (!fs.existsSync(imagePath)) {
+        console.error(`fat: image not found: ${imagePath}`);
+        process.exitCode = ExitCodes.BAD_ARGS;
+        return null;
+    }
+
+    try {
+        const driver = createFileDriverSync(imagePath, { partitionNumber: 1, readOnly });
+        const fatFs = fatfs.createFileSystem(driver);
+        return fatFs;
+    } catch (err) {
+        console.error(`fat: failed to open image: ${err.message}`);
+        process.exitCode = ExitCodes.ERROR;
+        return null;
+    }
+}
+
+function awaitReady(fatFs, cb) {
+    fatFs.on('error', err => {
+        console.error(`fat: failed to mount FAT partition: ${err.message}`);
+        console.error('Is this a valid partitioned FAT disk image?');
+        process.exitCode = ExitCodes.ERROR;
+        cb(err);
+    });
+    fatFs.on('ready', () => cb(null));
+}
+
+function dosPath(p) {
+    return (p || '/').replace(/\\/g, '/');
+}
+
+// ─── ls / dir ────────────────────────────────────────────────────────────────
+
+// Split a DOS 8.3 filename into { base, ext } for column-aligned display.
+function splitDos83(name) {
+    const dot = name.lastIndexOf('.');
+    if (dot > 0) {
+        return {
+            base: name.slice(0, dot).slice(0, 8),
+            ext: name.slice(dot + 1).slice(0, 3),
+        };
+    }
+    return { base: name.slice(0, 8), ext: '' };
+}
+
+function formatDosDate(d) {
+    if (!d) return '         ';
+    const mm = String(d.getMonth() + 1).padStart(2, '0');
+    const dd = String(d.getDate()).padStart(2, '0');
+    const yy = String(d.getFullYear()).slice(-2);
+    return `${mm}-${dd}-${yy}`;
+}
+
+function formatDosTime(d) {
+    if (!d) return '      ';
+    let h = d.getHours();
+    const m = String(d.getMinutes()).padStart(2, '0');
+    const ampm = h >= 12 ? 'p' : 'a';
+    h = h % 12 || 12;
+    return `${String(h).padStart(2)}:${m}${ampm}`;
+}
+
+function printDosListing(imagePath, target, results) {
+    const dosDir =
+        ('\\' + target.replace(/^\//, '').replace(/\//g, '\\')).toUpperCase() || '\\';
+
+    console.log(` Volume in drive A has no label`);
+    console.log(` Directory of A:${dosDir}\n`);
+
+    let fileCount = 0,
+        dirCount = 0,
+        totalBytes = 0;
+
+    for (const r of results) {
+        const { base, ext } = splitDos83(r.name);
+        const nameCol = `${base.padEnd(8)} ${ext.padEnd(3)}`;
+        const dateStr = formatDosDate(r.mtime);
+        const timeStr = formatDosTime(r.mtime);
+
+        if (r.isDir) {
+            console.log(`${nameCol}  <DIR>            ${dateStr}  ${timeStr}`);
+            dirCount++;
+        } else {
+            const sizeStr = r.size === null ? '        ?' : String(r.size).padStart(9);
+            console.log(`${nameCol}  ${sizeStr}   ${dateStr}  ${timeStr}`);
+            fileCount++;
+            totalBytes += r.size || 0;
+        }
+    }
+
+    console.log(
+        `\n  ${fileCount} File(s)    ${totalBytes.toLocaleString().padStart(12)} bytes`
+    );
+    console.log(`  ${dirCount} Dir(s)`);
+}
+
+function cmdLs(imagePath, listPath) {
+    const fatFs = mountImage(imagePath, true);
+    if (!fatFs) return;
+
+    awaitReady(fatFs, err => {
+        if (err) return;
+
+        const target = dosPath(listPath || '/');
+
+        fatFs.readdir(target, (err, entries) => {
+            if (err) {
+                console.error(`fat: cannot list ${target}: ${err.message}`);
+                process.exitCode = ExitCodes.ERROR;
+                return;
+            }
+
+            if (entries.length === 0) {
+                console.log(` Volume in drive A has no label`);
+                console.log(` Directory of A:${target.toUpperCase()}\n`);
+                console.log('  (empty)\n');
+                return;
+            }
+
+            let pending = entries.length;
+            const results = new Array(entries.length);
+
+            entries.forEach((entry, i) => {
+                const fullPath = `/${target.replace(/^\//, '')}/${entry}`.replace(
+                    '//',
+                    '/'
+                );
+                fatFs.stat(fullPath, (err, st) => {
+                    if (err && err.code === 'ISDIR') {
+                        results[i] = { name: entry, isDir: true, size: 0, mtime: null };
+                    } else if (err) {
+                        results[i] = {
+                            name: entry,
+                            isDir: false,
+                            size: null,
+                            mtime: null,
+                        };
+                    } else {
+                        results[i] = {
+                            name: entry,
+                            isDir: st.isDirectory(),
+                            size: st.size,
+                            mtime: st.mtime || null,
+                        };
+                    }
+
+                    if (--pending === 0) {
+                        // dirs first, then files — both alphabetical
+                        results.sort((a, b) => {
+                            if (a.isDir !== b.isDir) return a.isDir ? -1 : 1;
+                            return a.name.localeCompare(b.name);
+                        });
+                        printDosListing(imagePath, target, results);
+                    }
+                });
+            });
+        });
+    });
+}
+
+// ─── read / cat / type ───────────────────────────────────────────────────────
+
+function cmdRead(imagePath, dosFilePath) {
+    if (!dosFilePath) {
+        return printUsageAndSetExitCode(getHelpFor('Fat'), ExitCodes.BAD_ARGS);
+    }
+
+    const fatFs = mountImage(imagePath, true);
+    if (!fatFs) return;
+
+    awaitReady(fatFs, err => {
+        if (err) return;
+
+        const target = dosPath(dosFilePath);
+
+        fatFs.readFile(target, (err, data) => {
+            if (err) {
+                console.error(`fat: cannot read ${target}: ${err.message}`);
+                process.exitCode = ExitCodes.ERROR;
+                return;
+            }
+            process.stdout.write(data);
+        });
+    });
+}
+
+// ─── cp / copy ───────────────────────────────────────────────────────────────
+
+function cmdCp(imagePath, pairs) {
+    if (!pairs || pairs.length === 0 || pairs.length % 2 !== 0) {
+        console.error('fat cp: arguments after image must be src/dest pairs');
+        return printUsageAndSetExitCode(getHelpFor('Fat'), ExitCodes.BAD_ARGS);
+    }
+
+    const fatFs = mountImage(imagePath, false);
+    if (!fatFs) return;
+
+    awaitReady(fatFs, err => {
+        if (err) return;
+
+        // Process pairs sequentially
+        const next = i => {
+            if (i >= pairs.length) {
+                console.log('Done.');
+                return;
+            }
+
+            const localSrc = pairs[i];
+            const dosDst = dosPath(pairs[i + 1]).replace(/^\//, '');
+
+            if (!fs.existsSync(localSrc)) {
+                console.error(`fat cp: source not found: ${localSrc}`);
+                process.exitCode = ExitCodes.ERROR;
+                return;
+            }
+
+            const stat = fs.statSync(localSrc);
+            if (stat.isDirectory()) {
+                copyDirectory(fatFs, localSrc, dosDst, err => {
+                    if (err) {
+                        console.error(`fat cp: ${err.message}`);
+                        process.exitCode = ExitCodes.ERROR;
+                        return;
+                    }
+                    next(i + 2);
+                });
+            } else {
+                mkdirp(fatFs, path.dirname(dosDst), err => {
+                    if (err) {
+                        console.error(`fat cp: ${err.message}`);
+                        process.exitCode = ExitCodes.ERROR;
+                        return;
+                    }
+                    copyFile(fatFs, localSrc, dosDst, err => {
+                        if (err) {
+                            console.error(`fat cp: ${err.message}`);
+                            process.exitCode = ExitCodes.ERROR;
+                            return;
+                        }
+                        next(i + 2);
+                    });
+                });
+            }
+        };
+
+        next(0);
+    });
+}
+
+function mkdirp(fatFs, dosDir, cb) {
+    if (!dosDir || dosDir === '.' || dosDir === '/') return cb(null);
+
+    const parts = dosDir.replace(/\\/g, '/').split('/').filter(Boolean);
+    let current = '';
+
+    const next = i => {
+        if (i >= parts.length) return cb(null);
+        current = current ? `${current}/${parts[i]}` : parts[i];
+        fatFs.mkdir(current, err => {
+            if (err && err.code !== 'EEXIST') {
+                // Non-fatal: log and continue
+                console.warn(`  mkdir ${current}: ${err.message}`);
+            }
+            next(i + 1);
+        });
+    };
+
+    next(0);
+}
+
+function copyFile(fatFs, localPath, dosFilePath, cb) {
+    const upper = dosFilePath.toUpperCase();
+    const content = fs.readFileSync(localPath);
+    console.log(`  ${localPath} \u2192 ${upper} (${content.length} bytes)`);
+    fatFs.writeFile(upper, content, err => {
+        if (err) return cb(new Error(`Failed to write ${upper}: ${err.message}`));
+        cb(null);
+    });
+}
+
+function copyDirectory(fatFs, localDir, dosDir, cb) {
+    console.log(`  ${localDir}/ \u2192 ${dosDir.toUpperCase()}/`);
+    mkdirp(fatFs, dosDir, err => {
+        if (err) return cb(err);
+
+        const entries = fs.readdirSync(localDir);
+        const next = i => {
+            if (i >= entries.length) return cb(null);
+            const localPath = path.join(localDir, entries[i]);
+            const dosDst = `${dosDir}/${entries[i]}`;
+            if (fs.statSync(localPath).isDirectory()) {
+                copyDirectory(fatFs, localPath, dosDst, err => {
+                    if (err) return cb(err);
+                    next(i + 1);
+                });
+            } else {
+                copyFile(fatFs, localPath, dosDst, err => {
+                    if (err) return cb(err);
+                    next(i + 1);
+                });
+            }
+        };
+
+        next(0);
+    });
+}
+
+// ─── Entry point ─────────────────────────────────────────────────────────────
+
+function handleFatCommand() {
+    if (argv.help) {
+        return printUsageAndSetExitCode(getHelpFor('Fat'), ExitCodes.SUCCESS);
+    }
+
+    const action = argv._[1];
+    const imagePath = argv._[2];
+
+    if (!action || !imagePath) {
+        return printUsageAndSetExitCode(getHelpFor('Fat'), ExitCodes.BAD_ARGS);
+    }
+
+    switch (action) {
+        case 'ls':
+        case 'dir':
+            return cmdLs(imagePath, argv._[3]);
+
+        case 'read':
+        case 'cat':
+        case 'type':
+            return cmdRead(imagePath, argv._[3]);
+
+        case 'cp':
+        case 'copy':
+            return cmdCp(imagePath, argv._.slice(3));
+
+        default:
+            return printUsageAndSetExitCode(getHelpFor('Fat'), ExitCodes.BAD_COMMAND);
+    }
+}

--- a/core/oputil/oputil_file_base.js
+++ b/core/oputil/oputil_file_base.js
@@ -184,9 +184,7 @@ function scanFileAreaForChanges(areaInfo, options, cb) {
     //  Build an ignore filter from all .enigmaignore files found under baseDir.
     //  Rules are gitignore-style and scoped to the directory containing each file.
     function buildIgnoreFilter(baseDir, relFiles, next) {
-        const ignoreFiles = relFiles.filter(
-            rf => paths.basename(rf) === '.enigmaignore'
-        );
+        const ignoreFiles = relFiles.filter(rf => paths.basename(rf) === '.enigmaignore');
         if (0 === ignoreFiles.length) {
             return next(null, null);
         }
@@ -205,9 +203,7 @@ function scanFileAreaForChanges(areaInfo, options, cb) {
                     content.split('\n').forEach(line => {
                         const trimmed = line.trim();
                         if (trimmed && !trimmed.startsWith('#')) {
-                            ig.add(
-                                ignDir === '.' ? trimmed : `${ignDir}/${trimmed}`
-                            );
+                            ig.add(ignDir === '.' ? trimmed : `${ignDir}/${trimmed}`);
                         }
                     });
                 }
@@ -227,27 +223,32 @@ function scanFileAreaForChanges(areaInfo, options, cb) {
         const pattern = options.glob || (storageLoc.isWildcard ? '**/*' : null);
         if (pattern) {
             //  include .enigmaignore files in the glob so buildIgnoreFilter can read them
-            glob(pattern, { cwd: storageLoc.dir, nodir: true, follow: false }, (err, relFiles) => {
-                if (err) {
-                    return next(err);
-                }
-                buildIgnoreFilter(storageLoc.dir, relFiles, (err, ig) => {
+            glob(
+                pattern,
+                { cwd: storageLoc.dir, nodir: true, follow: false },
+                (err, relFiles) => {
                     if (err) {
                         return next(err);
                     }
-                    const filtered = relFiles
-                        .filter(rf => paths.basename(rf) !== '.enigmaignore')
-                        .filter(rf => !ig || !ig.ignores(rf));
-                    return next(
-                        null,
-                        filtered.map(rf => ({
-                            relFile: rf,
-                            relPath: paths.dirname(rf) === '.' ? null : paths.dirname(rf),
-                        })),
-                        true //  fromGlob — skip stat check
-                    );
-                });
-            });
+                    buildIgnoreFilter(storageLoc.dir, relFiles, (err, ig) => {
+                        if (err) {
+                            return next(err);
+                        }
+                        const filtered = relFiles
+                            .filter(rf => paths.basename(rf) !== '.enigmaignore')
+                            .filter(rf => !ig || !ig.ignores(rf));
+                        return next(
+                            null,
+                            filtered.map(rf => ({
+                                relFile: rf,
+                                relPath:
+                                    paths.dirname(rf) === '.' ? null : paths.dirname(rf),
+                            })),
+                            true //  fromGlob — skip stat check
+                        );
+                    });
+                }
+            );
         } else {
             fs.readdir(storageLoc.dir, (err, fileNames) => {
                 if (err) {
@@ -303,8 +304,9 @@ function scanFileAreaForChanges(areaInfo, options, cb) {
                                     //  when scanning a WC tag — those files are owned by the
                                     //  more-specific flat tag and will be (or were) scanned directly.
                                     if (storageLoc.isWildcard && excludedDirs.size > 0) {
-                                        const isExcluded = [...excludedDirs].some(excDir =>
-                                            fullPath.startsWith(excDir + paths.sep)
+                                        const isExcluded = [...excludedDirs].some(
+                                            excDir =>
+                                                fullPath.startsWith(excDir + paths.sep)
                                         );
                                         if (isExcluded) {
                                             return nextFile(null);

--- a/core/oputil/oputil_help.js
+++ b/core/oputil/oputil_help.js
@@ -22,6 +22,8 @@ Commands:
   mb                        Message base management
   ap                        ActivityPub management
   ssh                       SSH key management
+  fat                       FAT disk image management
+  v86                       v86 x86 emulation tools
 `,
     User: `usage: oputil.js user <action> [<arguments>]
 
@@ -244,6 +246,66 @@ condition arguments:
 
 Actions:
   create                      Create new SSH Keys
+`,
+    Fat: `usage: oputil.js fat <action> <image.img> [arguments]
+
+Inspect and modify raw FAT disk images without a running ENiGMA instance.
+Works on any partitioned FAT12/16/32 raw disk image (.img).
+
+Actions:
+  ls IMAGE [PATH]             List files and directories in image
+  (dir)                       PATH defaults to the root of the partition
+
+  cp IMAGE SRC DST [SRC DST] Copy one or more local files/directories into image
+  (copy)                      SRC is a local path; DST is a DOS path within the image
+                              Directories are copied recursively
+
+  read IMAGE DOS-PATH         Read a file from the image and write it to stdout
+  (cat, type)
+
+Examples:
+  oputil.js fat ls   freedos.img
+  oputil.js fat ls   freedos.img DOORS/LORD
+  oputil.js fat cp   freedos.img ./pimpwars/ DOORS/PW/PIMPWARS
+  oputil.js fat cp   freedos.img fdconfig.sys FDCONFIG.SYS
+  oputil.js fat read freedos.img FDAUTO.BAT
+  oputil.js fat read freedos.img FDCONFIG.SYS | less
+`,
+    V86: `usage: oputil.js v86 <action> <image.img> [arguments]
+
+Boot a raw FreeDOS disk image using the v86 x86 emulator.
+Does not require a running ENiGMA instance.
+
+BIOS files default to misc/v86_bios/seabios.bin and misc/v86_bios/vgabios.bin.
+Run misc/install.sh to download them, or see docs/_docs/modding/local-doors-v86.md.
+
+Actions:
+  console IMAGE               Boot image and monitor COM1 output in this terminal
+                              Ctrl+] to exit.
+                              Note: keyboard input is not forwarded to the shell —
+                              a C:\> prompt confirms serial output is working, but
+                              the shell is not interactive. Use 'desktop' instead.
+                              Full-screen programs (VGA RAM) also won't appear here.
+
+  desktop IMAGE               Boot image and open a full VGA DOS desktop in
+                              the system browser. Use to install and configure
+                              doors. A "Save Image" button downloads the modified
+                              image when done.
+
+Options:
+  --bios PATH                 Override SeaBIOS path
+  --vga-bios PATH             Override VGA BIOS path
+  --port PORT                 HTTP port for desktop mode (default: 18086)
+  --host HOST                 Bind host for desktop mode (default: 127.0.0.1)
+                              Use 0.0.0.0 to allow remote access, or set up an
+                              SSH tunnel: ssh -L PORT:localhost:PORT user@host
+  --memory MB                 Guest RAM in MB (default: 64)
+
+Examples:
+  oputil.js v86 console freedos.img
+  oputil.js v86 console freedos.img --bios /path/to/seabios.bin
+  oputil.js v86 desktop freedos.img
+  oputil.js v86 desktop freedos.img --port 9000
 `,
 });
 

--- a/core/oputil/oputil_main.js
+++ b/core/oputil/oputil_main.js
@@ -12,6 +12,8 @@ const handleMessageBaseCommand =
 const handleConfigCommand = require('./oputil_config.js').handleConfigCommand;
 const handleApCommand = require('./activitypub').handleUserCommand;
 const handleSSHKeyCommand = require('./oputil_ssh_key.js').handleSSHKeyCommand;
+const handleFatCommand = require('./oputil_fat.js').handleFatCommand;
+const handleV86Command = require('./oputil_v86.js').handleV86Command;
 const getHelpFor = require('./oputil_help.js').getHelpFor;
 
 module.exports = function () {
@@ -38,6 +40,10 @@ module.exports = function () {
             return handleApCommand();
         case 'ssh':
             return handleSSHKeyCommand();
+        case 'fat':
+            return handleFatCommand();
+        case 'v86':
+            return handleV86Command();
         default:
             return printUsageAndSetExitCode(getHelpFor('General'), ExitCodes.BAD_COMMAND);
     }

--- a/core/oputil/oputil_v86.js
+++ b/core/oputil/oputil_v86.js
@@ -1,0 +1,488 @@
+/* jslint node: true */
+/* eslint-disable no-console */
+'use strict';
+
+/**
+ * oputil_v86.js — v86 x86 emulation tools
+ *
+ * Provides oputil `v86` subcommands for booting raw FreeDOS disk images
+ * using the v86 emulator. Does not require a running ENiGMA instance.
+ *
+ * Commands:
+ *   v86 console <image.img> [options]   Boot image, wire COM1 to terminal
+ *   v86 desktop <image.img> [options]   Boot image in browser (full VGA)
+ *
+ * Options:
+ *   --bios PATH       SeaBIOS image path (default: misc/v86_bios/seabios.bin)
+ *   --vga-bios PATH   VGA BIOS image path (default: misc/v86_bios/vgabios.bin)
+ */
+
+const { printUsageAndSetExitCode, argv, ExitCodes } = require('./oputil_common.js');
+const { getHelpFor } = require('./oputil_help.js');
+
+const path = require('path');
+const fs = require('fs');
+const { Worker } = require('worker_threads');
+
+const ENIGMA_ROOT = path.join(__dirname, '..', '..');
+const DEFAULT_BIOS_PATH = path.join(ENIGMA_ROOT, 'misc', 'v86_bios', 'seabios.bin');
+const DEFAULT_VGA_BIOS_PATH = path.join(ENIGMA_ROOT, 'misc', 'v86_bios', 'vgabios.bin');
+const WORKER_PATH = path.join(ENIGMA_ROOT, 'core', 'v86_door', 'v86_worker.js');
+
+exports.handleV86Command = handleV86Command;
+
+// ─── Shared validation ───────────────────────────────────────────────────────
+
+function resolvePaths(imagePath) {
+    const biosPath = argv['bios'] || DEFAULT_BIOS_PATH;
+    const vgaBiosPath = argv['vga-bios'] || DEFAULT_VGA_BIOS_PATH;
+
+    for (const [label, p] of [
+        ['image', imagePath],
+        ['bios', biosPath],
+        ['vga-bios', vgaBiosPath],
+    ]) {
+        if (!fs.existsSync(p)) {
+            console.error(`v86: ${label} not found: ${p}`);
+            if (label !== 'image') {
+                console.error(
+                    'Download BIOS files: misc/install.sh or see docs/_docs/modding/local-doors-v86.md'
+                );
+            }
+            process.exitCode = ExitCodes.BAD_ARGS;
+            return null;
+        }
+    }
+
+    return { imagePath, biosPath, vgaBiosPath };
+}
+
+// ─── console ─────────────────────────────────────────────────────────────────
+
+function cmdConsole(imagePath) {
+    const paths = resolvePaths(imagePath);
+    if (!paths) return;
+
+    const { createFloppyWithFiles } = require('../v86_door/fat_image.js');
+
+    // Inject a RUN.BAT that redirects the DOS shell to COM1 so the
+    // terminal becomes an interactive DOS prompt (requires CTTY support).
+    const runBat = Buffer.from('CTTY COM1\r\n', 'ascii');
+    createFloppyWithFiles([{ name: 'RUN.BAT', content: runBat }])
+        .then(floppyBuffer => {
+            const workerData = {
+                imagePath: paths.imagePath,
+                floppyBuffer,
+                memoryMb: argv['memory'] || 64,
+                biosPath: paths.biosPath,
+                vgaBiosPath: paths.vgaBiosPath,
+            };
+
+            const worker = new Worker(WORKER_PATH, { workerData });
+
+            console.error('v86 console: booting — Ctrl+] to exit\n');
+
+            process.stdin.setRawMode?.(true);
+            process.stdin.resume();
+
+            process.stdin.on('data', data => {
+                // Ctrl+] (0x1D) = exit
+                if (data.length === 1 && data[0] === 0x1d) {
+                    console.error('\nv86 console: exit');
+                    worker.postMessage({ type: 'stop' });
+                    return;
+                }
+                worker.postMessage({ type: 'input', data });
+            });
+
+            worker.on('message', msg => {
+                switch (msg.type) {
+                    case 'output':
+                        process.stdout.write(Buffer.from(msg.data));
+                        break;
+
+                    case 'stopped':
+                        process.stdin.setRawMode?.(false);
+                        process.exit(0);
+                        break;
+
+                    case 'error':
+                        console.error(`v86 console: emulator error: ${msg.message}`);
+                        process.stdin.setRawMode?.(false);
+                        process.exitCode = ExitCodes.ERROR;
+                        worker.terminate();
+                        break;
+
+                    default:
+                        break;
+                }
+            });
+
+            worker.on('error', err => {
+                console.error(`v86 console: worker error: ${err.message}`);
+                process.stdin.setRawMode?.(false);
+                process.exitCode = ExitCodes.ERROR;
+            });
+
+            process.on('SIGINT', () => {
+                console.error('\nv86 console: SIGINT — stopping');
+                worker.postMessage({ type: 'stop' });
+            });
+        })
+        .catch(err => {
+            console.error(`v86 console: ${err.message}`);
+            process.exitCode = ExitCodes.ERROR;
+        });
+}
+
+// ─── desktop ─────────────────────────────────────────────────────────────────
+
+//  The HTML page served to the browser. Embedded here to keep the tool
+//  self-contained — no extra asset files needed.
+const DESKTOP_HTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>ENiGMA&#189; v86 Desktop</title>
+<style>
+* { box-sizing: border-box; margin: 0; padding: 0; }
+body { background: #111; color: #ccc; font-family: monospace; display: flex;
+       flex-direction: column; align-items: center; padding: 16px; gap: 12px; }
+h1 { font-size: 1rem; color: #8f8; letter-spacing: 2px; }
+#screen { border: 2px solid #444; cursor: default; line-height: 0; width: 720px; min-height: 400px; background: #000; }
+#screen canvas { image-rendering: pixelated; display: block; }
+#controls { display: flex; gap: 8px; align-items: center; }
+button { background: #333; color: #ccc; border: 1px solid #555; padding: 6px 14px;
+         cursor: pointer; font-family: monospace; font-size: 0.9rem; }
+button:hover { background: #444; }
+#status { font-size: 0.8rem; color: #888; }
+details { width: 724px; }
+summary { font-size: 0.75rem; color: #666; cursor: pointer; user-select: none; padding: 2px 0; }
+summary:hover { color: #999; }
+#log { background: #0a0a0a; border: 1px solid #333; padding: 8px;
+       font-size: 0.72rem; color: #666; max-height: 120px; overflow-y: auto;
+       white-space: pre; margin-top: 4px; }
+#log .ok  { color: #6a6; }
+#log .err { color: #a66; }
+#log .inf { color: #668; }
+</style>
+</head>
+<body>
+<h1>ENiGMA&#189; // v86 Desktop</h1>
+<div id="screen">
+  <div style="white-space:pre;font:14px monospace;line-height:14px"></div>
+  <canvas style="display:none"></canvas>
+</div>
+<div id="controls">
+  <button id="btnSave">Save Image</button>
+  <button id="btnStop">Stop</button>
+  <span id="status">Starting emulator...</span>
+</div>
+<details>
+  <summary>Show details</summary>
+  <div id="log"></div>
+</details>
+
+<script src="/libv86.js"></script>
+<script>
+const status = document.getElementById('status');
+const logEl  = document.getElementById('log');
+
+function log(msg, cls) {
+    const line = document.createElement('span');
+    if (cls) line.className = cls;
+    line.textContent = new Date().toISOString().slice(11,19) + '  ' + msg + '\\n';
+    logEl.appendChild(line);
+    logEl.scrollTop = logEl.scrollHeight;
+}
+
+// Intercept XHR (v86 uses XHR for WASM/BIOS/image, not fetch)
+const _XHRopen = XMLHttpRequest.prototype.open;
+const _XHRsend = XMLHttpRequest.prototype.send;
+XMLHttpRequest.prototype.open = function(method, url) {
+    this._logUrl = url;
+    return _XHRopen.apply(this, arguments);
+};
+XMLHttpRequest.prototype.send = function() {
+    const url = this._logUrl || '?';
+    log('XHR  ' + url, 'inf');
+    this.addEventListener('load', () => {
+        log((this.status < 400 ? 'OK   ' : 'FAIL ') + url + ' (' + this.status + ')', this.status < 400 ? 'ok' : 'err');
+    });
+    this.addEventListener('error', () => {
+        log('ERR  ' + url, 'err');
+    });
+    return _XHRsend.apply(this, arguments);
+};
+
+log('Loading libv86.js...', 'inf');
+
+// Preload the disk image with progress before starting v86.
+// async:true (range requests) is unusable over any network — each sector
+// read is a separate HTTP round-trip. One full download is far faster.
+let emulator;
+
+(async () => {
+    try {
+        log('Fetching disk image...', 'inf');
+        const resp = await fetch('/image');
+        if (!resp.ok) throw new Error('HTTP ' + resp.status);
+
+        const total   = parseInt(resp.headers.get('content-length') || '0', 10);
+        const reader  = resp.body.getReader();
+        const chunks  = [];
+        let   received = 0;
+
+        while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            chunks.push(value);
+            received += value.length;
+            if (total) {
+                const pct = Math.round(received / total * 100);
+                const mb  = (received / 1048576).toFixed(0);
+                const tot = (total    / 1048576).toFixed(0);
+                status.textContent = \`Loading image: \${mb} / \${tot} MB (\${pct}%)\`;
+            } else {
+                status.textContent = \`Loading image: \${(received / 1048576).toFixed(0)} MB...\`;
+            }
+        }
+
+        log('Image loaded (' + (received / 1048576).toFixed(1) + ' MB) — starting emulator', 'ok');
+        status.textContent = 'Starting emulator...';
+
+        // Combine chunks into one ArrayBuffer
+        const imageData = new Uint8Array(received);
+        let   offset    = 0;
+        for (const chunk of chunks) { imageData.set(chunk, offset); offset += chunk.length; }
+
+        emulator = new V86({
+            wasm_path:    '/v86.wasm',
+            bios:         { url: '/bios/seabios.bin' },
+            vga_bios:     { url: '/bios/vgabios.bin' },
+            hda:          { buffer: imageData.buffer, async: false },
+            boot_order:   786,
+            memory_size:  64 * 1024 * 1024,
+            vga_memory_size: 2 * 1024 * 1024,
+            screen_container: document.getElementById('screen'),
+            autostart: true,
+        });
+
+        log('V86 instance created', 'inf');
+
+        emulator.add_listener('emulator-loaded', () => {
+            status.textContent = 'Booting...';
+            log('emulator-loaded — booting', 'ok');
+        });
+        emulator.add_listener('emulator-started', () => {
+            status.textContent = 'Running';
+            log('emulator-started — CPU running', 'ok');
+        });
+        emulator.add_listener('emulator-stopped', () => {
+            status.textContent = 'Stopped.';
+            log('emulator-stopped', 'inf');
+        });
+
+    } catch (err) {
+        status.textContent = 'Error: ' + err.message;
+        log('Fatal: ' + err.message, 'err');
+    }
+})();
+
+document.getElementById('btnStop').onclick = () => {
+    if (!emulator) return;
+    if (!confirm('Stop the emulator and shut down the server?')) return;
+    log('Stop requested — shutting down server', 'inf');
+    emulator.stop();
+    fetch('/shutdown').catch(() => {});
+};
+
+document.getElementById('btnSave').onclick = () => {
+    if (!emulator) { alert('Emulator not running yet.'); return; }
+    status.textContent = 'Reading image buffer...';
+    log('Saving image...', 'inf');
+    // v86 exposes the IDE master buffer after boot
+    const buf = emulator.v86.cpu.devices.ide.primary.master.buffer;
+    const blob = new Blob([buf], { type: 'application/octet-stream' });
+
+    // Prefer File System Access API (Chromium) for save-in-place
+    if (window.showSaveFilePicker) {
+        window.showSaveFilePicker({ suggestedName: 'freedos.img' })
+            .then(handle => handle.createWritable())
+            .then(writable => blob.stream().pipeTo(writable))
+            .then(() => { status.textContent = 'Image saved.'; log('Image saved.', 'ok'); })
+            .catch(err => { status.textContent = 'Save cancelled: ' + err.message; log('Save error: ' + err.message, 'err'); });
+    } else {
+        const a = document.createElement('a');
+        a.href = URL.createObjectURL(blob);
+        a.download = 'freedos.img';
+        a.click();
+        status.textContent = 'Image download started.';
+        log('Image download started (fallback).', 'ok');
+    }
+};
+
+// Server shuts down via Ctrl+C in the terminal, or the Stop button above.
+</script>
+</body>
+</html>`;
+
+function cmdDesktop(imagePath) {
+    const paths = resolvePaths(imagePath);
+    if (!paths) return;
+
+    const http = require('http');
+    const { execSync } = require('child_process');
+
+    const v86Dir = path.dirname(require.resolve('v86'));
+    const libv86 = path.join(v86Dir, 'libv86.js');
+    const wasmPath = path.join(v86Dir, 'v86.wasm');
+
+    const PORT = argv['port'] || 18086;
+    const HOST = argv['host'] || '127.0.0.1';
+
+    const server = http.createServer((req, res) => {
+        // Supports HTTP Range requests (RFC 7233) — required for v86 async disk images.
+        // Without this, the browser downloads the entire image before the emulator can start.
+        const serve = (filePath, contentType) => {
+            try {
+                const total = fs.statSync(filePath).size;
+                const rangeHdr = req.headers['range'];
+
+                if (rangeHdr) {
+                    const match = rangeHdr.match(/bytes=(\d+)-(\d*)/);
+                    const start = parseInt(match[1], 10);
+                    const end = match[2] ? parseInt(match[2], 10) : total - 1;
+                    res.writeHead(206, {
+                        'Content-Type': contentType,
+                        'Content-Range': `bytes ${start}-${end}/${total}`,
+                        'Accept-Ranges': 'bytes',
+                        'Content-Length': end - start + 1,
+                    });
+                    fs.createReadStream(filePath, { start, end }).pipe(res);
+                } else {
+                    res.writeHead(200, {
+                        'Content-Type': contentType,
+                        'Content-Length': total,
+                        'Accept-Ranges': 'bytes',
+                    });
+                    fs.createReadStream(filePath).pipe(res);
+                }
+            } catch (err) {
+                res.writeHead(404);
+                res.end('Not found');
+            }
+        };
+
+        switch (req.url) {
+            case '/':
+            case '/index.html':
+                res.writeHead(200, { 'Content-Type': 'text/html' });
+                res.end(DESKTOP_HTML);
+                break;
+
+            case '/libv86.js':
+                serve(libv86, 'application/javascript');
+                break;
+
+            case '/v86.wasm':
+                serve(wasmPath, 'application/wasm');
+                break;
+
+            case '/bios/seabios.bin':
+                serve(paths.biosPath, 'application/octet-stream');
+                break;
+
+            case '/bios/vgabios.bin':
+                serve(paths.vgaBiosPath, 'application/octet-stream');
+                break;
+
+            case '/image':
+                //  Stream image — browser/v86 uses range requests if async
+                serve(paths.imagePath, 'application/octet-stream');
+                break;
+
+            case '/shutdown':
+                res.writeHead(200);
+                res.end('bye');
+                console.error('\nv86 desktop: browser page closed — shutting down');
+                server.close();
+                process.exit(0);
+                break;
+
+            default:
+                res.writeHead(404);
+                res.end('Not found');
+                break;
+        }
+    });
+
+    server.listen(PORT, HOST, () => {
+        // Always print a localhost URL when bound to loopback — VS Code Remote SSH
+        // auto-detects "localhost:PORT" in terminal output and forwards the port,
+        // then opens the browser on the local machine through the tunnel.
+        const printUrl =
+            HOST === '127.0.0.1' || HOST === 'localhost'
+                ? `http://localhost:${PORT}`
+                : `http://${HOST}:${PORT}`;
+
+        console.error(`v86 desktop: serving at ${printUrl}`);
+        console.error(`v86 desktop: image: ${paths.imagePath}`);
+
+        if (HOST !== '127.0.0.1' && HOST !== 'localhost') {
+            console.error(
+                `\nv86 desktop: NOTE: bound to ${HOST} — accessible from other machines.`
+            );
+        }
+
+        console.error('\nv86 desktop: press Ctrl+C to stop\n');
+
+        // Open browser — platform detection
+        try {
+            const platform = process.platform;
+            if (platform === 'darwin') {
+                execSync(`open "${printUrl}"`);
+            } else if (platform === 'win32') {
+                execSync(`start "" "${printUrl}"`);
+            } else {
+                execSync(`xdg-open "${printUrl}"`);
+            }
+        } catch {
+            console.error(
+                `v86 desktop: could not auto-open browser — navigate to ${printUrl}`
+            );
+        }
+    });
+
+    process.on('SIGINT', () => {
+        console.error('\nv86 desktop: shutting down');
+        server.close();
+        process.exit(0);
+    });
+}
+
+// ─── Entry point ─────────────────────────────────────────────────────────────
+
+function handleV86Command() {
+    if (argv.help) {
+        return printUsageAndSetExitCode(getHelpFor('V86'), ExitCodes.SUCCESS);
+    }
+
+    const action = argv._[1];
+    const imagePath = argv._[2];
+
+    if (!action || !imagePath) {
+        return printUsageAndSetExitCode(getHelpFor('V86'), ExitCodes.BAD_ARGS);
+    }
+
+    switch (action) {
+        case 'console':
+            return cmdConsole(imagePath);
+
+        case 'desktop':
+            return cmdDesktop(imagePath);
+
+        default:
+            return printUsageAndSetExitCode(getHelpFor('V86'), ExitCodes.BAD_COMMAND);
+    }
+}

--- a/core/servers/content/nntp.js
+++ b/core/servers/content/nntp.js
@@ -1412,18 +1412,16 @@ exports.getModule = class NNTPServerModule extends ServerModule {
                 const server = this[`${service}Server`];
                 if (server) {
                     const port = config.contentServers.nntp[service].port;
-                    server
-                        .listen(this.listenURI(port, service))
-                        .then(
-                            () => nextService(null),
-                            e => {
-                                Log.warn(
-                                    { error: e.message, port },
-                                    `${service.toUpperCase()} failed to listen`
-                                );
-                                return nextService(null); //  try next anyway
-                            }
-                        );
+                    server.listen(this.listenURI(port, service)).then(
+                        () => nextService(null),
+                        e => {
+                            Log.warn(
+                                { error: e.message, port },
+                                `${service.toUpperCase()} failed to listen`
+                            );
+                            return nextService(null); //  try next anyway
+                        }
+                    );
                 } else {
                     return nextService(null);
                 }

--- a/core/spinner_menu_view.js
+++ b/core/spinner_menu_view.js
@@ -53,8 +53,8 @@ class SpinnerMenuView extends MenuView {
             sgr = this.focusItemFormat
                 ? ''
                 : this.hasFocus
-                ? this.getFocusSGR()
-                : this.getSGR();
+                  ? this.getFocusSGR()
+                  : this.getSGR();
         } else {
             text = strUtil.stylizeString(
                 item.text,

--- a/core/v86_door/fat_image.js
+++ b/core/v86_door/fat_image.js
@@ -18,14 +18,14 @@
 const fatfs = require('fatfs');
 const { createBufferDriverSync } = require('fatfs-volume-driver');
 
-const SECTOR_SIZE        = 512;
-const NUM_SECTORS        = 2880;  // 80 tracks × 2 heads × 18 sectors
-const IMAGE_SIZE         = SECTOR_SIZE * NUM_SECTORS;  // 1,474,560 bytes
-const SECTORS_PER_FAT   = 9;
-const NUM_FATS           = 2;
-const ROOT_ENTRY_COUNT   = 224;
+const SECTOR_SIZE = 512;
+const NUM_SECTORS = 2880; // 80 tracks × 2 heads × 18 sectors
+const IMAGE_SIZE = SECTOR_SIZE * NUM_SECTORS; // 1,474,560 bytes
+const SECTORS_PER_FAT = 9;
+const NUM_FATS = 2;
+const ROOT_ENTRY_COUNT = 224;
 const SECTORS_PER_CLUSTER = 1;
-const RESERVED_SECTORS   = 1;
+const RESERVED_SECTORS = 1;
 
 const FAT1_SECTOR = RESERVED_SECTORS;
 const FAT2_SECTOR = FAT1_SECTOR + SECTORS_PER_FAT;
@@ -34,34 +34,34 @@ const ROOT_SECTOR = FAT2_SECTOR + SECTORS_PER_FAT;
 function buildBootSector() {
     const sector = Buffer.alloc(SECTOR_SIZE, 0);
 
-    sector[0] = 0xEB;
-    sector[1] = 0x3C;
+    sector[0] = 0xeb;
+    sector[1] = 0x3c;
     sector[2] = 0x90;
 
     sector.write('MSDOS5.0', 3, 'ascii');
 
-    sector.writeUInt16LE(SECTOR_SIZE,        11);  // BytsPerSec
-    sector[13] = SECTORS_PER_CLUSTER;              // SecPerClus
-    sector.writeUInt16LE(RESERVED_SECTORS,   14);  // RsvdSecCnt
-    sector[16] = NUM_FATS;                         // NumFATs
-    sector.writeUInt16LE(ROOT_ENTRY_COUNT,   17);  // RootEntCnt
-    sector.writeUInt16LE(NUM_SECTORS,        19);  // TotSec16
-    sector[21] = 0xF0;                             // Media descriptor (1.44MB floppy)
-    sector.writeUInt16LE(SECTORS_PER_FAT,    22);  // FATSz16
-    sector.writeUInt16LE(18,                 24);  // SecPerTrk
-    sector.writeUInt16LE(2,                  26);  // NumHeads
-    sector.writeUInt32LE(0,                  28);  // HiddSec
-    sector.writeUInt32LE(0,                  32);  // TotSec32 (0 = use TotSec16)
+    sector.writeUInt16LE(SECTOR_SIZE, 11); // BytsPerSec
+    sector[13] = SECTORS_PER_CLUSTER; // SecPerClus
+    sector.writeUInt16LE(RESERVED_SECTORS, 14); // RsvdSecCnt
+    sector[16] = NUM_FATS; // NumFATs
+    sector.writeUInt16LE(ROOT_ENTRY_COUNT, 17); // RootEntCnt
+    sector.writeUInt16LE(NUM_SECTORS, 19); // TotSec16
+    sector[21] = 0xf0; // Media descriptor (1.44MB floppy)
+    sector.writeUInt16LE(SECTORS_PER_FAT, 22); // FATSz16
+    sector.writeUInt16LE(18, 24); // SecPerTrk
+    sector.writeUInt16LE(2, 26); // NumHeads
+    sector.writeUInt32LE(0, 28); // HiddSec
+    sector.writeUInt32LE(0, 32); // TotSec32 (0 = use TotSec16)
 
-    sector[36] = 0x00;                             // DrvNum (floppy = 0)
-    sector[37] = 0x00;                             // Reserved1
-    sector[38] = 0x29;                             // BootSig
-    sector.writeUInt32LE(0x12345678,         39);  // VolID
-    sector.write('NO NAME    ',              43, 'ascii');  // VolLab (11 bytes)
-    sector.write('FAT12   ',                 54, 'ascii');  // FilSysType (8 bytes)
+    sector[36] = 0x00; // DrvNum (floppy = 0)
+    sector[37] = 0x00; // Reserved1
+    sector[38] = 0x29; // BootSig
+    sector.writeUInt32LE(0x12345678, 39); // VolID
+    sector.write('NO NAME    ', 43, 'ascii'); // VolLab (11 bytes)
+    sector.write('FAT12   ', 54, 'ascii'); // FilSysType (8 bytes)
 
     sector[510] = 0x55;
-    sector[511] = 0xAA;
+    sector[511] = 0xaa;
 
     return sector;
 }
@@ -69,9 +69,9 @@ function buildBootSector() {
 function buildFATTable() {
     const fat = Buffer.alloc(SECTORS_PER_FAT * SECTOR_SIZE, 0);
     // Reserved entries: media descriptor + EOC marker
-    fat[0] = 0xF0;
-    fat[1] = 0xFF;
-    fat[2] = 0xFF;
+    fat[0] = 0xf0;
+    fat[1] = 0xff;
+    fat[2] = 0xff;
     return fat;
 }
 
@@ -111,7 +111,9 @@ function createFloppyWithFiles(files) {
             for (const { name, content } of files) {
                 fs.writeFile(name, content, err => {
                     if (err) {
-                        return reject(new Error(`Failed to write ${name} to floppy: ${err.message}`));
+                        return reject(
+                            new Error(`Failed to write ${name} to floppy: ${err.message}`)
+                        );
                     }
                     pending--;
                     if (pending === 0) {

--- a/core/v86_door/fat_image.js
+++ b/core/v86_door/fat_image.js
@@ -1,0 +1,126 @@
+/* jslint node: true */
+'use strict';
+
+/**
+ * fat_image.js
+ *
+ * Builds a 1.44MB FAT12 floppy disk image in memory and writes files into it.
+ * Used by v86_worker.js to create the drop file drive (v86 mounts it as fda → A: in FreeDOS).
+ *
+ * FAT12 1.44MB floppy layout:
+ *   Sector 0       : Boot sector (BPB)
+ *   Sectors 1–9    : FAT1 (9 sectors)
+ *   Sectors 10–18  : FAT2 (copy of FAT1)
+ *   Sectors 19–32  : Root directory (14 sectors, 224 entries × 32 bytes)
+ *   Sectors 33+    : Data area
+ */
+
+const fatfs = require('fatfs');
+const { createBufferDriverSync } = require('fatfs-volume-driver');
+
+const SECTOR_SIZE        = 512;
+const NUM_SECTORS        = 2880;  // 80 tracks × 2 heads × 18 sectors
+const IMAGE_SIZE         = SECTOR_SIZE * NUM_SECTORS;  // 1,474,560 bytes
+const SECTORS_PER_FAT   = 9;
+const NUM_FATS           = 2;
+const ROOT_ENTRY_COUNT   = 224;
+const SECTORS_PER_CLUSTER = 1;
+const RESERVED_SECTORS   = 1;
+
+const FAT1_SECTOR = RESERVED_SECTORS;
+const FAT2_SECTOR = FAT1_SECTOR + SECTORS_PER_FAT;
+const ROOT_SECTOR = FAT2_SECTOR + SECTORS_PER_FAT;
+
+function buildBootSector() {
+    const sector = Buffer.alloc(SECTOR_SIZE, 0);
+
+    sector[0] = 0xEB;
+    sector[1] = 0x3C;
+    sector[2] = 0x90;
+
+    sector.write('MSDOS5.0', 3, 'ascii');
+
+    sector.writeUInt16LE(SECTOR_SIZE,        11);  // BytsPerSec
+    sector[13] = SECTORS_PER_CLUSTER;              // SecPerClus
+    sector.writeUInt16LE(RESERVED_SECTORS,   14);  // RsvdSecCnt
+    sector[16] = NUM_FATS;                         // NumFATs
+    sector.writeUInt16LE(ROOT_ENTRY_COUNT,   17);  // RootEntCnt
+    sector.writeUInt16LE(NUM_SECTORS,        19);  // TotSec16
+    sector[21] = 0xF0;                             // Media descriptor (1.44MB floppy)
+    sector.writeUInt16LE(SECTORS_PER_FAT,    22);  // FATSz16
+    sector.writeUInt16LE(18,                 24);  // SecPerTrk
+    sector.writeUInt16LE(2,                  26);  // NumHeads
+    sector.writeUInt32LE(0,                  28);  // HiddSec
+    sector.writeUInt32LE(0,                  32);  // TotSec32 (0 = use TotSec16)
+
+    sector[36] = 0x00;                             // DrvNum (floppy = 0)
+    sector[37] = 0x00;                             // Reserved1
+    sector[38] = 0x29;                             // BootSig
+    sector.writeUInt32LE(0x12345678,         39);  // VolID
+    sector.write('NO NAME    ',              43, 'ascii');  // VolLab (11 bytes)
+    sector.write('FAT12   ',                 54, 'ascii');  // FilSysType (8 bytes)
+
+    sector[510] = 0x55;
+    sector[511] = 0xAA;
+
+    return sector;
+}
+
+function buildFATTable() {
+    const fat = Buffer.alloc(SECTORS_PER_FAT * SECTOR_SIZE, 0);
+    // Reserved entries: media descriptor + EOC marker
+    fat[0] = 0xF0;
+    fat[1] = 0xFF;
+    fat[2] = 0xFF;
+    return fat;
+}
+
+function buildEmptyFloppyImage() {
+    const img = Buffer.alloc(IMAGE_SIZE, 0);
+    buildBootSector().copy(img, 0);
+    buildFATTable().copy(img, FAT1_SECTOR * SECTOR_SIZE);
+    buildFATTable().copy(img, FAT2_SECTOR * SECTOR_SIZE);
+    return img;
+}
+
+/**
+ * Create a 1.44MB FAT12 floppy image containing the given files.
+ *
+ * @param {Array<{name: string, content: Buffer}>} files
+ *   `name` is the DOS 8.3 filename (e.g. 'DOOR.SYS').
+ *   `content` is a Buffer.
+ * @returns {Promise<Buffer>} The completed image buffer.
+ */
+function createFloppyWithFiles(files) {
+    const img = buildEmptyFloppyImage();
+
+    return new Promise((resolve, reject) => {
+        // partitionNumber: 0 = raw FAT at offset 0 (no MBR partition table — floppy style)
+        const driver = createBufferDriverSync('', { buffer: img, partitionNumber: 0 });
+        const fs = fatfs.createFileSystem(driver);
+
+        fs.on('error', reject);
+
+        fs.on('ready', () => {
+            if (files.length === 0) {
+                return resolve(img);
+            }
+
+            let pending = files.length;
+
+            for (const { name, content } of files) {
+                fs.writeFile(name, content, err => {
+                    if (err) {
+                        return reject(new Error(`Failed to write ${name} to floppy: ${err.message}`));
+                    }
+                    pending--;
+                    if (pending === 0) {
+                        resolve(img);
+                    }
+                });
+            }
+        });
+    });
+}
+
+module.exports = { createFloppyWithFiles };

--- a/core/v86_door/v86_door.js
+++ b/core/v86_door/v86_door.js
@@ -40,6 +40,7 @@ const { Errors }          = require('../enig_error.js');
 const { trackDoorRunBegin, trackDoorRunEnd } = require('../door_util.js');
 const DropFile            = require('../dropfile.js');
 const theme               = require('../theme.js');
+const ansi                = require('../ansi_term.js');
 const { createFloppyWithFiles } = require('./fat_image.js');
 
 //  deps
@@ -149,22 +150,46 @@ exports.getModule = class V86DoorModule extends MenuModule {
 
                 function buildFloppy(callback) {
                     const dropFileType = (self.config.dropFileType || '').toUpperCase();
-                    if (!dropFileType || dropFileType === 'NONE') {
+                    const hasDropFile  = dropFileType && dropFileType !== 'NONE';
+                    const hasRunBatch  = _.isString(self.config.runBatch) && self.config.runBatch.trim().length > 0;
+
+                    if (!hasDropFile && !hasRunBatch) {
                         self.floppyBuffer = null;
                         return callback(null);
                     }
 
-                    const dropFile = new DropFile(self.client, { fileType: dropFileType });
-                    if (!dropFile.isSupported()) {
-                        return callback(
-                            Errors.MissingConfig(`v86_door: unsupported dropFileType "${dropFileType}" (use DORINFO, DOOR, or DOOR32)`)
-                        );
+                    const floppyFiles = [];
+
+                    if (hasDropFile) {
+                        const dropFile = new DropFile(self.client, { fileType: dropFileType });
+                        if (!dropFile.isSupported()) {
+                            return callback(
+                                Errors.MissingConfig(`v86_door: unsupported dropFileType "${dropFileType}" (use DORINFO, DOOR, or DOOR32)`)
+                            );
+                        }
+                        floppyFiles.push({ name: dropFile.fileName, content: dropFile.getContents() });
                     }
 
-                    const contents = dropFile.getContents();
-                    const fileName = dropFile.fileName;
+                    if (hasRunBatch) {
+                        const dropFileName = hasDropFile
+                            ? new DropFile(self.client, { fileType: dropFileType }).fileName
+                            : '';
 
-                    createFloppyWithFiles([{ name: fileName, content: contents }])
+                        //  Variable substitution: {dropFile}, {node}, {baud}
+                        const runBatchText = self.config.runBatch
+                            .replace(/\{dropFile\}/gi, dropFileName)
+                            .replace(/\{node\}/gi,     String(self.client.node))
+                            .replace(/\{baud\}/gi,     '57600');
+
+                        //  Normalize to CRLF — DOS requires it
+                        const runBatchCrlf = runBatchText
+                            .replace(/\r\n/g, '\n')
+                            .replace(/\n/g, '\r\n');
+
+                        floppyFiles.push({ name: 'RUN.BAT', content: Buffer.from(runBatchCrlf, 'ascii') });
+                    }
+
+                    createFloppyWithFiles(floppyFiles)
                         .then(img => {
                             self.floppyBuffer = img;
                             return callback(null);
@@ -191,6 +216,29 @@ exports.getModule = class V86DoorModule extends MenuModule {
                         return callback(err);
                     }
 
+                    //  Loading spinner — shown until the first serial byte arrives
+                    const SPINNER_FRAMES = ['|', '/', '-', '\\'];
+                    let spinnerIdx = 0;
+                    let firstOutput = true;
+                    const doorName = self.config.name;
+
+                    self.client.term.write(ansi.resetScreen());
+                    self.client.term.write(`\r\n  Loading ${doorName}... ${SPINNER_FRAMES[0]}`);
+
+                    const spinnerInterval = setInterval(() => {
+                        spinnerIdx = (spinnerIdx + 1) % SPINNER_FRAMES.length;
+                        self.client.term.rawWrite(
+                            Buffer.from(`\r  Loading ${doorName}... ${SPINNER_FRAMES[spinnerIdx]}`)
+                        );
+                    }, 150);
+
+                    const stopSpinner = () => {
+                        if (!firstOutput) return;
+                        firstOutput = false;
+                        clearInterval(spinnerInterval);
+                        self.client.term.write(ansi.resetScreen());
+                    };
+
                     //  Client → COM1
                     const onClientData = data => {
                         worker.postMessage({ type: 'input', data });
@@ -200,6 +248,7 @@ exports.getModule = class V86DoorModule extends MenuModule {
                     //  Client disconnected
                     self.client.once('end', () => {
                         clientTerminated = true;
+                        clearInterval(spinnerInterval);
                         self.client.log.info(
                             { name: self.config.name },
                             'Client disconnected — terminating v86 worker'
@@ -218,10 +267,12 @@ exports.getModule = class V86DoorModule extends MenuModule {
                                 break;
 
                             case 'output':
+                                stopSpinner();
                                 self.client.term.rawWrite(Buffer.from(msg.data));
                                 break;
 
                             case 'stopped': {
+                                clearInterval(spinnerInterval);
                                 const secs = (msg.elapsed / 1000).toFixed(1);
                                 self.client.log.info(
                                     { name: self.config.name, elapsed: secs },
@@ -234,6 +285,7 @@ exports.getModule = class V86DoorModule extends MenuModule {
                             }
 
                             case 'error':
+                                clearInterval(spinnerInterval);
                                 self.client.log.warn(
                                     { name: self.config.name, error: msg.message },
                                     'v86 worker error'
@@ -249,6 +301,7 @@ exports.getModule = class V86DoorModule extends MenuModule {
                     });
 
                     worker.on('error', err => {
+                        clearInterval(spinnerInterval);
                         self.client.log.warn(
                             { name: self.config.name, error: err.message },
                             'v86 worker thread error'

--- a/core/v86_door/v86_door.js
+++ b/core/v86_door/v86_door.js
@@ -169,6 +169,7 @@ exports.getModule = class V86DoorModule extends MenuModule {
                     }
 
                     const floppyFiles = [];
+                    let dropFileName = '';
 
                     if (hasDropFile) {
                         const dropFile = new DropFile(self.client, {
@@ -181,18 +182,14 @@ exports.getModule = class V86DoorModule extends MenuModule {
                                 )
                             );
                         }
+                        dropFileName = dropFile.fileName;
                         floppyFiles.push({
-                            name: dropFile.fileName,
+                            name: dropFileName,
                             content: dropFile.getContents(),
                         });
                     }
 
                     if (hasRunBatch) {
-                        const dropFileName = hasDropFile
-                            ? new DropFile(self.client, { fileType: dropFileType })
-                                  .fileName
-                            : '';
-
                         //  Variable substitution: {dropFile}, {node}, {baud}
                         const runBatchText = self.config.runBatch
                             .replace(/\{dropFile\}/gi, dropFileName)

--- a/core/v86_door/v86_door.js
+++ b/core/v86_door/v86_door.js
@@ -35,32 +35,32 @@
  *   curl -fL https://github.com/copy/v86/raw/master/bios/vgabios.bin -o misc/v86_bios/vgabios.bin
  */
 
-const { MenuModule }      = require('../menu_module.js');
-const { Errors }          = require('../enig_error.js');
+const { MenuModule } = require('../menu_module.js');
+const { Errors } = require('../enig_error.js');
 const { trackDoorRunBegin, trackDoorRunEnd } = require('../door_util.js');
-const DropFile            = require('../dropfile.js');
-const theme               = require('../theme.js');
-const ansi                = require('../ansi_term.js');
+const DropFile = require('../dropfile.js');
+const theme = require('../theme.js');
+const ansi = require('../ansi_term.js');
 const { createFloppyWithFiles } = require('./fat_image.js');
 
 //  deps
-const async  = require('async');
-const _      = require('lodash');
-const paths  = require('path');
+const async = require('async');
+const _ = require('lodash');
+const paths = require('path');
 const { existsSync } = require('fs');
-const { Worker }     = require('worker_threads');
+const { Worker } = require('worker_threads');
 
-const WORKER_PATH   = paths.join(__dirname, 'v86_worker.js');
-const ENIGMA_ROOT   = paths.join(__dirname, '..', '..');
-const DEFAULT_BIOS_PATH     = paths.join(ENIGMA_ROOT, 'misc', 'v86_bios', 'seabios.bin');
+const WORKER_PATH = paths.join(__dirname, 'v86_worker.js');
+const ENIGMA_ROOT = paths.join(__dirname, '..', '..');
+const DEFAULT_BIOS_PATH = paths.join(ENIGMA_ROOT, 'misc', 'v86_bios', 'seabios.bin');
 const DEFAULT_VGA_BIOS_PATH = paths.join(ENIGMA_ROOT, 'misc', 'v86_bios', 'vgabios.bin');
 
 //  Track active instances per door name (mirrors abracadabra pattern)
 const activeDoorInstances = {};
 
 exports.moduleInfo = {
-    name:   'V86Door',
-    desc:   'Native x86/DOS Door Emulation via v86',
+    name: 'V86Door',
+    desc: 'Native x86/DOS Door Emulation via v86',
     author: 'NuSkooler',
 };
 
@@ -69,10 +69,10 @@ exports.getModule = class V86DoorModule extends MenuModule {
         super(options);
 
         this.config = options.menuConfig.config || {};
-        this.config.nodeMax  = this.config.nodeMax  || 0;
+        this.config.nodeMax = this.config.nodeMax || 0;
         this.config.memoryMb = this.config.memoryMb || 64;
 
-        this.config.biosPath    = this.config.biosPath    || DEFAULT_BIOS_PATH;
+        this.config.biosPath = this.config.biosPath || DEFAULT_BIOS_PATH;
         this.config.vgaBiosPath = this.config.vgaBiosPath || DEFAULT_VGA_BIOS_PATH;
     }
 
@@ -91,14 +91,14 @@ exports.getModule = class V86DoorModule extends MenuModule {
 
                 function checkBios(callback) {
                     for (const [label, p] of [
-                        ['biosPath',    self.config.biosPath],
+                        ['biosPath', self.config.biosPath],
                         ['vgaBiosPath', self.config.vgaBiosPath],
                     ]) {
                         if (!existsSync(p)) {
                             return callback(
                                 Errors.MissingConfig(
                                     `v86_door: ${label} not found: ${p}\n` +
-                                    'Download BIOS files from https://github.com/copy/v86/tree/master/bios'
+                                        'Download BIOS files from https://github.com/copy/v86/tree/master/bios'
                                 )
                             );
                         }
@@ -109,7 +109,9 @@ exports.getModule = class V86DoorModule extends MenuModule {
                 function checkImage(callback) {
                     if (!existsSync(self.config.image)) {
                         return callback(
-                            Errors.MissingConfig(`v86_door: disk image not found: ${self.config.image}`)
+                            Errors.MissingConfig(
+                                `v86_door: disk image not found: ${self.config.image}`
+                            )
                         );
                     }
                     return callback(null);
@@ -132,12 +134,18 @@ exports.getModule = class V86DoorModule extends MenuModule {
                                 { client: self.client, name: self.config.tooManyArt },
                                 () => {
                                     self.pausePrompt(() =>
-                                        callback(Errors.AccessDenied('Too many active instances'))
+                                        callback(
+                                            Errors.AccessDenied(
+                                                'Too many active instances'
+                                            )
+                                        )
                                     );
                                 }
                             );
                         } else {
-                            self.client.term.write('\nToo many active instances. Try again later.\n');
+                            self.client.term.write(
+                                '\nToo many active instances. Try again later.\n'
+                            );
                             self.pausePrompt(() =>
                                 callback(Errors.AccessDenied('Too many active instances'))
                             );
@@ -150,8 +158,10 @@ exports.getModule = class V86DoorModule extends MenuModule {
 
                 function buildFloppy(callback) {
                     const dropFileType = (self.config.dropFileType || '').toUpperCase();
-                    const hasDropFile  = dropFileType && dropFileType !== 'NONE';
-                    const hasRunBatch  = _.isString(self.config.runBatch) && self.config.runBatch.trim().length > 0;
+                    const hasDropFile = dropFileType && dropFileType !== 'NONE';
+                    const hasRunBatch =
+                        _.isString(self.config.runBatch) &&
+                        self.config.runBatch.trim().length > 0;
 
                     if (!hasDropFile && !hasRunBatch) {
                         self.floppyBuffer = null;
@@ -161,32 +171,43 @@ exports.getModule = class V86DoorModule extends MenuModule {
                     const floppyFiles = [];
 
                     if (hasDropFile) {
-                        const dropFile = new DropFile(self.client, { fileType: dropFileType });
+                        const dropFile = new DropFile(self.client, {
+                            fileType: dropFileType,
+                        });
                         if (!dropFile.isSupported()) {
                             return callback(
-                                Errors.MissingConfig(`v86_door: unsupported dropFileType "${dropFileType}" (use DORINFO, DOOR, or DOOR32)`)
+                                Errors.MissingConfig(
+                                    `v86_door: unsupported dropFileType "${dropFileType}" (use DORINFO, DOOR, or DOOR32)`
+                                )
                             );
                         }
-                        floppyFiles.push({ name: dropFile.fileName, content: dropFile.getContents() });
+                        floppyFiles.push({
+                            name: dropFile.fileName,
+                            content: dropFile.getContents(),
+                        });
                     }
 
                     if (hasRunBatch) {
                         const dropFileName = hasDropFile
-                            ? new DropFile(self.client, { fileType: dropFileType }).fileName
+                            ? new DropFile(self.client, { fileType: dropFileType })
+                                  .fileName
                             : '';
 
                         //  Variable substitution: {dropFile}, {node}, {baud}
                         const runBatchText = self.config.runBatch
                             .replace(/\{dropFile\}/gi, dropFileName)
-                            .replace(/\{node\}/gi,     String(self.client.node))
-                            .replace(/\{baud\}/gi,     '57600');
+                            .replace(/\{node\}/gi, String(self.client.node))
+                            .replace(/\{baud\}/gi, '57600');
 
                         //  Normalize to CRLF — DOS requires it
                         const runBatchCrlf = runBatchText
                             .replace(/\r\n/g, '\n')
                             .replace(/\n/g, '\r\n');
 
-                        floppyFiles.push({ name: 'RUN.BAT', content: Buffer.from(runBatchCrlf, 'ascii') });
+                        floppyFiles.push({
+                            name: 'RUN.BAT',
+                            content: Buffer.from(runBatchCrlf, 'ascii'),
+                        });
                     }
 
                     createFloppyWithFiles(floppyFiles)
@@ -201,10 +222,10 @@ exports.getModule = class V86DoorModule extends MenuModule {
                     const doorTracking = trackDoorRunBegin(self.client, self.config.name);
 
                     const workerData = {
-                        imagePath:   self.config.image,
+                        imagePath: self.config.image,
                         floppyBuffer: self.floppyBuffer || Buffer.alloc(0),
-                        memoryMb:    self.config.memoryMb,
-                        biosPath:    self.config.biosPath,
+                        memoryMb: self.config.memoryMb,
+                        biosPath: self.config.biosPath,
                         vgaBiosPath: self.config.vgaBiosPath,
                     };
 
@@ -223,12 +244,16 @@ exports.getModule = class V86DoorModule extends MenuModule {
                     const doorName = self.config.name;
 
                     self.client.term.write(ansi.resetScreen());
-                    self.client.term.write(`\r\n  Loading ${doorName}... ${SPINNER_FRAMES[0]}`);
+                    self.client.term.write(
+                        `\r\n  Loading ${doorName}... ${SPINNER_FRAMES[0]}`
+                    );
 
                     const spinnerInterval = setInterval(() => {
                         spinnerIdx = (spinnerIdx + 1) % SPINNER_FRAMES.length;
                         self.client.term.rawWrite(
-                            Buffer.from(`\r  Loading ${doorName}... ${SPINNER_FRAMES[spinnerIdx]}`)
+                            Buffer.from(
+                                `\r  Loading ${doorName}... ${SPINNER_FRAMES[spinnerIdx]}`
+                            )
                         );
                     }, 150);
 
@@ -278,7 +303,10 @@ exports.getModule = class V86DoorModule extends MenuModule {
                                     { name: self.config.name, elapsed: secs },
                                     'v86 emulator stopped'
                                 );
-                                self.client.term.output.removeListener('data', onClientData);
+                                self.client.term.output.removeListener(
+                                    'data',
+                                    onClientData
+                                );
                                 trackDoorRunEnd(doorTracking);
                                 self._decrementInstances();
                                 return callback(null);
@@ -290,7 +318,10 @@ exports.getModule = class V86DoorModule extends MenuModule {
                                     { name: self.config.name, error: msg.message },
                                     'v86 worker error'
                                 );
-                                self.client.term.output.removeListener('data', onClientData);
+                                self.client.term.output.removeListener(
+                                    'data',
+                                    onClientData
+                                );
                                 trackDoorRunEnd(doorTracking);
                                 self._decrementInstances();
                                 return callback(new Error(msg.message));

--- a/core/v86_door/v86_door.js
+++ b/core/v86_door/v86_door.js
@@ -1,0 +1,297 @@
+/* jslint node: true */
+'use strict';
+
+/**
+ * v86_door.js — ENiGMA½ native x86/DOS door emulation module
+ *
+ * Boots a FreeDOS disk image in a v86 x86 emulator (worker thread) and bridges
+ * the user's connection to the emulated COM1 port. No external emulator required.
+ *
+ * The emulator runs in a worker_threads Worker to avoid blocking ENiGMA's event loop.
+ * A 1.44MB FAT12 floppy image containing the drop file is built in memory and
+ * mounted as A: in FreeDOS. The op's AUTOEXEC.BAT copies it to the door directory.
+ *
+ * Config (menu.hjson):
+ *   module: v86_door
+ *   config: {
+ *     name:         string   - door name (required, used for node count tracking)
+ *     image:        string   - path to FreeDOS door disk image (required)
+ *     dropFileType: string   - DORINFO | DOOR | DOOR32 (optional, default: none)
+ *     nodeMax:      number   - max concurrent sessions, 0 = unlimited (default: 0)
+ *     tooManyArt:   string   - art file to show when nodeMax exceeded (optional)
+ *     memoryMb:     number   - guest RAM in MB (default: 64)
+ *     biosPath:     string   - path to SeaBIOS image (default: {enigma_root}/bios/seabios.bin)
+ *     vgaBiosPath:  string   - path to VGA BIOS image (default: {enigma_root}/bios/vgabios.bin)
+ *   }
+ *
+ * Drop file filename on A: drive:
+ *   DORINFO → DORINFOx.DEF (x = node-based suffix, per DORINFO spec)
+ *   DOOR    → DOOR.SYS
+ *   DOOR32  → door32.sys
+ *
+ * BIOS files are not bundled with the v86 npm package. install.sh downloads them automatically
+ * to misc/v86_bios/. To download manually:
+ *   curl -fL https://github.com/copy/v86/raw/master/bios/seabios.bin -o misc/v86_bios/seabios.bin
+ *   curl -fL https://github.com/copy/v86/raw/master/bios/vgabios.bin -o misc/v86_bios/vgabios.bin
+ */
+
+const { MenuModule }      = require('../menu_module.js');
+const { Errors }          = require('../enig_error.js');
+const { trackDoorRunBegin, trackDoorRunEnd } = require('../door_util.js');
+const DropFile            = require('../dropfile.js');
+const theme               = require('../theme.js');
+const { createFloppyWithFiles } = require('./fat_image.js');
+
+//  deps
+const async  = require('async');
+const _      = require('lodash');
+const paths  = require('path');
+const { existsSync } = require('fs');
+const { Worker }     = require('worker_threads');
+
+const WORKER_PATH   = paths.join(__dirname, 'v86_worker.js');
+const ENIGMA_ROOT   = paths.join(__dirname, '..', '..');
+const DEFAULT_BIOS_PATH     = paths.join(ENIGMA_ROOT, 'misc', 'v86_bios', 'seabios.bin');
+const DEFAULT_VGA_BIOS_PATH = paths.join(ENIGMA_ROOT, 'misc', 'v86_bios', 'vgabios.bin');
+
+//  Track active instances per door name (mirrors abracadabra pattern)
+const activeDoorInstances = {};
+
+exports.moduleInfo = {
+    name:   'V86Door',
+    desc:   'Native x86/DOS Door Emulation via v86',
+    author: 'NuSkooler',
+};
+
+exports.getModule = class V86DoorModule extends MenuModule {
+    constructor(options) {
+        super(options);
+
+        this.config = options.menuConfig.config || {};
+        this.config.nodeMax  = this.config.nodeMax  || 0;
+        this.config.memoryMb = this.config.memoryMb || 64;
+
+        this.config.biosPath    = this.config.biosPath    || DEFAULT_BIOS_PATH;
+        this.config.vgaBiosPath = this.config.vgaBiosPath || DEFAULT_VGA_BIOS_PATH;
+    }
+
+    initSequence() {
+        const self = this;
+        let clientTerminated = false;
+
+        async.series(
+            [
+                function validateConfig(callback) {
+                    return self.validateConfigFields(
+                        { name: 'string', image: 'string' },
+                        callback
+                    );
+                },
+
+                function checkBios(callback) {
+                    for (const [label, p] of [
+                        ['biosPath',    self.config.biosPath],
+                        ['vgaBiosPath', self.config.vgaBiosPath],
+                    ]) {
+                        if (!existsSync(p)) {
+                            return callback(
+                                Errors.MissingConfig(
+                                    `v86_door: ${label} not found: ${p}\n` +
+                                    'Download BIOS files from https://github.com/copy/v86/tree/master/bios'
+                                )
+                            );
+                        }
+                    }
+                    return callback(null);
+                },
+
+                function checkImage(callback) {
+                    if (!existsSync(self.config.image)) {
+                        return callback(
+                            Errors.MissingConfig(`v86_door: disk image not found: ${self.config.image}`)
+                        );
+                    }
+                    return callback(null);
+                },
+
+                function validateNodeCount(callback) {
+                    const name = self.config.name;
+                    if (
+                        self.config.nodeMax > 0 &&
+                        _.isNumber(activeDoorInstances[name]) &&
+                        activeDoorInstances[name] + 1 > self.config.nodeMax
+                    ) {
+                        self.client.log.info(
+                            { name, activeCount: activeDoorInstances[name] },
+                            `Too many active instances of door "${name}"`
+                        );
+
+                        if (_.isString(self.config.tooManyArt)) {
+                            theme.displayThemeArt(
+                                { client: self.client, name: self.config.tooManyArt },
+                                () => {
+                                    self.pausePrompt(() =>
+                                        callback(Errors.AccessDenied('Too many active instances'))
+                                    );
+                                }
+                            );
+                        } else {
+                            self.client.term.write('\nToo many active instances. Try again later.\n');
+                            self.pausePrompt(() =>
+                                callback(Errors.AccessDenied('Too many active instances'))
+                            );
+                        }
+                    } else {
+                        self._incrementInstances();
+                        return callback(null);
+                    }
+                },
+
+                function buildFloppy(callback) {
+                    const dropFileType = (self.config.dropFileType || '').toUpperCase();
+                    if (!dropFileType || dropFileType === 'NONE') {
+                        self.floppyBuffer = null;
+                        return callback(null);
+                    }
+
+                    const dropFile = new DropFile(self.client, { fileType: dropFileType });
+                    if (!dropFile.isSupported()) {
+                        return callback(
+                            Errors.MissingConfig(`v86_door: unsupported dropFileType "${dropFileType}" (use DORINFO, DOOR, or DOOR32)`)
+                        );
+                    }
+
+                    const contents = dropFile.getContents();
+                    const fileName = dropFile.fileName;
+
+                    createFloppyWithFiles([{ name: fileName, content: contents }])
+                        .then(img => {
+                            self.floppyBuffer = img;
+                            return callback(null);
+                        })
+                        .catch(err => callback(err));
+                },
+
+                function runDoor(callback) {
+                    const doorTracking = trackDoorRunBegin(self.client, self.config.name);
+
+                    const workerData = {
+                        imagePath:   self.config.image,
+                        floppyBuffer: self.floppyBuffer || Buffer.alloc(0),
+                        memoryMb:    self.config.memoryMb,
+                        biosPath:    self.config.biosPath,
+                        vgaBiosPath: self.config.vgaBiosPath,
+                    };
+
+                    let worker;
+                    try {
+                        worker = new Worker(WORKER_PATH, { workerData });
+                    } catch (err) {
+                        trackDoorRunEnd(doorTracking);
+                        return callback(err);
+                    }
+
+                    //  Client → COM1
+                    const onClientData = data => {
+                        worker.postMessage({ type: 'input', data });
+                    };
+                    self.client.term.output.on('data', onClientData);
+
+                    //  Client disconnected
+                    self.client.once('end', () => {
+                        clientTerminated = true;
+                        self.client.log.info(
+                            { name: self.config.name },
+                            'Client disconnected — terminating v86 worker'
+                        );
+                        worker.terminate();
+                        self.client.term.output.removeListener('data', onClientData);
+                    });
+
+                    worker.on('message', msg => {
+                        switch (msg.type) {
+                            case 'ready':
+                                self.client.log.info(
+                                    { name: self.config.name },
+                                    'v86 emulator ready'
+                                );
+                                break;
+
+                            case 'output':
+                                self.client.term.rawWrite(Buffer.from(msg.data));
+                                break;
+
+                            case 'stopped': {
+                                const secs = (msg.elapsed / 1000).toFixed(1);
+                                self.client.log.info(
+                                    { name: self.config.name, elapsed: secs },
+                                    'v86 emulator stopped'
+                                );
+                                self.client.term.output.removeListener('data', onClientData);
+                                trackDoorRunEnd(doorTracking);
+                                self._decrementInstances();
+                                return callback(null);
+                            }
+
+                            case 'error':
+                                self.client.log.warn(
+                                    { name: self.config.name, error: msg.message },
+                                    'v86 worker error'
+                                );
+                                self.client.term.output.removeListener('data', onClientData);
+                                trackDoorRunEnd(doorTracking);
+                                self._decrementInstances();
+                                return callback(new Error(msg.message));
+
+                            default:
+                                break;
+                        }
+                    });
+
+                    worker.on('error', err => {
+                        self.client.log.warn(
+                            { name: self.config.name, error: err.message },
+                            'v86 worker thread error'
+                        );
+                        self.client.term.output.removeListener('data', onClientData);
+                        trackDoorRunEnd(doorTracking);
+                        self._decrementInstances();
+                        return callback(err);
+                    });
+
+                    worker.on('exit', code => {
+                        if (code !== 0) {
+                            self.client.log.warn(
+                                { name: self.config.name, code },
+                                'v86 worker exited with non-zero code'
+                            );
+                        }
+                    });
+                },
+            ],
+            err => {
+                if (err) {
+                    self.client.log.warn({ error: err.message }, 'v86_door error');
+                }
+
+                if (!clientTerminated) {
+                    self.prevMenu();
+                }
+            }
+        );
+    }
+
+    _incrementInstances() {
+        const name = this.config.name;
+        activeDoorInstances[name] = (activeDoorInstances[name] || 0) + 1;
+        this._instanceIncremented = true;
+    }
+
+    _decrementInstances() {
+        if (this._instanceIncremented) {
+            const name = this.config.name;
+            activeDoorInstances[name] = Math.max(0, (activeDoorInstances[name] || 1) - 1);
+            this._instanceIncremented = false;
+        }
+    }
+};

--- a/core/v86_door/v86_worker.js
+++ b/core/v86_door/v86_worker.js
@@ -136,8 +136,20 @@ emulator.add_listener('emulator-loaded', () => {
 
 // ─── Serial I/O ───────────────────────────────────────────────────────────────
 
+// Buffer serial output and flush in batches — one postMessage per byte would
+// generate hundreds of cross-thread messages per second during ANSI rendering.
+let outputBuf = [];
+let flushTimer = null;
+
 emulator.add_listener('serial0-output-byte', byte => {
-    parentPort.postMessage({ type: 'output', data: Buffer.from([byte]) });
+    outputBuf.push(byte);
+    if (!flushTimer) {
+        flushTimer = setTimeout(() => {
+            parentPort.postMessage({ type: 'output', data: Buffer.from(outputBuf) });
+            outputBuf = [];
+            flushTimer = null;
+        }, 5);
+    }
 });
 
 parentPort.on('message', msg => {

--- a/core/v86_door/v86_worker.js
+++ b/core/v86_door/v86_worker.js
@@ -41,17 +41,23 @@ let diskBuffer;
 try {
     diskBuffer = readFileSync(workerData.imagePath);
 } catch (err) {
-    parentPort.postMessage({ type: 'error', message: `Cannot read disk image: ${err.message}` });
+    parentPort.postMessage({
+        type: 'error',
+        message: `Cannot read disk image: ${err.message}`,
+    });
     process.exit(1);
 }
 
 let biosBuffer;
 let vgaBiosBuffer;
 try {
-    biosBuffer    = readFileSync(workerData.biosPath);
+    biosBuffer = readFileSync(workerData.biosPath);
     vgaBiosBuffer = readFileSync(workerData.vgaBiosPath);
 } catch (err) {
-    parentPort.postMessage({ type: 'error', message: `Cannot read BIOS: ${err.message}` });
+    parentPort.postMessage({
+        type: 'error',
+        message: `Cannot read BIOS: ${err.message}`,
+    });
     process.exit(1);
 }
 
@@ -62,7 +68,10 @@ let v86WasmPath;
 try {
     ({ V86 } = require('v86'));
     // Resolve the WASM file relative to the v86 package — not relative to CWD
-    v86WasmPath = require('path').join(require('path').dirname(require.resolve('v86')), 'v86.wasm');
+    v86WasmPath = require('path').join(
+        require('path').dirname(require.resolve('v86')),
+        'v86.wasm'
+    );
 } catch (err) {
     parentPort.postMessage({ type: 'error', message: `Cannot load v86: ${err.message}` });
     process.exit(1);
@@ -72,12 +81,25 @@ const memoryMb = workerData.memoryMb || 64;
 
 const emulator = new V86({
     wasm_path: v86WasmPath,
-    bios:     { buffer: biosBuffer.buffer.slice(biosBuffer.byteOffset, biosBuffer.byteOffset + biosBuffer.byteLength) },
-    vga_bios: { buffer: vgaBiosBuffer.buffer.slice(vgaBiosBuffer.byteOffset, vgaBiosBuffer.byteOffset + vgaBiosBuffer.byteLength) },
+    bios: {
+        buffer: biosBuffer.buffer.slice(
+            biosBuffer.byteOffset,
+            biosBuffer.byteOffset + biosBuffer.byteLength
+        ),
+    },
+    vga_bios: {
+        buffer: vgaBiosBuffer.buffer.slice(
+            vgaBiosBuffer.byteOffset,
+            vgaBiosBuffer.byteOffset + vgaBiosBuffer.byteLength
+        ),
+    },
 
     // HDD: door image (C: in FreeDOS) — sync, no async (would deadlock)
     hda: {
-        buffer: diskBuffer.buffer.slice(diskBuffer.byteOffset, diskBuffer.byteOffset + diskBuffer.byteLength),
+        buffer: diskBuffer.buffer.slice(
+            diskBuffer.byteOffset,
+            diskBuffer.byteOffset + diskBuffer.byteLength
+        ),
         async: false,
     },
 
@@ -95,7 +117,7 @@ const emulator = new V86({
     // but no bootable code — the CPU would execute garbage and hang.
     boot_order: 786,
 
-    memory_size:     memoryMb * 1024 * 1024,
+    memory_size: memoryMb * 1024 * 1024,
     vga_memory_size: 2 * 1024 * 1024,
 
     screen_dummy: true,
@@ -108,7 +130,7 @@ const emulator = new V86({
 
 emulator.add_listener('emulator-loaded', () => {
     // Assert DCD + DSR + CTS on COM1 so door games see a live connection
-    emulator.serial_set_modem_status(0, 0xB0);
+    emulator.serial_set_modem_status(0, 0xb0);
     parentPort.postMessage({ type: 'ready' });
 });
 
@@ -156,8 +178,8 @@ emulator.add_listener('emulator-stopped', () => {
 // 'emulator-stopped'. If the instruction counter stops advancing (with ic > 1M),
 // the CPU is halted — trigger shutdown.
 let lastInsnCount = 0;
-let haltTicks     = 0;
-const HALT_TICKS_REQUIRED = 2;  // 2 × 5s = 10 seconds of no progress
+let haltTicks = 0;
+const HALT_TICKS_REQUIRED = 2; // 2 × 5s = 10 seconds of no progress
 
 const haltTimer = setInterval(() => {
     const ic = emulator.get_instruction_counter();

--- a/core/v86_door/v86_worker.js
+++ b/core/v86_door/v86_worker.js
@@ -1,0 +1,174 @@
+/* jslint node: true */
+'use strict';
+
+/**
+ * v86_worker.js
+ *
+ * Worker thread that runs a v86 x86 emulator instance for a single DOS door session.
+ * Spawned by v86_door.js via worker_threads. Communicates with the main thread via
+ * MessagePort for I/O and lifecycle events.
+ *
+ * workerData shape:
+ * {
+ *   imagePath:    string   - path to the FreeDOS door disk image (hda)
+ *   floppyBuffer: Buffer   - 1.44MB FAT12 floppy image with drop file (fda / A:)
+ *   memoryMb:     number   - guest RAM in MB (default 64)
+ *   biosPath:     string   - path to SeaBIOS image
+ *   vgaBiosPath:  string   - path to VGA BIOS image
+ * }
+ *
+ * MessagePort protocol (worker → parent):
+ *   { type: 'ready' }                      - emulator loaded, serial I/O active
+ *   { type: 'output', data: Buffer }        - bytes from COM1 (serial0-output-byte)
+ *   { type: 'stopped', elapsed: number }   - emulator halted, worker will exit
+ *   { type: 'error', message: string }     - fatal error before ready
+ *
+ * MessagePort protocol (parent → worker):
+ *   { type: 'input', data: Buffer }        - bytes to send to COM1
+ *   { type: 'stop' }                       - request clean shutdown
+ */
+
+const { workerData, parentPort } = require('worker_threads');
+const { readFileSync } = require('fs');
+
+const t0 = Date.now();
+
+// ─── Load disk image synchronously ───────────────────────────────────────────
+// async: true deadlocks in Node.js — v86's CPU loop starves the event loop,
+// so disk read callbacks never fire. Sync load is required.
+
+let diskBuffer;
+try {
+    diskBuffer = readFileSync(workerData.imagePath);
+} catch (err) {
+    parentPort.postMessage({ type: 'error', message: `Cannot read disk image: ${err.message}` });
+    process.exit(1);
+}
+
+let biosBuffer;
+let vgaBiosBuffer;
+try {
+    biosBuffer    = readFileSync(workerData.biosPath);
+    vgaBiosBuffer = readFileSync(workerData.vgaBiosPath);
+} catch (err) {
+    parentPort.postMessage({ type: 'error', message: `Cannot read BIOS: ${err.message}` });
+    process.exit(1);
+}
+
+// ─── Start emulator ───────────────────────────────────────────────────────────
+
+let V86;
+let v86WasmPath;
+try {
+    ({ V86 } = require('v86'));
+    // Resolve the WASM file relative to the v86 package — not relative to CWD
+    v86WasmPath = require('path').join(require('path').dirname(require.resolve('v86')), 'v86.wasm');
+} catch (err) {
+    parentPort.postMessage({ type: 'error', message: `Cannot load v86: ${err.message}` });
+    process.exit(1);
+}
+
+const memoryMb = workerData.memoryMb || 64;
+
+const emulator = new V86({
+    wasm_path: v86WasmPath,
+    bios:     { buffer: biosBuffer.buffer.slice(biosBuffer.byteOffset, biosBuffer.byteOffset + biosBuffer.byteLength) },
+    vga_bios: { buffer: vgaBiosBuffer.buffer.slice(vgaBiosBuffer.byteOffset, vgaBiosBuffer.byteOffset + vgaBiosBuffer.byteLength) },
+
+    // HDD: door image (C: in FreeDOS) — sync, no async (would deadlock)
+    hda: {
+        buffer: diskBuffer.buffer.slice(diskBuffer.byteOffset, diskBuffer.byteOffset + diskBuffer.byteLength),
+        async: false,
+    },
+
+    // Floppy: drop file image (A: in FreeDOS)
+    fda: {
+        buffer: workerData.floppyBuffer.buffer.slice(
+            workerData.floppyBuffer.byteOffset,
+            workerData.floppyBuffer.byteOffset + workerData.floppyBuffer.byteLength
+        ),
+        async: false,
+    },
+
+    // Boot from HDD first. Without this, v86 defaults to floppy-first (boot_order 801)
+    // when fda is set. Our FAT12 floppy has a valid 0x55AA boot signature (written by fatfs)
+    // but no bootable code — the CPU would execute garbage and hang.
+    boot_order: 786,
+
+    memory_size:     memoryMb * 1024 * 1024,
+    vga_memory_size: 2 * 1024 * 1024,
+
+    screen_dummy: true,
+    autostart: true,
+    disable_keyboard: true,
+    disable_mouse: true,
+});
+
+// ─── Lifecycle ────────────────────────────────────────────────────────────────
+
+emulator.add_listener('emulator-loaded', () => {
+    // Assert DCD + DSR + CTS on COM1 so door games see a live connection
+    emulator.serial_set_modem_status(0, 0xB0);
+    parentPort.postMessage({ type: 'ready' });
+});
+
+// ─── Serial I/O ───────────────────────────────────────────────────────────────
+
+emulator.add_listener('serial0-output-byte', byte => {
+    parentPort.postMessage({ type: 'output', data: Buffer.from([byte]) });
+});
+
+parentPort.on('message', msg => {
+    switch (msg.type) {
+        case 'input':
+            emulator.serial0_send(Buffer.from(msg.data).toString('binary'));
+            break;
+
+        case 'stop':
+            shutdown();
+            break;
+
+        default:
+            break;
+    }
+});
+
+// ─── Shutdown ────────────────────────────────────────────────────────────────
+
+let shutdownStarted = false;
+
+function shutdown() {
+    if (shutdownStarted) return;
+    shutdownStarted = true;
+    emulator.stop();
+    setTimeout(() => {
+        const elapsed = Date.now() - t0;
+        parentPort.postMessage({ type: 'stopped', elapsed });
+        process.exit(0);
+    }, 500);
+}
+
+emulator.add_listener('emulator-stopped', () => {
+    shutdown();
+});
+
+// Detect CPU halt: FDAPM POWEROFF halts the CPU but doesn't always fire
+// 'emulator-stopped'. If the instruction counter stops advancing (with ic > 1M),
+// the CPU is halted — trigger shutdown.
+let lastInsnCount = 0;
+let haltTicks     = 0;
+const HALT_TICKS_REQUIRED = 2;  // 2 × 5s = 10 seconds of no progress
+
+const haltTimer = setInterval(() => {
+    const ic = emulator.get_instruction_counter();
+    if (ic === lastInsnCount && ic > 1_000_000) {
+        haltTicks++;
+        if (haltTicks >= HALT_TICKS_REQUIRED) {
+            clearInterval(haltTimer);
+            shutdown();
+        }
+    } else {
+        haltTicks = 0;
+    }
+    lastInsnCount = ic;
+}, 5000);

--- a/core/vertical_menu_view.js
+++ b/core/vertical_menu_view.js
@@ -99,8 +99,8 @@ class VerticalMenuView extends MenuView {
             sgr = this.focusItemFormat
                 ? ''
                 : index === this.focusedItemIndex
-                ? this.getFocusSGR()
-                : this.getSGR();
+                  ? this.getFocusSGR()
+                  : this.getSGR();
         } else {
             text = strUtil.stylizeString(
                 item.text,

--- a/core/view_controller.js
+++ b/core/view_controller.js
@@ -252,10 +252,9 @@ class ViewController extends events.EventEmitter {
                             //  :TODO: handle propAsset.location for @method script specification
                             if ('systemMethod' === propAsset.type) {
                                 //  :TODO: implementation validation @systemMethod handling!
-                                const methodModule = require(paths.join(
-                                    __dirname,
-                                    'system_view_validate.js'
-                                ));
+                                const methodModule = require(
+                                    paths.join(__dirname, 'system_view_validate.js')
+                                );
                                 if (_.isFunction(methodModule[propAsset.asset])) {
                                     propValue = methodModule[propAsset.asset];
                                 }

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -87,6 +87,7 @@ collections:
       - art/general.md
       - art/themes.md
       - art/mci.md
+      - art/views/views.md
       - art/views/button_view.md
       - art/views/edit_text_view.md
       - art/views/full_menu_view.md
@@ -95,15 +96,23 @@ collections:
       - art/views/multi_line_edit_text_view.md
       - art/views/spinner_menu_view.md
       - art/views/text_view.md
+      - art/views/status_bar_view.md
+      - art/views/ticker_view.md
       - art/views/toggle_menu_view.md
       - art/views/vertical_menu_view.md
       - servers/loginservers/telnet.md
       - servers/loginservers/ssh.md
       - servers/loginservers/websocket.md
       - servers/contentservers/web-server.md
+      - servers/contentservers/web-handlers.md
+      - servers/contentservers/activitypub-handler.md
+      - servers/contentservers/webfinger-handler.md
       - servers/contentservers/gopher.md
       - servers/contentservers/nntp.md
       - modding/local-doors.md
+      - modding/local-doors-abracadabra.md
+      - modding/local-doors-dos-emulation.md
+      - modding/local-doors-v86.md
       - modding/door-servers.md
       - modding/telnet-bridge.md
       - modding/existing-mods.md
@@ -129,7 +138,7 @@ collections:
       - modding/wfc.md
       - admin/administration.md
       - admin/oputil.md
-      - admin/updating.md
+      - admin/upgrading.md
       - troubleshooting/monitoring-logs.md
       - troubleshooting/ssh-troubleshooting.md
 

--- a/docs/_docs/admin/oputil.md
+++ b/docs/_docs/admin/oputil.md
@@ -31,6 +31,8 @@ Commands break up operations by groups:
 | `config`  | System configuration and maintenance |
 | `fb`      | File base configuration and management    |
 | `mb`      | Message base configuration and management |
+| `fat`     | FAT disk image inspection and modification |
+| `v86`     | Boot disk images in the v86 x86 emulator |
 
 Global arguments apply to most commands and actions:
 * `--config`: Specify configuration directory if it is not the default of `./config/`.
@@ -329,3 +331,128 @@ qwk-export arguments:
 | `qwk-export` | Export messages to a QWK packet | `./oputil.js mb qwk-export /path/to/XIBALBA.QWK` |
 
 When using the `import-areas` action, you will be prompted for any missing additional arguments described in "import-areas args".
+
+## FAT Disk Image Management
+The `fat` command lets you inspect and modify raw FAT disk images directly — no running ENiGMA instance or database required. Useful for preparing and maintaining FreeDOS images used by the `v86_door` module.
+
+Works with any partitioned FAT12/16/32 raw disk image (`.img`).
+
+```
+usage: oputil.js fat <action> <image.img> [arguments]
+
+Actions:
+  ls IMAGE [PATH]             List files and directories in image
+  (dir)                       PATH defaults to the root of the partition
+
+  cp IMAGE SRC DST [SRC DST] Copy one or more local files/directories into image
+  (copy)                      SRC is a local path; DST is a DOS path within the image
+                              Directories are copied recursively
+
+  read IMAGE DOS-PATH         Read a file from the image and write it to stdout
+  (cat, type)
+```
+
+| Action  | Description | Aliases |
+|---------|-------------|---------|
+| `ls`    | List files and directories at an optional DOS path | `dir` |
+| `cp`    | Copy local files or directories into the image | `copy` |
+| `read`  | Read a file from the image and write to stdout | `cat`, `type` |
+
+#### Examples
+
+List files at the root of the image:
+```bash
+./oputil.js fat ls freedos.img
+```
+
+List a subdirectory:
+```bash
+./oputil.js fat ls freedos.img DOORS/LORD
+```
+
+Copy a local directory recursively into the image:
+```bash
+./oputil.js fat cp freedos.img ./pimpwars/ DOORS/PW/PIMPWARS
+```
+
+Copy a single file:
+```bash
+./oputil.js fat cp freedos.img fdconfig.sys FDCONFIG.SYS
+```
+
+Read a file from the image (can be piped):
+```bash
+./oputil.js fat read freedos.img FDAUTO.BAT
+./oputil.js fat read freedos.img FDCONFIG.SYS | less
+```
+
+## v86 Emulation Tools
+The `v86` command boots raw FreeDOS disk images using the [v86](https://github.com/copy/v86) x86 emulator. Does not require a running ENiGMA instance.
+
+BIOS files default to `misc/v86_bios/seabios.bin` and `misc/v86_bios/vgabios.bin`. Run `misc/install.sh` to download them, or see [Local Doors — v86](../modding/local-doors-v86.md) for details.
+
+```
+usage: oputil.js v86 <action> <image.img> [arguments]
+
+Actions:
+  console IMAGE               Boot image and wire COM1 to this terminal
+                              Useful for verifying door I/O. Ctrl+] to exit.
+                              Note: full-screen DOS programs write to VGA RAM
+                              and will not appear over serial. Use 'desktop' instead.
+
+  desktop IMAGE               Boot image and open a full VGA DOS desktop in
+                              the system browser. Use to install and configure
+                              doors. A "Save Image" button downloads the modified
+                              image when done.
+
+Options:
+  --bios PATH                 Override SeaBIOS path
+  --vga-bios PATH             Override VGA BIOS path
+  --port PORT                 HTTP port for desktop mode (default: 18086)
+  --memory MB                 Guest RAM in MB (default: 64)
+```
+
+| Action    | Description |
+|-----------|-------------|
+| `console` | Boot the image and bridge COM1 to your terminal. Press `Ctrl+]` to exit. |
+| `desktop` | Boot the image in a browser with full VGA output. A **Save Image** button lets you download the modified image when done. |
+
+#### console
+`console` mode boots the image and bridges COM1 to your terminal. It is useful for monitoring door serial output — for example, verifying that a door's COM1 I/O is working correctly before going live.
+
+```bash
+./oputil.js v86 console freedos.img
+```
+
+Override BIOS paths:
+```bash
+./oputil.js v86 console freedos.img --bios /path/to/seabios.bin --vga-bios /path/to/vgabios.bin
+```
+
+**Limitations:**
+
+- **Input is not supported.** A `C:\>` prompt will appear (confirming the boot chain and serial output are working), but keystrokes are not forwarded to the shell. This is a limitation of how v86's serial receive interacts with FreeDOS's BIOS INT 14h input — it works for door games that use a FOSSIL driver, but not for interactive shell use. Use `desktop` for an interactive DOS session.
+- **Full-screen programs are not visible.** Programs that draw directly to VGA memory (most door games) will not appear over serial. Again, use `desktop` for those.
+
+#### desktop
+`desktop` mode starts a local HTTP server, serves the v86 emulator and the disk image, and opens your default browser automatically. The page includes a full VGA canvas and a **Save Image** button to write changes back to disk.
+
+```bash
+./oputil.js v86 desktop freedos.img
+```
+
+Use a custom HTTP port:
+```bash
+./oputil.js v86 desktop freedos.img --port 9000
+```
+
+Close the browser tab or press `Ctrl+C` to stop the server.
+
+#### A note on image size
+
+`desktop` mode downloads the entire disk image into the browser before booting. Smaller images load faster:
+
+- A minimal FreeDOS installation with a handful of doors fits comfortably in **100–200 MB** and loads in a few seconds on a typical connection.
+- A 500 MB image will take noticeably longer, especially when accessed over an SSH tunnel or slow link.
+- Prefer lean images: install only what a door needs, and avoid bundling large data files that aren't required at runtime.
+- The same advice applies to the live BBS door sessions — smaller images mean less RAM and faster startup for users.

--- a/docs/_docs/modding/local-doors-abracadabra.md
+++ b/docs/_docs/modding/local-doors-abracadabra.md
@@ -1,0 +1,157 @@
+---
+layout: page
+title: Local Doors — Scripts & Native Binaries
+---
+## Scripts & Native Binaries (abracadabra)
+
+The `abracadabra` module provides a generic solution for launching any local process as a door: native Linux binaries, shell scripts, Python scripts, and more. I/O is handled through standard I/O (stdio) or a temporary TCP socket server.
+
+> :information_source: For DOS-specific setups using DOSEMU or QEMU, see [External DOS Emulators](local-doors-dos-emulation.md). For zero-dependency DOS emulation, see [Native v86 Emulation](local-doors-v86.md).
+
+---
+
+### Configuration
+
+The `abracadabra` `config` block supports the following fields:
+
+| Item | Required | Description |
+|------|----------|-------------|
+| `name` | :+1: | Used as a key for tracking the number of clients using this door. |
+| `dropFileType` | :-1: | Type of drop file to generate. See [Drop File Types](local-doors.md#drop-file-types). Can be omitted or `none`. |
+| `cmd` | :+1: | Path to the executable to launch. |
+| `args` | :-1: | Array of arguments to pass to `cmd`. See [Argument Variables](#argument-variables) below. |
+| `preCmd` | :-1: | Path to a pre-command executable or script. Executes before `cmd`. |
+| `preCmdArgs` | :-1: | Arguments to pass to `preCmd`. See [Argument Variables](#argument-variables) below. |
+| `cwd` | :-1: | Working directory for `cmd`. Defaults to the directory containing `cmd`. |
+| `env` | :-1: | Environment variables as a map: `{ SOME_VAR: "value" }` |
+| `nodeMax` | :-1: | Max concurrent sessions for this door. Uses `name` as the tracking key. |
+| `tooManyArt` | :-1: | Art spec to display when `nodeMax` is exceeded. |
+| `io` | :-1: | I/O mode: `stdio` (default) or `socket`. When `socket`, ENiGMA½ spawns a temporary TCP server on `{srvPort}` that the door process connects back to. |
+| `encoding` | :-1: | The door process's text encoding. Defaults to `cp437`. Linux-native binaries often use `utf8`. |
+
+#### Argument Variables
+
+The following variables can be used in `args` and `preCmdArgs`:
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `{node}` | Current node number | `1` |
+| `{dropFile}` | Drop file filename only | `DOOR.SYS` |
+| `{dropFilePath}` | Full path to the generated drop file | `/home/enigma/drop/node1/DOOR.SYS` |
+| `{dropFileDir}` | Full path to the drop file directory | `/home/enigma/drop/node1/` |
+| `{userAreaDir}` | User-specific save directory | `/home/enigma/drop/node1/NuSkooler/lord/` |
+| `{userId}` | Current user ID | `42` |
+| `{userName}` | Sanitized username (safe for filenames) | `nuskooler` |
+| `{userNameRaw}` | Raw username (may not be filename-safe) | `\/\/izard` |
+| `{srvPort}` | Temporary TCP server port (when `io: socket`) | `1234` |
+| `{cwd}` | Working directory | `/home/enigma/doors/foo/` |
+| `{termHeight}` | Terminal height | `25` |
+| `{termWidth}` | Terminal width | `80` |
+
+```hjson
+args: [
+    "-D", "{dropFilePath}",
+    "-N", "{node}",
+    "-U", "{userId}"
+]
+```
+
+---
+
+### Examples
+
+#### Shell Script Door (stdio)
+
+A simple wrapper script that launches a native binary:
+
+```hjson
+doorMyGame: {
+    desc: My Door Game
+    module: abracadabra
+    config: {
+        name: MyGame
+        dropFileType: DOOR
+        cmd: /home/enigma/doors/mygame/launch.sh
+        args: [ "{node}", "{dropFilePath}" ]
+        nodeMax: 4
+        tooManyArt: DOORMANY
+        io: stdio
+    }
+}
+```
+
+#### Python Script Door (stdio)
+
+```hjson
+doorPythonGame: {
+    desc: Python Door
+    module: abracadabra
+    config: {
+        name: PythonGame
+        dropFileType: DORINFO
+        cmd: /usr/bin/python3
+        args: [ "/home/enigma/doors/pydoor/main.py", "{node}", "{dropFilePath}" ]
+        encoding: utf8
+        nodeMax: 8
+        io: stdio
+    }
+}
+```
+
+#### Socket-Based Door
+
+Some doors require a socket connection rather than stdio. ENiGMA½ starts a temporary TCP server and passes the port to your script:
+
+```hjson
+doorSocketGame: {
+    desc: Socket Door
+    module: abracadabra
+    config: {
+        name: SocketGame
+        dropFileType: DOOR
+        cmd: /home/enigma/doors/socketgame/launch.sh
+        args: [ "{node}", "{dropFile}", "{srvPort}" ]
+        nodeMax: 1
+        io: socket
+    }
+}
+```
+
+---
+
+### DOOR32.SYS Socket Descriptor Sharing
+
+Due to Node.js limitations, ENiGMA½ does not directly support `DOOR32.SYS`-style socket descriptor sharing. However, [bivrost!](https://github.com/NuSkooler/bivrost) bridges this gap. bivrost! is available for Windows and Linux x86/x86_64 (and buildable from Rust on other platforms).
+
+```hjson
+doorWithBivrost: {
+    desc: Bivrost Example
+    module: abracadabra
+    config: {
+        name: BivrostExample
+        dropFileType: DOOR32
+        cmd: /home/enigma/utils/bivrost
+        args: [
+            "--port", "{srvPort}",
+            "--dropfile", "{dropFilePath}",
+            "--out", "/home/enigma/doors/jezebel",
+            "/home/enigma/doors/jezebel/door.exe /home/enigma/doors/jezebel/door32.sys"
+        ]
+        nodeMax: 1
+        tooManyArt: DOORMANY
+        io: socket
+    }
+}
+```
+
+See the [bivrost!](https://github.com/NuSkooler/bivrost) documentation for details. Pre-built binaries are also available via [Phenom Productions](https://www.phenomprod.com/) on various boards.
+
+Alternative workarounds: [Telnet Bridge](telnet-bridge.md), or [NET2BBS](http://pcmicro.com/netfoss/guide/net2bbs.html).
+
+---
+
+## See Also
+* [Local Doors](local-doors.md)
+* [External DOS Emulators](local-doors-dos-emulation.md)
+* [Native v86 Emulation](local-doors-v86.md)
+* [Telnet Bridge](telnet-bridge.md)

--- a/docs/_docs/modding/local-doors-abracadabra.md
+++ b/docs/_docs/modding/local-doors-abracadabra.md
@@ -4,7 +4,7 @@ title: Local Doors — Scripts & Native Binaries
 ---
 ## Scripts & Native Binaries (abracadabra)
 
-The `abracadabra` module provides a generic solution for launching any local process as a door: native Linux binaries, shell scripts, Python scripts, and more. I/O is handled through standard I/O (stdio) or a temporary TCP socket server.
+The `abracadabra` module provides a generic solution for launching any local process as a door: native terminal applications, shell scripts, Python scripts, and more. Any process that communicates over stdio works. I/O is bridged through standard I/O (stdio) or a temporary TCP socket server.
 
 > :information_source: For DOS-specific setups using DOSEMU or QEMU, see [External DOS Emulators](local-doors-dos-emulation.md). For zero-dependency DOS emulation, see [Native v86 Emulation](local-doors-v86.md).
 

--- a/docs/_docs/modding/local-doors-dos-emulation.md
+++ b/docs/_docs/modding/local-doors-dos-emulation.md
@@ -1,0 +1,169 @@
+---
+layout: page
+title: Local Doors — External DOS Emulators
+---
+## DOS Doors via External Emulators
+
+This page covers running classic DOS door games using external emulators — DOSEMU and QEMU — via the `abracadabra` module. ENiGMA½ launches the emulator as a child process and bridges I/O over stdio or a socket.
+
+> :information_source: **No emulator on the server?** See [Native v86 Emulation](local-doors-v86.md) — ENiGMA½ includes a built-in x86 emulator. Raw FreeDOS `.img` images are compatible between QEMU and v86, so you can set up your image with QEMU and run it with v86 in production.
+
+---
+
+## DOSEMU
+
+[DOSEMU](http://www.dosemu.org/) provides a DOS environment on Linux via stdio. Configure COM1 as a virtual serial port to connect it to ENiGMA½'s stdio bridge.
+
+### Step 1: Create dosemu.conf
+
+```
+$_cpu = "80486"
+$_cpu_emu = "vm86"
+$_external_char_set = "utf8"
+$_internal_char_set = "cp437"
+$_term_updfreq = (8)
+$_layout = "us"
+$_rawkeyboard = (0)
+$_com1 = "virtual"
+```
+
+`$_com1 = "virtual"` maps COM1 to stdio — ENiGMA½ speaks directly to the door over stdin/stdout.
+
+### Step 2: Create the Door Drive
+
+Create a virtual drive for your door, e.g. `/home/enigma/DOS/X/PW`, and map it in your DOSEMU `AUTOEXEC.BAT`:
+
+```bat
+@echo off
+path d:\bin;d:\gnu;d:\dosemu
+set TEMP=c:\tmp
+prompt $P$G
+C:\BNU\BNU.COM /L0:57600,8N1 /F
+lredir.com x: linux\fs\home\enigma\DOS\X
+unix -e
+```
+
+[BNU](http://www.pcmicro.com/bnu/) is a FOSSIL driver installed here at `C:\BNU\`. A FOSSIL driver is required by most classic DOS doors.
+
+### Step 3: Menu Entry
+
+```hjson
+doorPimpWars: {
+    desc: Playing PimpWars
+    module: abracadabra
+    config: {
+        name: PimpWars
+        dropFileType: DORINFO
+        cmd: /usr/bin/dosemu
+        args: [
+            "-quiet",
+            "-f",
+            "/path/to/dosemu.conf",
+            "X:\\PW\\START.BAT {dropFile} {node}"
+        ]
+        nodeMax: 1
+        tooManyArt: DOORMANY
+        io: stdio
+    }
+}
+```
+
+---
+
+## QEMU
+
+[QEMU](https://www.qemu.org/) provides a robust, cross-platform solution for DOS doors. The general approach is a bootstrap shell script that prepares a node-specific `GO.BAT`, then launches QEMU with the FreeDOS image.
+
+> :warning: **Multiple concurrent sessions of the same QEMU image are not safe.** Each node needs its own image copy, or use [Native v86 Emulation](local-doors-v86.md) which isolates each session automatically.
+
+### Step 1: Create a FreeDOS Image
+
+Follow the [QEMU/FreeDOS](https://en.wikibooks.org/wiki/QEMU/FreeDOS) guide to create a `freedos_c.img`. Install FreeDOS, then install your door game at `C:\DOORS\LORD\` (or similar).
+
+Transfer files from host to the image using QEMU's vfat drive:
+
+```bash
+qemu-system-i386 -localtime /home/enigma/dos/images/freedos_c.img \
+    -hdb fat:/path/to/files/to/copy
+```
+
+Files appear on `D:` inside FreeDOS. Add to the image's `AUTOEXEC.BAT`:
+
+```bat
+CALL E:\GO.BAT
+```
+
+### Step 2: Create a Bootstrap Script
+
+This script writes a per-node `GO.BAT` before launching QEMU:
+
+```bash
+#!/bin/bash
+NODE=$1
+DROPFILE=D:\\$2
+SRVPORT=$3
+
+mkdir -p /home/enigma/dos/go/node$NODE
+
+cat > /home/enigma/dos/go/node$NODE/GO.BAT <<EOF
+C:
+CD \FOSSIL\BNU
+BNU.COM
+CD \DOORS\LORD
+COPY /Y $DROPFILE
+CALL START.BAT $NODE
+FDAPM POWEROFF
+EOF
+
+unix2dos /home/enigma/dos/go/node$NODE/GO.BAT
+
+qemu-system-i386 -localtime /home/enigma/dos/images/freedos_c.img \
+    -chardev socket,port=$SRVPORT,nowait,host=localhost,id=s0 \
+    -device isa-serial,chardev=s0 \
+    -hdb fat:/home/enigma/drop/node$NODE \
+    -hdc fat:/home/enigma/dos/go/node$NODE \
+    -nographic
+```
+
+- `-chardev socket,...` connects COM1 to ENiGMA½'s socket server on `$SRVPORT`
+- `-hdb fat:...` exposes the drop file directory as `D:`
+- `-hdc fat:...` exposes the `GO.BAT` directory as `E:`
+- `-nographic` runs headless
+
+### Step 3: Menu Entry
+
+```hjson
+doorLORD: {
+    desc: Playing L.O.R.D.
+    module: abracadabra
+    config: {
+        name: LORD
+        dropFileType: DOOR
+        cmd: /home/enigma/dos/scripts/lord.sh
+        args: [
+            "{node}",
+            "{dropFile}",
+            "{srvPort}",
+        ]
+        nodeMax: 1
+        tooManyArt: DOORMANY
+        io: socket
+    }
+}
+```
+
+---
+
+## DOSBox-X
+
+[DOSBox-X](https://dosbox-x.com/) is a graphical DOS environment available on Windows, macOS, and Linux. It is primarily useful for **preparing disk images** — raw `.img` images created in DOSBox-X are compatible with QEMU and with ENiGMA½'s built-in [v86_door](local-doors-v86.md).
+
+Using DOSBox-X as a production door server (launching it per user session) is possible but uncommon. The `imgmount` command can mount raw disk images inside DOSBox-X. See the [DOSBox-X documentation](https://dosbox-x.com/wiki) for details.
+
+---
+
+## See Also
+* [Local Doors](local-doors.md)
+* [Native v86 Emulation](local-doors-v86.md) — run the same FreeDOS image without QEMU on the server
+* [Scripts & Native Binaries](local-doors-abracadabra.md) — abracadabra module reference
+* [Telnet Bridge](telnet-bridge.md)

--- a/docs/_docs/modding/local-doors-v86.md
+++ b/docs/_docs/modding/local-doors-v86.md
@@ -1,0 +1,150 @@
+---
+layout: page
+title: Local Doors — Native v86 Emulation
+---
+## Native DOS Emulation via v86
+
+ENiGMA½ includes a built-in x86/DOS emulator powered by [v86](https://github.com/copy/v86) — a JavaScript x86 emulator that runs entirely within Node.js. The `v86_door` module boots a FreeDOS disk image and bridges COM1 directly to the user's connection, with no external emulator installed on the server.
+
+> :information_source: The emulator runs in a dedicated worker thread, so it does not block ENiGMA½'s event loop. Each active session gets its own isolated emulator instance.
+
+---
+
+### How It Works
+
+1. ENiGMA½ generates the appropriate drop file for the user (DORINFO, DOOR.SYS, etc.)
+2. The drop file is written into a small in-memory FAT12 floppy image — no temp files on disk
+3. v86 boots the op-supplied FreeDOS disk image from the hard drive (`C:`)
+4. The drop file floppy is mounted as `A:` in FreeDOS
+5. The door's `AUTOEXEC.BAT` copies the drop file from `A:` and launches the game
+6. COM1 serial I/O is bridged directly between v86 and the user's connection
+7. When the door exits and FreeDOS powers off, the session ends cleanly
+
+---
+
+### Prerequisites
+
+#### BIOS Files
+
+v86 requires SeaBIOS and a VGA BIOS image. The ENiGMA½ installer (`misc/install.sh`) downloads these automatically to `misc/v86_bios/`. To download manually:
+
+```bash
+mkdir -p misc/v86_bios
+curl -fL https://github.com/copy/v86/raw/master/bios/seabios.bin -o misc/v86_bios/seabios.bin
+curl -fL https://github.com/copy/v86/raw/master/bios/vgabios.bin -o misc/v86_bios/vgabios.bin
+```
+
+#### Disk Image
+
+You need a raw FreeDOS disk image (`.img`) with your door game pre-installed. Raw `.img` images are **fully compatible between QEMU, DOSBox-X, and v86** — set up your image with QEMU or DOSBox-X, then point `v86_door` at it on the production server.
+
+---
+
+### Configuration
+
+| Item | Required | Description |
+|------|----------|-------------|
+| `name` | :+1: | Door name. Used as a key for tracking concurrent sessions. |
+| `image` | :+1: | Path to the raw FreeDOS disk image (`.img`). |
+| `dropFileType` | :-1: | Drop file to generate and inject onto the `A:` floppy: `DORINFO`, `DOOR`, or `DOOR32`. Omit if the door needs no drop file. |
+| `nodeMax` | :-1: | Max concurrent sessions. `0` = unlimited. |
+| `tooManyArt` | :-1: | Art spec to display when `nodeMax` is exceeded. |
+| `memoryMb` | :-1: | Guest RAM in MB. Default: `64`. |
+| `biosPath` | :-1: | Path to SeaBIOS image. Default: `misc/v86_bios/seabios.bin`. |
+| `vgaBiosPath` | :-1: | Path to VGA BIOS image. Default: `misc/v86_bios/vgabios.bin`. |
+
+#### Drop File Filenames on A:
+
+| `dropFileType` | Filename on `A:` |
+|----------------|-----------------|
+| `DORINFO` | `DORINFOx.DEF` (x = node-based suffix per spec) |
+| `DOOR` | `DOOR.SYS` |
+| `DOOR32` | `door32.sys` |
+
+---
+
+### Example Menu Entry
+
+```hjson
+doorPimpWars: {
+    desc: Playing PimpWars
+    module: v86_door
+    config: {
+        name: PimpWars
+        image: /path/to/images/freedos_pimpwars.img
+        dropFileType: DORINFO
+        nodeMax: 1
+        tooManyArt: DOORMANY
+    }
+}
+```
+
+---
+
+### Image Preparation
+
+Your disk image must contain:
+- A working FreeDOS installation
+- Your door game (e.g. `C:\DOORS\PIMPWARS\`)
+- A FOSSIL driver such as [X00](http://pcmicro.com/xtalk/x00.html) — required by most classic DOS doors
+- An `AUTOEXEC.BAT` (or `FDAUTO.BAT`) that copies the drop file from `A:` and launches the door
+
+#### Example AUTOEXEC.BAT
+
+```bat
+CD C:\DOORS\PIMPWARS
+COPY A:\DORINFO1.DEF C:\DOORS\PIMPWARS\
+PIMPWARS.EXE A:\DORINFO1.DEF 1
+FDAPM POWEROFF
+```
+
+> :information_source: `FDAPM POWEROFF` shuts FreeDOS down after the door exits. Without it, the emulator idles until the session times out.
+
+#### FOSSIL Driver
+
+Most classic DOS doors use the [FOSSIL](https://en.wikipedia.org/wiki/FOSSIL) serial interface to communicate over COM1. If your door fails to start or runs in local mode, install a FOSSIL driver in your image. [X00](http://pcmicro.com/xtalk/x00.html) works well with v86. In `FDCONFIG.SYS`:
+
+```
+DEVICE=C:\FOSSIL\X00.SYS
+```
+
+#### Creating the Image with QEMU
+
+```bash
+# Create a 500MB raw image
+qemu-img create -f raw freedos_mygame.img 500M
+
+# Install FreeDOS (boot from CD)
+qemu-system-i386 -hda freedos_mygame.img -cdrom FD14CD.iso -boot d
+
+# Boot into FreeDOS to install your door
+qemu-system-i386 -hda freedos_mygame.img
+
+# Transfer files from host using QEMU's vfat driver — files appear on D:
+qemu-system-i386 -hda freedos_mygame.img -hdb fat:/path/to/door/files
+```
+
+[DOSBox-X](https://dosbox-x.com/) is a graphical alternative for image setup on Windows, macOS, and Linux. See the DOSBox-X documentation for `imgmount`.
+
+#### FreeDOS Boot Configuration for Fast Startup
+
+For ~5 second boot times, configure FreeDOS to use Emergency Mode (no memory managers, no networking). In `FDCONFIG.SYS`:
+
+```
+MENUDEFAULT=5,0
+```
+
+Ensure the `5?` config block loads your FOSSIL driver:
+
+```
+5?DEVICE=C:\FOSSIL\X00.SYS
+5?SHELL=C:\FreeDOS\BIN\COMMAND.COM C:\FreeDOS\BIN /E:1024 /P=C:\FDAUTO.BAT
+```
+
+---
+
+## See Also
+* [Local Doors](local-doors.md)
+* [External DOS Emulators](local-doors-dos-emulation.md)
+* [Scripts & Native Binaries](local-doors-abracadabra.md)
+* [v86](https://github.com/copy/v86) — upstream JavaScript x86 emulator

--- a/docs/_docs/modding/local-doors-v86.md
+++ b/docs/_docs/modding/local-doors-v86.md
@@ -47,6 +47,7 @@ You need a raw FreeDOS disk image (`.img`) with your door game pre-installed. Ra
 | `name` | :+1: | Door name. Used as a key for tracking concurrent sessions. |
 | `image` | :+1: | Path to the raw FreeDOS disk image (`.img`). |
 | `dropFileType` | :-1: | Drop file to generate and inject onto the `A:` floppy: `DORINFO`, `DOOR`, or `DOOR32`. Omit if the door needs no drop file. |
+| `runBatch` | :-1: | Multi-line batch script written to `A:\RUN.BAT` at runtime. Supports [variable substitution](#runbatch-variables). See [One Image, Multiple Doors](#one-image-multiple-doors). |
 | `nodeMax` | :-1: | Max concurrent sessions. `0` = unlimited. |
 | `tooManyArt` | :-1: | Art spec to display when `nodeMax` is exceeded. |
 | `memoryMb` | :-1: | Guest RAM in MB. Default: `64`. |
@@ -61,6 +62,16 @@ You need a raw FreeDOS disk image (`.img`) with your door game pre-installed. Ra
 | `DOOR` | `DOOR.SYS` |
 | `DOOR32` | `door32.sys` |
 
+#### runBatch Variables
+
+When `runBatch` is set, ENiGMA replaces the following variables before writing `RUN.BAT`:
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `{dropFile}` | Drop file filename | `DORINFO1.DEF` |
+| `{node}` | Node number | `1` |
+| `{baud}` | Baud rate | `57600` |
+
 ---
 
 ### Example Menu Entry
@@ -71,10 +82,18 @@ doorPimpWars: {
     module: v86_door
     config: {
         name: PimpWars
-        image: /path/to/images/freedos_pimpwars.img
+        image: /path/to/images/freedos_doors.img
         dropFileType: DORINFO
         nodeMax: 1
         tooManyArt: DOORMANY
+        runBatch:
+            '''
+            COPY A:\{dropFile} C:\DOORS\PW\
+            C:\FOSSIL\X00.SYS
+            CD C:\DOORS\PW
+            PW.EXE {node}
+            ECHO Returning to BBS, please wait... > COM1
+            '''
     }
 }
 ```
@@ -85,24 +104,79 @@ doorPimpWars: {
 
 Your disk image must contain:
 - A working FreeDOS installation
-- Your door game (e.g. `C:\DOORS\PIMPWARS\`)
-- A FOSSIL driver such as [X00](http://pcmicro.com/xtalk/x00.html) — required by most classic DOS doors
-- An `AUTOEXEC.BAT` (or `FDAUTO.BAT`) that copies the drop file from `A:` and launches the door
+- Your door game(s) installed (e.g. `C:\DOORS\PIMPWARS\`)
+- Optionally, a FOSSIL driver such as [X00](http://pcmicro.com/xtalk/x00.html) — required by most classic DOS doors
+- An `AUTOEXEC.BAT` (or `FDAUTO.BAT`) that calls `A:\RUN.BAT` and powers off
 
-#### Example AUTOEXEC.BAT
+#### AUTOEXEC.BAT Convention
+
+Set up your image's `AUTOEXEC.BAT` once. ENiGMA writes `RUN.BAT` to `A:` at runtime with the door-specific launch commands:
 
 ```bat
-CD C:\DOORS\PIMPWARS
-COPY A:\DORINFO1.DEF C:\DOORS\PIMPWARS\
-PIMPWARS.EXE A:\DORINFO1.DEF 1
+CALL A:\RUN.BAT
+ECHO Shutting down, please wait... > COM1
 FDAPM POWEROFF
 ```
 
-> :information_source: `FDAPM POWEROFF` shuts FreeDOS down after the door exits. Without it, the emulator idles until the session times out.
+- **`CALL A:\RUN.BAT`** — executes the per-door launch script ENiGMA injects at runtime
+- **`ECHO ... > COM1`** — sends a message to the user's terminal while FreeDOS shuts down (can take a few seconds)
+- **`FDAPM POWEROFF`** — shuts FreeDOS down cleanly; placed after the CALL so it always fires even if the door crashes
+
+#### One Image, Multiple Doors
+
+Because `RUN.BAT` is generated at runtime, a single FreeDOS image can host multiple doors. Each door has its own menu entry pointing at the same `image` path with a different `runBatch`:
+
+```hjson
+doorPimpWars: {
+    module: v86_door
+    config: {
+        name: PimpWars
+        image: /path/to/images/freedos_doors.img
+        dropFileType: DORINFO
+        nodeMax: 1
+        runBatch:
+            '''
+            COPY A:\{dropFile} C:\DOORS\PW\
+            C:\FOSSIL\X00.SYS
+            CD C:\DOORS\PW
+            PW.EXE {node}
+            ECHO Returning to BBS, please wait... > COM1
+            '''
+    }
+}
+
+doorSmurfCombat: {
+    module: v86_door
+    config: {
+        name: SmurfCombat
+        image: /path/to/images/freedos_doors.img   // same image
+        dropFileType: DOOR
+        nodeMax: 1
+        runBatch:
+            '''
+            COPY A:\{dropFile} C:\DOORS\SMURF\
+            C:\FOSSIL\X00.SYS
+            CD C:\DOORS\SMURF
+            SMURF.EXE {node}
+            ECHO Returning to BBS, please wait... > COM1
+            '''
+    }
+}
+```
+
+> :information_source: Concurrent sessions on the same image file are safe — each worker loads the image into its own isolated memory buffer. `nodeMax: 1` gates single-player doors, but even without it there is no shared state between sessions.
 
 #### FOSSIL Driver
 
-Most classic DOS doors use the [FOSSIL](https://en.wikipedia.org/wiki/FOSSIL) serial interface to communicate over COM1. If your door fails to start or runs in local mode, install a FOSSIL driver in your image. [X00](http://pcmicro.com/xtalk/x00.html) works well with v86. In `FDCONFIG.SYS`:
+Most classic DOS doors use the [FOSSIL](https://en.wikipedia.org/wiki/FOSSIL) serial interface for COM1 I/O. If your door fails to start or falls back to local mode, a FOSSIL driver is needed. [X00](http://pcmicro.com/xtalk/x00.html) works well with v86.
+
+Load it from `runBatch` (per-door, recommended) rather than `FDCONFIG.SYS` (global):
+
+```bat
+C:\FOSSIL\X00.SYS
+```
+
+Or in `FDCONFIG.SYS` if all doors on the image need it:
 
 ```
 DEVICE=C:\FOSSIL\X00.SYS

--- a/docs/_docs/modding/local-doors.md
+++ b/docs/_docs/modding/local-doors.md
@@ -16,7 +16,7 @@ ENiGMA½ supports running local BBS door games through several approaches. In ad
 |----------|--------|----------|-----------------------|
 | **[Native v86 Emulation](local-doors-v86.md)** | `v86_door` | DOS doors, no emulator on server | FreeDOS disk image |
 | **[External DOS Emulators](local-doors-dos-emulation.md)** | `abracadabra` | DOS doors, full graphical setup | QEMU or DOSEMU installed |
-| **[Scripts & Native Binaries](local-doors-abracadabra.md)** | `abracadabra` | Linux-native doors, shell/Python scripts | None |
+| **[Scripts & Native Binaries](local-doors-abracadabra.md)** | `abracadabra` | Native terminal apps, shell/Python scripts | None |
 
 ### Quick Guide
 
@@ -24,7 +24,7 @@ ENiGMA½ supports running local BBS door games through several approaches. In ad
 
 - **Already have a QEMU or DOSEMU setup, or need a full graphical DOS environment for image configuration?** → [External DOS Emulators](local-doors-dos-emulation.md). Raw disk images are compatible with both approaches, so you can configure with QEMU and run with v86.
 
-- **Running a Linux-native binary, a shell script, or a Python-based door?** → [Scripts & Native Binaries](local-doors-abracadabra.md). The `abracadabra` module launches any local process and bridges I/O over stdio or a TCP socket.
+- **Running a native terminal application, a shell script, or a Python-based door?** → [Scripts & Native Binaries](local-doors-abracadabra.md). The `abracadabra` module launches any local process that speaks stdio and bridges I/O over stdin/stdout or a TCP socket.
 
 ---
 

--- a/docs/_docs/modding/local-doors.md
+++ b/docs/_docs/modding/local-doors.md
@@ -3,245 +3,52 @@ layout: page
 title: Local Doors
 ---
 ## Local Doors
-ENiGMA½ has many ways to add doors to your system. In addition to the [many built in door server modules](door-servers.md), local doors are of course also supported using the ! The `abracadabra` module!
 
-> :information_source: See also [Let’s add a DOS door to Enigma½ BBS](https://medium.com/retro-future/lets-add-a-dos-game-to-enigma-1-2-41f257deaa3c) by Robbie Whiting for a great writeup on adding doors!
+ENiGMA½ supports running local BBS door games through several approaches. In addition to the [many built-in door server modules](door-servers.md) (DoorParty, BBSLink, Exodus, etc.), local doors run directly on your server.
 
-## The abracadabra Module
-The `abracadabra` module provides a generic and flexible solution for many door types. Through this module you can execute native processes & scripts directly, and perform I/O through standard I/O (stdio) or a temporary TCP server.
+> :information_source: See also [Let's add a DOS door to Enigma½ BBS](https://medium.com/retro-future/lets-add-a-dos-game-to-enigma-1-2-41f257deaa3c) by Robbie Whiting for a great writeup on adding doors!
 
-### Configuration
-The `abracadabra` `config` block can contain the following members:
+---
 
-| Item | Required | Description |
-|------|----------|-------------|
-| `name` | :+1: | Used as a key for tracking number of clients using a particular door. |
-| `dropFileType` | :-1: | Specifies the type of dropfile to generate (See [Dropfile Types](#dropfile-types) below). Can be omitted or set to `none`. |
-| `cmd` | :+1: | Path to executable to launch. |
-| `args` | :-1: | Array of argument(s) to pass to `cmd`. See [Argument Variables](#argument-variables) below for information on variables that can be utilized here. |
-| `preCmd` | :-1: | Path to a pre-command executable or script to launch. Executes before `cmd`. |
-| `preCmdArgs` | :-1: | Array of argument(s) to pass to `preCmd`. See [Argument Variables](#argument-variables) below for information on variables that can be utilized here. |
-| `cwd` | :-1: | Sets the Current Working Directory (CWD) for `cmd`. Defaults to the directory of `cmd`. |
-| `env` | :-1: | Sets the environment. Supplied in the form of an map: `{ SOME_VAR: "value" }`
-| `nodeMax` | :-1: | Max number of nodes that can access this door at once. Uses `name` as a tracking key. |
-| `tooManyArt` | :-1: | Art spec to display if too many instances are already in use. |
-| `io` | :-1: | How to process input/output (I/O). Can be `stdio` or `socket`. When using `stdio`, I/O is handled via standard stdin/stdout. When using `socket` a temporary socket server is spawned that can be connected back to. The server listens on localhost on `{srvPort}` (See [Argument Variables](#argument-variables) below for more information). Default value is `stdio`. |
-| `encoding` | :-1: | Sets the **door's** encoding. Defaults to `cp437`. Linux binaries often produce `utf8`. |
+## Choosing an Approach
 
-#### Dropfile Types
-Dropfile types specified by `dropFileType`:
+| Approach | Module | Best For | External Requirements |
+|----------|--------|----------|-----------------------|
+| **[Native v86 Emulation](local-doors-v86.md)** | `v86_door` | DOS doors, no emulator on server | FreeDOS disk image |
+| **[External DOS Emulators](local-doors-dos-emulation.md)** | `abracadabra` | DOS doors, full graphical setup | QEMU or DOSEMU installed |
+| **[Scripts & Native Binaries](local-doors-abracadabra.md)** | `abracadabra` | Linux-native doors, shell/Python scripts | None |
+
+### Quick Guide
+
+- **Running a classic DOS door game and want zero server dependencies?** → [Native v86 Emulation](local-doors-v86.md). ENiGMA½ boots FreeDOS in a built-in emulator; no QEMU or DOSEMU required on the production machine.
+
+- **Already have a QEMU or DOSEMU setup, or need a full graphical DOS environment for image configuration?** → [External DOS Emulators](local-doors-dos-emulation.md). Raw disk images are compatible with both approaches, so you can configure with QEMU and run with v86.
+
+- **Running a Linux-native binary, a shell script, or a Python-based door?** → [Scripts & Native Binaries](local-doors-abracadabra.md). The `abracadabra` module launches any local process and bridges I/O over stdio or a TCP socket.
+
+---
+
+## Drop File Types
+
+All local door approaches in ENiGMA½ support the same drop file types:
 
 | Value | Description |
 |-------|-------------|
-| `none` | No door file is needed |
-| `DOOR` | [DOOR.SYS](https://web.archive.org/web/20160325192739/http://goldfndr.home.mindspring.com/dropfile/doorsys.htm)
-| `DOOR32` | [DOOR32.SYS](https://raw.githubusercontent.com/NuSkooler/ansi-bbs/master/docs/dropfile_formats/door32_sys.txt)
-| `DORINFO` | [DORINFOx.DEF](https://web.archive.org/web/20160321190038/http://goldfndr.home.mindspring.com/dropfile/dorinfo.htm)
+| `none` | No drop file needed |
+| `DOOR` | [DOOR.SYS](https://web.archive.org/web/20160325192739/http://goldfndr.home.mindspring.com/dropfile/doorsys.htm) |
+| `DOOR32` | [DOOR32.SYS](https://raw.githubusercontent.com/NuSkooler/ansi-bbs/master/docs/dropfile_formats/door32_sys.txt) |
+| `DORINFO` | [DORINFOx.DEF](https://web.archive.org/web/20160321190038/http://goldfndr.home.mindspring.com/dropfile/dorinfo.htm) |
 
-#### Argument Variables
-The following variables may be used in `args` and `preCmdArgs` entries:
-
-| Variable | Description | Example |
-|----------|-------------|---------|
-| `{node}` | Current node number. | `1` |
-| `{dropFile}` | Dropfile _filename_ only. | `DOOR.SYS` |
-| `{dropFilePath}` | Full path to generated dropfile. The system places dropfiles in the path set by `paths.dropFiles` in `config.hjson`. | `C:\enigma-bbs\drop\node1\DOOR.SYS` |
-| `{dropFileDir}` | Full path to **directory** containing the generated dropfile. | `/home/enigma-bbs/drop/node1/` |
-| `{userAreaDir}` | Full path to a **directory** safe for user-specific save files/etc. | `/home/enigma-bbs/drop/node1/NuSkooler/lord/` |
-| `{userId}` | Current user ID. | `420` |
-| `{userName}` | [Sanitized](https://www.npmjs.com/package/sanitize-filename) username. Safe for filenames, etc. If the full username is sanitized away, this will resolve to something like "user_1234". | `izard` |
-| `{userNameRaw}` | _Raw_ username. May not be safe for filenames! | `\/\/izard` |
-| `{srvPort}` | Temporary server port when `io` is set to `socket`. | `1234` |
-| `{cwd}` | Current Working Directory. | `/home/enigma-bbs/doors/foo/` |
-| `{termHeight}` | Current client term height | `25` |
-| `{termWidth}` | Current client term width | `80` |
-
-Example `args` member using some variables described above:
-```hjson
-args: [
-    "-D", "{dropFilePath}",
-    "-N", "{node}"
-    "-U", "{userId}"
-]
-```
-
-### DOSEMU with abracadabra
-[DOSEMU](http://www.dosemu.org/) can provide a good solution for running legacy DOS doors when running on Linux systems. For this, we will create a virtual serial port (COM1) that communicates via stdio.
-
-As an example, here are the steps for setting up Pimp Wars:
-
-First, create a `dosemu.conf` file with the following contents:
-```
-$_cpu = "80486"
-$_cpu_emu = "vm86"
-$_external_char_set = "utf8"
-$_internal_char_set = "cp437"
-$_term_updfreq = (8)
-$_layout = "us"
-$_rawkeyboard = (0)
-$_com1 = "virtual"
-```
-
-The line `$_com1 = "virtual"` tells DOSEMU to use `stdio` as a virtual serial port on COM1.
-
-Next, we create a virtual **X** drive for Pimp Wars to live such as `/enigma-bbs/DOS/X/PW` and map it with a custom `AUTOEXEC.BAT` file within DOSEMU:
-```
-@echo off
-path d:\bin;d:\gnu;d:\dosemu
-set TEMP=c:\tmp
-prompt $P$G
-REM http://www.pcmicro.com/bnu/
-C:\BNU\BNU.COM /L0:57600,8N1 /F
-lredir.com x: linux\fs\enigma-bbs\DOS\X
-unix -e
-```
-
-Note that we also have the [BNU](http://www.pcmicro.com/bnu/) FOSSIL driver installed at `C:\BNU\\`. Another option would be to install this to X: somewhere as well.
-
-Finally, let's create a `menu.hjson` entry to launch the game:
-```hjson
-doorPimpWars: {
-    desc: Playing PimpWars
-    module: abracadabra
-    config: {
-        name: PimpWars
-        dropFileType: DORINFO
-        cmd: /usr/bin/dosemu
-        args: [
-            "-quiet",
-            "-f",
-            "/path/to/dosemu.conf",
-            "X:\\PW\\START.BAT {dropFile} {node}"
-        ],
-        nodeMax: 1
-        tooManyArt: DOORMANY
-        io: stdio
-    }
-}
-```
-
-### Shared Socket Descriptors
-Due to Node.js limitations, ENiGMA½ does not _directly_ support `DOOR32.SYS` style socket descriptor sharing (other `DOOR32.SYS` features are fully supported). However, a separate binary called [bivrost!](https://github.com/NuSkooler/bivrost) can be used. bivrost! is available for Windows and Linux x86/i686 and x86_64/AMD64. Other platforms where [Rust](https://www.rust-lang.org/) builds are likely to work as well.
-
-#### Example configuration
-Below is an example `menu.hjson` entry using bivrost! to launch a door:
-
-```hjson
-doorWithBivrost: {
-    desc: Bivrost Example
-    module: abracadabra
-    config: {
-        name: BivrostExample
-        dropFileType: DOOR32
-        cmd: "C:\\enigma-bbs\\utils\\bivrost.exe"
-        args: [
-            "--port", "{srvPort}",          //  bivrost! will connect this port on localhost
-            "--dropfile", "{dropFilePath}", //  ...and read this DOOR32.SYS produced by ENiGMA½
-            "--out", "C:\\doors\\jezebel",  //  ...and produce a NEW DOOR32.SYS here.
-
-            //
-            //  Note that the final <target> params bivrost! will use to
-            //  launch the door are grouped here. The {fd} variable could
-            //  also be supplied here if needed.
-            //
-            "C:\\door\\door.exe C:\\door\\door32.sys"
-        ],
-        nodeMax: 1
-        tooManyArt: DOORMANY
-        io: socket
-    }
-}
-```
-
-Please see the [bivrost!](https://github.com/NuSkooler/bivrost) documentation for more information.
-
-#### Phenom Productions Releases
-Pre-built binaries of bivrost! have been released under [Phenom Productions](https://www.phenomprod.com/) and can be found on various boards.
-
-#### Alternative Workarounds
-Alternative workarounds include [Telnet Bridge module](telnet-bridge.md) to hook up Telnet-accessible (including local) door servers -- It may also be possible bridge via [NET2BBS](http://pcmicro.com/netfoss/guide/net2bbs.html).
-
-### QEMU with abracadabra
-[QEMU](https://www.qemu.org/) provides a robust, cross platform solution for launching doors under many platforms (likely anywhere Node.js is supported and ENiGMA½ can run). Note however that there is an important and major caveat: **Multiple instances of a particular door/OS image should not be run at once!** Being more flexible means being a bit more complex. Let's look at an example for running L.O.R.D. under a UNIX like system such as Linux or FreeBSD.
-
-Basically we'll be creating a bootstrap shell script that generates a temporary node specific `GO.BAT` to launch our door. This will be called from `AUTOEXEC.BAT` within our QEMU FreeDOS partition.
-
-#### Step 1: Create a FreeDOS image
-[FreeDOS](https://www.freedos.org/) is a free mostly MS-DOS compatible DOS package that works well for running 16bit doors. Follow the [QEMU/FreeDOS](https://en.wikibooks.org/wiki/QEMU/FreeDOS) guide for creating an `freedos_c.img`. This will contain FreeDOS itself and installed BBS doors.
-
-After this is complete, copy LORD to C:\DOORS\LORD within FreeDOS. An easy way to tranfer files from host to DOS is to use QEMU's vfat as a drive. For example:
-```bash
-qemu-system-i386 -localtime /home/enigma/dos/images/freedos_c.img -hdb fat:/path/to/downloads
-```
-
-With the above you can now copy files from D: to C: within FreeDOS and add the following to it's `autoexec.bat`:
-```bat
-CALL E:\GO.BAT
-```
-
-#### Step 2: Create a bootstrap script
-Our bootstrap script will prepare `GO.BAT` and launch FreeDOS. Below is an example:
-
-
-```bash
-#!/bin/bash
-
-NODE=$1
-DROPFILE=D:\\$2
-SRVPORT=$3
-
-mkdir -p /home/enigma/dos/go/node$NODE
-
-cat > /home/enigma/dos/go/node$NODE/GO.BAT <<EOF
-C:
-CD \FOSSIL\BNU
-BNU.COM
-CD \DOORS\LORD
-COPY /Y $DROPFILE
-CALL START.BAT $NODE
-FDAPM POWEROFF
-EOF
-
-unix2dos /home/enigma/dos/go/node$NODE/GO.BAT
-
-qemu-system-i386 -localtime /home/enigma/dos/images/freedos_c.img -chardev socket,port=$SRVPORT,nowait,host=localhost,id=s0 -device isa-serial,chardev=s0 -hdb fat:/home/enigma/xibalba/dropfiles/node$NODE -hdc fat:/home/enigma/dos/go/node$NODE -nographic
-```
-
-Note the `qemu-system-i386` line. We're telling QEMU to launch and use localtime for the clock, create a character device that connects to our temporary server port on localhost and map that to a serial device. The `-hdb` entry will represent the D: drive where our dropfile is generated, while `-hdc` is the path that `GO.BAT` is generated in (`E:\GO.BAT`). Finally we specify `-nographic` to run headless.
-
-For doors that do not *require* a FOSSIL driver, it is recommended to not load or use one unless you are having issues.
-
-##### Step 3: Create a menu entry
-Finally we can create a `menu.hjson` entry using the `abracadabra` module:
-```hjson
-doorLORD: {
-    desc: Playing L.O.R.D.
-    module: abracadabra
-    config: {
-        name: LORD
-        dropFileType: DOOR
-        cmd: /home/enigma/dos/scripts/lord.sh
-        args: [
-            "{node}",
-            "{dropFile}",
-            "{srvPort}",
-        ],
-        nodeMax: 1
-        tooManyArt: DOORMANY
-        io: socket
-    }
-}
-```
+---
 
 ## See Also
+* [Door Servers](door-servers.md) — DoorParty, BBSLink, Exodus, and other hosted door services
 * [Telnet Bridge](telnet-bridge.md)
-* [Door Servers](door-servers.md)
+* [Scripts & Native Binaries](local-doors-abracadabra.md)
+* [External DOS Emulators](local-doors-dos-emulation.md)
+* [Native v86 Emulation](local-doors-v86.md)
 
 ## Additional Resources
-### DOS Emulation
-* [DOSEMU](http://www.dosemu.org/)
-* [DOSBox-X](https://github.com/joncampbell123/dosbox-x)
-
 ### Door Downloads & Support Sites
 #### General
 * http://bbsfiles.com/

--- a/misc/install.sh
+++ b/misc/install.sh
@@ -208,6 +208,26 @@ copy_template_files() {
     fi
 }
 
+download_v86_bios() {
+    local BIOS_DIR="${ENIGMA_INSTALL_DIR}/misc/v86_bios"
+    local V86_BIOS_BASE="https://github.com/copy/v86/raw/master/bios"
+
+    log "Downloading v86 BIOS files to ${BIOS_DIR}..."
+    mkdir -p "${BIOS_DIR}"
+
+    for BIOS_FILE in seabios.bin vgabios.bin; do
+        if [[ -f "${BIOS_DIR}/${BIOS_FILE}" ]]; then
+            log "  ${BIOS_FILE} already present, skipping."
+        else
+            log "  Downloading ${BIOS_FILE}..."
+            curl -fL "${V86_BIOS_BASE}/${BIOS_FILE}" -o "${BIOS_DIR}/${BIOS_FILE}" ||
+                fatal_error "Failed to download ${BIOS_FILE} from ${V86_BIOS_BASE}"
+        fi
+    done
+
+    log "v86 BIOS files ready."
+}
+
 enigma_footer() {
     log "ENiGMA½ installation complete!"
     printf "${FOREGROUND_YELLOW}"
@@ -298,6 +318,7 @@ install_bbs() {
 
     download_enigma_source
     copy_template_files
+    download_v86_bios
 }
 
 install_everything() {
@@ -305,6 +326,7 @@ install_everything() {
     download_enigma_source
     install_dependencies
     copy_template_files
+    download_v86_bios
 }
 
 menu() {

--- a/misc/menu_templates/doors.in.hjson
+++ b/misc/menu_templates/doors.in.hjson
@@ -38,6 +38,14 @@
                     value: { command: "EXODUS" }
                     action: @menu:doorExodusCataclysm
                 }
+                //
+                //  v86 native DOS emulation example
+                //  See: docs/_docs/modding/local-doors-v86.md
+                //
+                {
+                    value: { command: "MYGAME" }
+                    action: @menu:doorMyGameV86
+                }
             ]
         }
 
@@ -93,6 +101,48 @@
                 username: XXXXXXXX
                 password: XXXXXXXX
                 bbsTag: XX
+            }
+        }
+
+        //
+        //  Native x86/DOS door via v86 — no external emulator required.
+        //
+        //  Prerequisites:
+        //    1. A raw FreeDOS disk image (.img) with your door(s) pre-installed.
+        //       Compatible with QEMU and DOSBox-X for image setup.
+        //    2. BIOS files in misc/v86_bios/ (downloaded automatically by install.sh).
+        //
+        //  Image AUTOEXEC.BAT / FDAUTO.BAT convention:
+        //    CALL A:\RUN.BAT
+        //    ECHO Shutting down, please wait... > COM1
+        //    FDAPM POWEROFF
+        //
+        //  ENiGMA writes RUN.BAT to the A: floppy at runtime using the runBatch config
+        //  below. This lets a single image host multiple doors — one entry per door,
+        //  same image path.
+        //
+        //  See docs/_docs/modding/local-doors-v86.md for full setup instructions.
+        //
+        doorMyGameV86: {
+            desc: My DOS Door (v86)
+            module: v86_door
+            config: {
+                name: MyGame
+                image: /path/to/images/freedos_doors.img
+                dropFileType: DORINFO
+                nodeMax: 1
+                tooManyArt: DOORMANY
+                runBatch:
+                    '''
+                    COPY A:\{dropFile} C:\DOORS\MYGAME\
+                    C:\FOSSIL\X00.SYS
+                    CD C:\DOORS\MYGAME
+                    MYGAME.EXE {node}
+                    ECHO Returning to BBS, please wait... > COM1
+                    '''
+                //  memoryMb: 64      // optional, default 64
+                //  biosPath: /path/to/seabios.bin      // default: misc/v86_bios/seabios.bin
+                //  vgaBiosPath: /path/to/vgabios.bin   // default: misc/v86_bios/vgabios.bin
             }
         }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,8 @@
                 "deepdash": "^5.3.9",
                 "easy-table": "^1.2.0",
                 "exiftool": "^0.0.3",
+                "fatfs": "^0.10.8",
+                "fatfs-volume-driver": "^0.0.4",
                 "follow-redirects": "^1.15.11",
                 "fs-extra": "10.1.0",
                 "glob": "8.0.3",
@@ -53,6 +55,7 @@
                 "temptmp": "^1.1.0",
                 "uuid": "8.3.2",
                 "uuid-parse": "1.1.0",
+                "v86": "^0.5.319",
                 "ws": "8.18.3",
                 "yazl": "^2.5.1"
             },
@@ -2009,6 +2012,30 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/fatfs": {
+            "version": "0.10.8",
+            "resolved": "https://registry.npmjs.org/fatfs/-/fatfs-0.10.8.tgz",
+            "integrity": "sha512-SgtbqGNMwptNXpgLeqSSShm254JIzoVUyyFQBbqMmSPDpKsdZ65vSiS2SzyUI8sMtPvYK62hkuYhXzGZCMt5uQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "fifolock": "^1.0.0",
+                "struct-fu": "^1.2.1",
+                "xok": "^1.0.0"
+            }
+        },
+        "node_modules/fatfs-volume-driver": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/fatfs-volume-driver/-/fatfs-volume-driver-0.0.4.tgz",
+            "integrity": "sha512-+G55P4aXAh2D40B+i9tgrDAdu+Op1uwDQT56i/QyOeZUIxA4wbD5G2/d65VxF0/THckctlDzrQGOlPoKCVR5NQ==",
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "fatfs": "^0.10.8",
+                "lodash": "^4.17.21"
+            },
+            "engines": {
+                "node": ">=18.12.0"
+            }
+        },
         "node_modules/fb-watchman": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
@@ -2017,6 +2044,12 @@
             "dependencies": {
                 "bser": "2.1.1"
             }
+        },
+        "node_modules/fifolock": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fifolock/-/fifolock-1.0.0.tgz",
+            "integrity": "sha512-CqipzmuW6+xm7emSaBx1rV/fX17UGF9HkzLH887cFOj/Pe3TJsrboGxjZZtzV/5JrQ5vMegQ7ipZkB9wvsBDDQ==",
+            "license": "BSD-2-Clause"
         },
         "node_modules/figures": {
             "version": "3.2.0",
@@ -5398,6 +5431,12 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/struct-fu": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/struct-fu/-/struct-fu-1.2.1.tgz",
+            "integrity": "sha512-QrtfoBRe+RixlBJl852/Gu7tLLTdx3kWs3MFzY1OHNrSsYYK7aIAnzqsncYRWrKGG/QSItDmOTlELMxehw4Gjw==",
+            "license": "BSD-2-Clause"
+        },
         "node_modules/supports-color": {
             "version": "7.2.0",
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -5695,6 +5734,12 @@
             "integrity": "sha512-OdmXxA8rDsQ7YpNVbKSJkNzTw2I+S5WsbMDnCtIWSQaosNAcWtFuI/YK1TjzUI6nbkgiqEyh8gWngfcv8Asd9A==",
             "license": "MIT"
         },
+        "node_modules/v86": {
+            "version": "0.5.319",
+            "resolved": "https://registry.npmjs.org/v86/-/v86-0.5.319.tgz",
+            "integrity": "sha512-OsAGtpDYexAFTfIXf9iMh+JM6IK1GRahWZG3ghNEHtzCxQnyCXQOnN4m5fwV+b5cD0Yj97x8EpsloDtSIpcidA==",
+            "license": "BSD-2-Clause"
+        },
         "node_modules/verror": {
             "version": "1.10.0",
             "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
@@ -5859,6 +5904,12 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/xok": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/xok/-/xok-1.0.0.tgz",
+            "integrity": "sha512-DVb6F65Oiq0/fQxLH4adxE92OeNl1njEd+A1pPknmujM/nJhid2iofGXhrU4subNbUi2F0whuKhLv8ReFsqg6g==",
+            "license": "WTFPL"
         },
         "node_modules/y18n": {
             "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
         "deepdash": "^5.3.9",
         "easy-table": "^1.2.0",
         "exiftool": "^0.0.3",
+        "fatfs": "^0.10.8",
+        "fatfs-volume-driver": "^0.0.4",
         "follow-redirects": "^1.15.11",
         "fs-extra": "10.1.0",
         "glob": "8.0.3",
@@ -74,6 +76,7 @@
         "temptmp": "^1.1.0",
         "uuid": "8.3.2",
         "uuid-parse": "1.1.0",
+        "v86": "^0.5.319",
         "ws": "8.18.3",
         "yazl": "^2.5.1"
     },

--- a/test/file_base_db.test.js
+++ b/test/file_base_db.test.js
@@ -269,7 +269,11 @@ describe('FileEntry.quickCheckExistsByPath()', function () {
                             '2024/March',
                             (err2, existsC) => {
                                 assert.ifError(err2);
-                                assert.equal(existsC, false, 'March record should not exist');
+                                assert.equal(
+                                    existsC,
+                                    false,
+                                    'March record should not exist'
+                                );
                                 done();
                             }
                         );

--- a/test/file_base_storage_tags.test.js
+++ b/test/file_base_storage_tags.test.js
@@ -122,7 +122,10 @@ describe('FileEntry.getAreaStorageDirectoryByTag() — static', () => {
     });
 
     it('returns an absolute flat tag unchanged', () => {
-        assert.equal(FileEntry.getAreaStorageDirectoryByTag('flat_abs'), '/srv/files/flat');
+        assert.equal(
+            FileEntry.getAreaStorageDirectoryByTag('flat_abs'),
+            '/srv/files/flat'
+        );
     });
 });
 
@@ -241,7 +244,10 @@ describe('relPath derivation from glob results', () => {
     });
 
     it('returns the full relative subdir path for a deeply nested file', () => {
-        assert.equal(relPathFromGlobResult('2024/April/games/foo.zip'), '2024/April/games');
+        assert.equal(
+            relPathFromGlobResult('2024/April/games/foo.zip'),
+            '2024/April/games'
+        );
     });
 
     it('returns null for a file directly in . (normalized dirname)', () => {

--- a/test/oputil_fat.test.js
+++ b/test/oputil_fat.test.js
@@ -1,0 +1,243 @@
+'use strict';
+
+/**
+ * oputil_fat.test.js
+ *
+ * Unit tests for the FAT disk image helpers used by oputil_fat.js.
+ * Tests operate entirely on in-memory buffers — no real disk images required.
+ *
+ * We test the underlying helpers (mkdirp, copyFile, etc.) by building a
+ * real in-memory FAT12 image via fat_image.js, mounting it with
+ * fatfs-volume-driver, and then exercising the helpers against it.
+ */
+
+const { strict: assert } = require('assert');
+const { createRequire } = require('module');
+
+const _require = createRequire(__filename);
+const fatfs = _require('fatfs');
+const { createBufferDriverSync } = _require('fatfs-volume-driver');
+
+const { createFloppyWithFiles } = require('../core/v86_door/fat_image.js');
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Build a fresh in-memory FAT12 image and return a mounted fatfs instance.
+ * @param {Array<{name:string, content:Buffer}>} [files]
+ */
+async function buildMountedImage(files = []) {
+    const img = await createFloppyWithFiles(files);
+    const driver = createBufferDriverSync('', { buffer: img, partitionNumber: 0 });
+    const fs = fatfs.createFileSystem(driver);
+    await new Promise((resolve, reject) => {
+        fs.on('error', reject);
+        fs.on('ready', resolve);
+    });
+    return { fs, img };
+}
+
+/** Promise wrapper around fatfs.readdir */
+function readdir(fs, p) {
+    return new Promise((resolve, reject) =>
+        fs.readdir(p, (err, entries) => (err ? reject(err) : resolve(entries)))
+    );
+}
+
+/** Promise wrapper around fatfs.readFile */
+function readFile(fs, p) {
+    return new Promise((resolve, reject) =>
+        fs.readFile(p, (err, data) => (err ? reject(err) : resolve(data)))
+    );
+}
+
+/** Promise wrapper around fatfs.mkdir */
+function mkdir(fs, p) {
+    return new Promise(
+        resolve => fs.mkdir(p, err => resolve(err)) // resolve even on error (caller checks)
+    );
+}
+
+/** Promise wrapper around fatfs.writeFile */
+function writeFile(fs, p, data) {
+    return new Promise((resolve, reject) =>
+        fs.writeFile(p, data, err => (err ? reject(err) : resolve()))
+    );
+}
+
+// ─── createFloppyWithFiles ────────────────────────────────────────────────────
+
+describe('createFloppyWithFiles', () => {
+    it('returns a 1.44MB buffer', async () => {
+        const img = await createFloppyWithFiles([]);
+        assert.equal(img.length, 512 * 2880);
+    });
+
+    it('has a valid FAT12 boot sector signature', async () => {
+        const img = await createFloppyWithFiles([]);
+        assert.equal(img[510], 0x55);
+        assert.equal(img[511], 0xaa);
+    });
+
+    it('writes a file that can be read back', async () => {
+        const content = Buffer.from('Hello, DOS!\r\n', 'ascii');
+        const { fs } = await buildMountedImage([{ name: 'TEST.TXT', content }]);
+
+        const data = await readFile(fs, 'TEST.TXT');
+        assert.deepEqual(data, content);
+    });
+
+    it('writes multiple files', async () => {
+        const files = [
+            { name: 'DOOR.SYS', content: Buffer.from('door\r\n') },
+            { name: 'DORINFO1.DEF', content: Buffer.from('dorinfo\r\n') },
+        ];
+        const { fs } = await buildMountedImage(files);
+
+        const entries = await readdir(fs, '/');
+        assert.ok(entries.includes('DOOR.SYS'));
+        assert.ok(entries.includes('DORINFO1.DEF'));
+    });
+
+    it('returns an empty-rooted image when no files given', async () => {
+        const { fs } = await buildMountedImage([]);
+        const entries = await readdir(fs, '/');
+        assert.equal(entries.length, 0);
+    });
+});
+
+// ─── FAT image — write & read roundtrip ──────────────────────────────────────
+
+describe('FAT image write/read roundtrip', () => {
+    it('preserves binary content exactly', async () => {
+        const content = Buffer.from([0x00, 0xff, 0x1b, 0x0d, 0x0a, 0xaa]);
+        const { fs } = await buildMountedImage([{ name: 'BIN.DAT', content }]);
+
+        const data = await readFile(fs, 'BIN.DAT');
+        assert.deepEqual(data, content);
+    });
+
+    it('preserves CRLF line endings', async () => {
+        const lines = 'line1\r\nline2\r\nline3\r\n';
+        const content = Buffer.from(lines, 'ascii');
+        const { fs } = await buildMountedImage([{ name: 'CRLF.TXT', content }]);
+
+        const data = await readFile(fs, 'CRLF.TXT');
+        assert.equal(data.toString('ascii'), lines);
+    });
+
+    it('handles an empty file', async () => {
+        const { fs } = await buildMountedImage([
+            { name: 'EMPTY.TXT', content: Buffer.alloc(0) },
+        ]);
+        const data = await readFile(fs, 'EMPTY.TXT');
+        assert.equal(data.length, 0);
+    });
+});
+
+// ─── mkdir ────────────────────────────────────────────────────────────────────
+
+describe('FAT image mkdir', () => {
+    it('creates a directory', async () => {
+        const { fs } = await buildMountedImage([]);
+
+        await mkdir(fs, 'DOORS');
+        const entries = await readdir(fs, '/');
+        assert.ok(entries.includes('DOORS'));
+    });
+
+    it('does not error on EEXIST', async () => {
+        const { fs } = await buildMountedImage([]);
+
+        await mkdir(fs, 'DOORS');
+        const err = await mkdir(fs, 'DOORS'); // second call
+        assert.ok(!err || err.code === 'EEXIST' || err.code === 'EXIST');
+    });
+
+    it('supports nested directories', async () => {
+        const { fs } = await buildMountedImage([]);
+
+        await mkdir(fs, 'DOORS');
+        await mkdir(fs, 'DOORS/PW');
+        await mkdir(fs, 'DOORS/PW/PIMPWARS');
+
+        const sub = await readdir(fs, 'DOORS/PW');
+        assert.ok(sub.includes('PIMPWARS'));
+    });
+});
+
+// ─── runBatch variable substitution ──────────────────────────────────────────
+
+describe('runBatch variable substitution', () => {
+    //  Test the substitution logic that lives in v86_door.js by replicating it
+    //  here — ensures the pattern stays correct independently of the module.
+
+    function applySubstitutions(template, dropFile, node, baud) {
+        return template
+            .replace(/\{dropFile\}/gi, dropFile)
+            .replace(/\{node\}/gi, String(node))
+            .replace(/\{baud\}/gi, String(baud))
+            .replace(/\r\n/g, '\n')
+            .replace(/\n/g, '\r\n');
+    }
+
+    it('substitutes {dropFile}', () => {
+        const result = applySubstitutions(
+            'COPY A:\\{dropFile} C:\\',
+            'DORINFO1.DEF',
+            1,
+            57600
+        );
+        assert.ok(result.includes('DORINFO1.DEF'));
+        assert.ok(!result.includes('{dropFile}'));
+    });
+
+    it('substitutes {node}', () => {
+        const result = applySubstitutions('GAME.EXE {node}', 'DOOR.SYS', 3, 57600);
+        assert.ok(result.includes('3'));
+        assert.ok(!result.includes('{node}'));
+    });
+
+    it('substitutes {baud}', () => {
+        const result = applySubstitutions('MODE COM1:{baud}', 'DOOR.SYS', 1, 57600);
+        assert.ok(result.includes('57600'));
+        assert.ok(!result.includes('{baud}'));
+    });
+
+    it('normalizes LF-only to CRLF', () => {
+        const result = applySubstitutions('line1\nline2\nline3', 'X', 1, 57600);
+        assert.ok(result.includes('\r\nline2\r\n'));
+        assert.ok(!result.match(/(?<!\r)\n/));
+    });
+
+    it('does not double-convert existing CRLF', () => {
+        const result = applySubstitutions('line1\r\nline2\r\n', 'X', 1, 57600);
+        assert.ok(!result.includes('\r\r\n'));
+    });
+
+    it('is case-insensitive for variable names', () => {
+        const result = applySubstitutions(
+            '{DROPFILE} {Node} {BAUD}',
+            'DOOR.SYS',
+            2,
+            57600
+        );
+        assert.ok(result.includes('DOOR.SYS'));
+        assert.ok(result.includes('2'));
+        assert.ok(result.includes('57600'));
+    });
+
+    it('writes the substituted RUN.BAT into a floppy and reads it back', async () => {
+        const template = 'COPY A:\\{dropFile} C:\\DOORS\\\r\nGAME.EXE {node}\r\n';
+        const substituted = applySubstitutions(template, 'DORINFO1.DEF', 1, 57600);
+        const content = Buffer.from(substituted, 'ascii');
+
+        const { fs } = await buildMountedImage([
+            { name: 'DORINFO1.DEF', content: Buffer.from('drop\r\n') },
+            { name: 'RUN.BAT', content },
+        ]);
+
+        const data = await readFile(fs, 'RUN.BAT');
+        assert.equal(data.toString('ascii'), substituted);
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -627,12 +627,34 @@ extsprintf@^1.2.0, extsprintf@1.3.0:
   resolved "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz"
   integrity sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==
 
+fatfs-volume-driver@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.npmjs.org/fatfs-volume-driver/-/fatfs-volume-driver-0.0.4.tgz"
+  integrity sha512-+G55P4aXAh2D40B+i9tgrDAdu+Op1uwDQT56i/QyOeZUIxA4wbD5G2/d65VxF0/THckctlDzrQGOlPoKCVR5NQ==
+  dependencies:
+    fatfs "^0.10.8"
+    lodash "^4.17.21"
+
+fatfs@^0.10.8:
+  version "0.10.8"
+  resolved "https://registry.npmjs.org/fatfs/-/fatfs-0.10.8.tgz"
+  integrity sha512-SgtbqGNMwptNXpgLeqSSShm254JIzoVUyyFQBbqMmSPDpKsdZ65vSiS2SzyUI8sMtPvYK62hkuYhXzGZCMt5uQ==
+  dependencies:
+    fifolock "^1.0.0"
+    struct-fu "^1.2.1"
+    xok "^1.0.0"
+
 fb-watchman@^2.0.1:
   version "2.0.2"
   resolved "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz"
   integrity sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==
   dependencies:
     bser "2.1.1"
+
+fifolock@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/fifolock/-/fifolock-1.0.0.tgz"
+  integrity sha512-CqipzmuW6+xm7emSaBx1rV/fX17UGF9HkzLH887cFOj/Pe3TJsrboGxjZZtzV/5JrQ5vMegQ7ipZkB9wvsBDDQ==
 
 figures@^3.0.0:
   version "3.2.0"
@@ -1941,6 +1963,11 @@ strip-json-comments@~2.0.1:
   resolved "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
   integrity sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==
 
+struct-fu@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/struct-fu/-/struct-fu-1.2.1.tgz"
+  integrity sha512-QrtfoBRe+RixlBJl852/Gu7tLLTdx3kWs3MFzY1OHNrSsYYK7aIAnzqsncYRWrKGG/QSItDmOTlELMxehw4Gjw==
+
 supports-color@^7.1.0:
   version "7.2.0"
   resolved "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz"
@@ -2096,6 +2123,11 @@ uuid@8.3.2:
   resolved "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
+v86@^0.5.319:
+  version "0.5.319"
+  resolved "https://registry.npmjs.org/v86/-/v86-0.5.319.tgz"
+  integrity sha512-OsAGtpDYexAFTfIXf9iMh+JM6IK1GRahWZG3ghNEHtzCxQnyCXQOnN4m5fwV+b5cD0Yj97x8EpsloDtSIpcidA==
+
 verror@1.10.0:
   version "1.10.0"
   resolved "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz"
@@ -2156,6 +2188,11 @@ ws@8.18.3:
   version "8.18.3"
   resolved "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz"
   integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==
+
+xok@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/xok/-/xok-1.0.0.tgz"
+  integrity sha512-DVb6F65Oiq0/fQxLH4adxE92OeNl1njEd+A1pPknmujM/nJhid2iofGXhrU4subNbUi2F0whuKhLv8ReFsqg6g==
 
 yallist@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Native x86/DOS Door Emulation via v86

Closes #212. Adds first-class native DOS door support to ENiGMA½ — no external emulator (QEMU, DOSBox, DOSEMU) required on the server.

### What's delivered

**`core/v86_door/` — production door module**
- `v86_door.js` — `MenuModule` that boots a FreeDOS disk image per user session, bridges COM1 to the user's connection, and handles node count limits, drop files, and clean shutdown
- `v86_worker.js` — v86 x86 emulator runs in a `worker_threads` Worker to keep ENiGMA's event loop unblocked; serial output batched in 5ms flush windows to minimize cross-thread message overhead
- `fat_image.js` — builds a 1.44MB FAT12 floppy image in memory at runtime; mounted as `A:` in FreeDOS for drop file and `RUN.BAT` injection — no temp files, no host disk writes

**`runBatch` — one image, many doors**
- Per-door batch script injected onto the floppy at runtime; `AUTOEXEC.BAT` calls `CALL A:\RUN.BAT`
- Variable substitution: `{dropFile}`, `{node}`, `{baud}` — line endings normalized to CRLF
- A single FreeDOS image can host multiple doors; concurrent sessions on the same image are safe (each worker loads into its own memory buffer)

**`oputil fat` — FAT disk image management**
- `ls/dir`, `cp/copy`, `read/cat/type` — inspect and modify raw FAT12/16/32 images without a running ENiGMA instance
- DOS 5.x-style directory listing with timestamps and file counts
- No ENiGMA config or database required

**`oputil v86` — emulator tools**
- `console` — boots image, bridges COM1 to terminal; useful for verifying door serial I/O (output only — keyboard input limitation documented)
- `desktop` — local HTTP server with full VGA canvas in browser; image preloaded with MB/% progress; HTTP Range support; collapsible debug log; Save Image button (File System Access API + download fallback); VS Code Remote SSH compatible

**`misc/install.sh`** — downloads SeaBIOS and VGA BIOS to `misc/v86_bios/` automatically

**Docs**
- `docs/_docs/modding/local-doors-v86.md` — full sysop guide: image setup, `runBatch` config, variable reference, FOSSIL loading, one-image/multiple-doors pattern, image size guidance
- `docs/_docs/admin/oputil.md` — `fat` and `v86` command reference with examples and known limitations
- `misc/menu_templates/doors.in.hjson` — `v86_door` example entry

**Tests**
- `test/oputil_fat.test.js` — 18 tests covering `createFloppyWithFiles`, FAT write/read roundtrip, mkdir, and `runBatch` variable substitution; all in-memory, no real disk images required


### Notes
- Requires SeaBIOS + VGA BIOS — run `misc/install.sh` or see the docs
- Guest RAM is configurable (`memoryMb`, default 64MB); document trade-offs for concurrent sessions
- Multi-player doors (LORD multi-node, TradeWars 2002) explicitly deferred — single-user only in this PR
