### PR TITLE
Implement server-side baud rate emulation

### DIFF
--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -3,7 +3,10 @@ This document attempts to track **major** changes and additions in ENiGMA½. For
 
 ## 0.2.0-beta
 
+* **Server-side baud rate emulation** — `baudRate` in a menu's `config` block now throttles art display on the server rather than delegating to a SyncTERM-specific terminal escape sequence. Emulation now works with every terminal client. The previous approach was sticky (rate persisted across menus until explicitly cleared); the new approach is scoped precisely to each art display and resets automatically. Existing `baudRate` config values require no changes.
+
 * **SQLite driver migrated to `better-sqlite3`** -- This is an internal change with no impact on existing data or configuration. Results in some major DB performance gains.
+
 * **[Z-Machine Interactive Fiction Door](./docs/_docs/modding/local-doors-zmachine.md)** — new `zmachine_door` module runs Z-Machine IF games (Zork, Colossal Cave Adventure, Photopia, Anchorhead, Lost Pig, and hundreds more) natively in Node.js. No external emulator, no serial bridge, no drop file — a cross-platform pure-JavaScript path for text-adventure games.
 
   * Backed by [ifvms.js](https://github.com/curiousdannii/ifvms.js) (the Z-Machine interpreter used by Parchment) and [glkote-term](https://github.com/curiousdannii/glkote-term), run in a dedicated worker thread per session for isolation.

--- a/core/ansi_term.js
+++ b/core/ansi_term.js
@@ -62,7 +62,6 @@ exports.setSyncTermFont = setSyncTermFont;
 exports.getSyncTermFontFromAlias = getSyncTermFontFromAlias;
 exports.setSyncTermFontWithAlias = setSyncTermFontWithAlias;
 exports.setCursorStyle = setCursorStyle;
-exports.setEmulatedBaudRate = setEmulatedBaudRate;
 exports.vtxHyperlink = vtxHyperlink;
 
 //
@@ -142,8 +141,6 @@ const CONTROL = {
 
     blinkToBrightIntensity: '?33h',
     blinkNormal: '?33l',
-
-    emulationSpeed: '*r', //  Set output emulation speed. See cterm.txt
 
     hideCursor: '?25l', //  Nonstandard - cterm.txt
     showCursor: '?25h', //  Nonstandard - cterm.txt
@@ -490,27 +487,6 @@ function goHome() {
 //
 function disableVT100LineWrapping() {
     return `${ESC_CSI}?7l`;
-}
-
-function setEmulatedBaudRate(rate) {
-    const speed =
-        {
-            unlimited: 0,
-            off: 0,
-            0: 0,
-            300: 1,
-            600: 2,
-            1200: 3,
-            2400: 4,
-            4800: 5,
-            9600: 6,
-            19200: 7,
-            38400: 8,
-            57600: 9,
-            76800: 10,
-            115200: 11,
-        }[rate] || 0;
-    return 0 === speed ? exports.emulationSpeed() : exports.emulationSpeed(1, speed);
 }
 
 function vtxHyperlink(client, url, len) {

--- a/core/art.js
+++ b/core/art.js
@@ -385,8 +385,29 @@ function display(client, art, options, cb) {
         });
     });
 
-    ansiParser.on('literal', literal => client.term.write(literal, false));
-    ansiParser.on('control', control => client.term.rawWrite(control));
+    //  Server-side baud emulation: collect all output into chunks, then drip at
+    //  the target byte rate after parsing completes. Works for every terminal.
+    //  baudRate / 10 = bytes/sec (standard 8N1: 8 data + 1 start + 1 stop bits).
+    const bytesPerSec = options.baudRate > 0 ? Math.floor(options.baudRate / 10) : 0;
+    const drip = bytesPerSec > 0;
+    const dripChunks = drip ? [] : null;
+
+    ansiParser.on('literal', literal => {
+        const encoded = client.term.encode(literal, false);
+        if (drip) {
+            dripChunks.push(encoded);
+        } else {
+            client.term.rawWrite(encoded);
+        }
+    });
+
+    ansiParser.on('control', control => {
+        if (drip) {
+            dripChunks.push(Buffer.isBuffer(control) ? control : Buffer.from(control));
+        } else {
+            client.term.rawWrite(control);
+        }
+    });
 
     ansiParser.on('complete', () => {
         ansiParser.removeAllListeners();
@@ -395,7 +416,13 @@ function display(client, art, options, cb) {
             height: ansiParser.row - 1,
         };
 
-        return cb(null, mciMap, extraInfo);
+        if (!drip) {
+            return cb(null, mciMap, extraInfo);
+        }
+
+        client.term.dripWrite(Buffer.concat(dripChunks), bytesPerSec, err =>
+            cb(err, mciMap, extraInfo)
+        );
     });
 
     let initSeq = '';

--- a/core/client_term.js
+++ b/core/client_term.js
@@ -246,6 +246,39 @@ ClientTerminal.prototype.pipeWrite = function (s, cb) {
     this.write(renegadeToAnsi(s, this), null, cb); //  null = use default for |convertLineFeeds|
 };
 
+//  dripWrite() — send |buf| to the socket at |bytesPerSec|, calling |cb| when done.
+//  Goes directly to this.output, intentionally bypassing _writeBuf batching (the two
+//  are mutually exclusive: batch = instant display; drip = throttled display).
+ClientTerminal.prototype.dripWrite = function (buf, bytesPerSec, cb) {
+    if (!buf || buf.length === 0) {
+        return cb(null);
+    }
+
+    const INTERVAL_MS = 16; //  ~60fps
+    const bytesPerInterval = Math.max(1, Math.round((bytesPerSec * INTERVAL_MS) / 1000));
+    let offset = 0;
+
+    const sendChunk = () => {
+        if (!this.output || !this.output.writable) {
+            return cb(new Error('Connection closed during baud emulation'));
+        }
+        const end = Math.min(offset + bytesPerInterval, buf.length);
+        const chunk = buf.slice(offset, end);
+        offset = end;
+        this.output.write(chunk, err => {
+            if (err) {
+                return cb(err);
+            }
+            if (offset >= buf.length) {
+                return cb(null);
+            }
+            setTimeout(sendChunk, INTERVAL_MS);
+        });
+    };
+
+    sendChunk();
+};
+
 ClientTerminal.prototype.encode = function (s, convertLineFeeds) {
     convertLineFeeds = _.isBoolean(convertLineFeeds) ? convertLineFeeds : this.convertLF;
 

--- a/core/menu_module.js
+++ b/core/menu_module.js
@@ -217,13 +217,8 @@ exports.MenuModule = class MenuModule extends PluginModule {
     }
 
     beforeArt(cb) {
-        if (_.isNumber(this.menuConfig.config.baudRate)) {
-            //  :TODO: some terminals not supporting cterm style emulated baud rate end up displaying a broken ESC sequence or a single "r" here
-            this.client.term.rawWrite(
-                ansi.setEmulatedBaudRate(this.menuConfig.config.baudRate)
-            );
-        }
-
+        //  baudRate is now handled server-side inside art.display() via collect-and-drip;
+        //  no terminal escape sequence needed (and none sent — fixes sticky baud state).
         if (this.cls) {
             this.client.term.rawWrite(ansi.resetScreen());
         }

--- a/core/theme.js
+++ b/core/theme.js
@@ -547,6 +547,7 @@ function displayPreparedArt(options, artInfo, cb) {
         font: options.font,
         trailingLF: options.trailingLF,
         startRow: options.startRow,
+        baudRate: options.baudRate,
     };
     art.display(options.client, artInfo.data, displayOpts, (err, mciMap, extraInfo) => {
         return cb(err, { mciMap: mciMap, artInfo: artInfo, extraInfo: extraInfo });

--- a/core/zmachine_door/zmachine_db.js
+++ b/core/zmachine_door/zmachine_db.js
@@ -11,7 +11,10 @@
  * packageName (codes.l33t.enigma.zmachine_door).
  */
 
-const { getModDatabasePath, openDatabase: openSqliteDatabase } = require('../database.js');
+const {
+    getModDatabasePath,
+    openDatabase: openSqliteDatabase,
+} = require('../database.js');
 
 const MODULE_INFO = {
     packageName: 'codes.l33t.enigma.zmachine_door',
@@ -123,12 +126,7 @@ function writeAutosave(userId, signature, data, cb) {
             }
 
             //  UPSERT with updated_at and accumulated play stats.
-            _stmtUpsertAutosave.run(
-                userId,
-                signature,
-                data,
-                new Date().toISOString()
-            );
+            _stmtUpsertAutosave.run(userId, signature, data, new Date().toISOString());
             return cb(null);
         } catch (runErr) {
             return cb(runErr);

--- a/docs/_docs/art/general.md
+++ b/docs/_docs/art/general.md
@@ -48,7 +48,7 @@ A menu entry has a few elements that control how art is selected and displayed. 
 |------|------------|
 | `font` | Sets the [SyncTERM](http://syncterm.bbsdev.net/) style font to use when displaying this art. If unset, the system will use the art's embedded [SAUCE](http://www.acid.org/info/sauce/sauce.htm) record if present or simply use the current font. See Fonts below. |
 | `pause` | Pause after displaying. `true` or `'end'` pauses at the end; `'pageBreak'` paginates the art screen-by-screen; a prompt name string uses that prompt in end mode. See [Pause Prompts](pause-prompts.md). |
-| `baudRate` | Set a [SyncTERM](http://syncterm.bbsdev.net/) style emulated baud rate when displaying this art. In other words, slow down the display. |
+| `baudRate` | Throttle art display to simulate a modem connection at the given baud rate. Works with all terminal clients. See [Baud Rates](#baud-rates) below. |
 | `cls` | Clear the screen before display if set to `true`. |
 | `random` | Set to `false` to explicitly disable random lookup. |
 | `types` | An optional array of types (aka file extensions) to consider for lookup. For example : `[ '.ans', '.asc' ]` |
@@ -151,10 +151,25 @@ Other "fonts" also available:
 
 > :information_source: See [this specification](https://github.com/protomouse/synchronet/blob/master/src/conio/cterm.txt) for more information.
 
-#### SyncTERM Style Baud Rates
-The `baudRate` member can set a [SyncTERM](http://syncterm.bbsdev.net/) style emulated baud rate. May be `300`, `600`, `1200`, `2400`, `4800`, `9600`, `19200`, `38400`, `57600`, `76800`, or `115200`. A value of `ulimited`, `off`, or `0` resets (disables) the rate.
+#### Baud Rates
+The `baudRate` member throttles art display on the server side, dripping bytes to the terminal at the rate a real modem of that speed would have delivered them. This works with every terminal client — no special support required. The rate applies only while the art is displaying and resets automatically when it finishes.
 
-> :information_source: See [this specification](https://github.com/protomouse/synchronet/blob/master/src/conio/cterm.txt) for more information.
+Accepted values: `300`, `600`, `1200`, `2400`, `4800`, `9600`, `19200`, `38400`, `57600`, `76800`, `115200`. A value of `unlimited`, `off`, or `0` disables throttling (immediate display).
+
+The table below maps each rate to the modem era it evokes:
+
+| Rate | Era | Representative Hardware |
+|------|-----|------------------------|
+| `300` | Late 1970s – early 1980s | Acoustic couplers; Bell 103; Novation CAT |
+| `1200` | 1982 – 1986 | Hayes Smartmodem 1200; Bell 212A |
+| `2400` | 1986 – 1991 | Hayes Smartmodem 2400; USR Courier 2400 |
+| `4800` | 1989 – 1993 | USR Courier HST (early) |
+| `9600` | 1990 – 1994 | USR Courier HST 9600; ZyXEL U-1496 |
+| `19200` | 1992 – 1994 | USR Dual Standard; early V.32bis modems |
+| `38400` | 1993 – 1996 | USR Sportster 14400; SupraFAXModem 14.4 |
+| `57600` | 1994 – 1997 | USR Courier V.Everything (28.8k); SupraFAXModem 28.8 |
+| `76800` | 1996 – 1998 | USR Courier 33.6; Rockwell V.34+ chipsets |
+| `115200` | 1997 – 2000 | USR Courier 56K; Hayes Accura 56K; 3Com 56K |
 
 ### Common Example
 ```hjson

--- a/docs/_docs/configuration/menu-hjson.md
+++ b/docs/_docs/configuration/menu-hjson.md
@@ -56,7 +56,7 @@ The `config` block for a menu entry can contain common members as well as a per-
 | `pausePrompt` | Override the prompt name(s) used for pauses. A string uses that prompt for both end-of-art and page-break pauses; an object `{ end, page }` controls each independently. Takes precedence over the `pause: '<promptId>'` shorthand. See [Pause Prompts](../art/pause-prompts.md). |
 | `pausePosition` | Force the pause prompt to a specific screen position: `{ row, col }` (1-based). |
 | `nextTimeout` | Sets the number of **milliseconds** before the system will automatically advanced to the `next` menu. |
-| `baudRate` | See baud rate information in [General Art Information](../art/general.md). |
+| `baudRate` | Throttle art display to simulate a modem at the given speed. Works with all terminal clients. See [Baud Rates](../art/general.md#baud-rates). |
 | `font` | Sets a SyncTERM style font to use when displaying this menus `art`. See font listing in [General Art Information](../art/general.md). |
 | `menuFlags` | An array of menu flag(s) controlling menu behavior. See **Menu Flags** below.
 

--- a/docs/_docs/modding/menu-modules.md
+++ b/docs/_docs/modding/menu-modules.md
@@ -118,7 +118,7 @@ Methods indicated above with `()` in their name such as `enter()` are overridabl
 
 * `enter()` is the first to be called. There is no callback. The default implementation is to simply call `this.initSequence()`.
 * `displayQueuedInterruptions(callback)` is called, and if interruptions are allowed for this menu, any that may be queued will be displayed first.
-* `beforeArt(callback)` is called before any art is displayed. The default implementation will set emulated baud rate, and clear the screen if either are requested by the menu's `config` block.
+* `beforeArt(callback)` is called before any art is displayed. The default implementation clears the screen if requested by the menu's `config` block (`cls: true`). Baud rate emulation, if configured, is applied during the art display itself rather than here.
 * `mciReady(mciData, callback)` is called when art is loaded and MCI codes are initialized. The default implementation of a custom `MenuModule` simply continues. See also [standardMCIReadyHandler](#standardmcireadyhandlermcidata-callback).
 
 ## MenuModule Helper Methods

--- a/test/baud_emulation.test.js
+++ b/test/baud_emulation.test.js
@@ -1,0 +1,239 @@
+'use strict';
+
+const { strict: assert } = require('assert');
+
+const { ClientTerminal } = require('../core/client_term.js');
+const { display } = require('../core/art.js');
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+//  Build a mock writable output that accumulates all chunks written to it.
+function makeMockOutput() {
+    const chunks = [];
+    const output = {
+        writable: true,
+        write(chunk, cb) {
+            chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+            if (cb) cb(null);
+        },
+        get data() {
+            return Buffer.concat(chunks);
+        },
+        get writeCount() {
+            return chunks.length;
+        },
+    };
+    return output;
+}
+
+//  Build a minimal client mock suitable for art.display().
+//  |drip| is an optional spy function; when supplied it replaces dripWrite
+//  and immediately calls cb so tests don't have to wait for real timers.
+function makeMockClient({ dripSpy } = {}) {
+    const written = [];
+    return {
+        term: {
+            termWidth: 80,
+            termHeight: 25,
+            syncTermFontsEnabled: false,
+            encode(s /*, convertLineFeeds */) {
+                //  Minimal encode: just return a Buffer of the string as-is.
+                return Buffer.from(s || '', 'binary');
+            },
+            rawWrite(data) {
+                written.push(Buffer.isBuffer(data) ? data : Buffer.from(data));
+            },
+            get rawWritten() {
+                return Buffer.concat(written);
+            },
+            dripWrite: dripSpy || null,
+        },
+        log: { warn: () => {}, debug: () => {}, trace: () => {} },
+    };
+}
+
+// ─── ClientTerminal.dripWrite ─────────────────────────────────────────────────
+
+describe('ClientTerminal.dripWrite', () => {
+    it('calls cb immediately for an empty buffer', done => {
+        const term = new ClientTerminal(makeMockOutput());
+        term.dripWrite(Buffer.alloc(0), 960, err => {
+            assert.ifError(err);
+            done();
+        });
+    });
+
+    it('calls cb immediately for a null buffer', done => {
+        const term = new ClientTerminal(makeMockOutput());
+        term.dripWrite(null, 960, err => {
+            assert.ifError(err);
+            done();
+        });
+    });
+
+    it('delivers all bytes to output', done => {
+        const output = makeMockOutput();
+        const term = new ClientTerminal(output);
+        const data = Buffer.from('Hello, ENiGMA½!');
+        //  Use a high rate so the test finishes quickly.
+        term.dripWrite(data, 115200, err => {
+            assert.ifError(err);
+            assert.deepStrictEqual(output.data, data);
+            done();
+        });
+    });
+
+    it('delivers bytes in correct order across multiple ticks', done => {
+        const output = makeMockOutput();
+        const term = new ClientTerminal(output);
+        //  240 bytes/sec (2400 baud equivalent) → 4 bytes/tick at 16ms → 8 ticks for 32 bytes.
+        const data = Buffer.from(Array.from({ length: 32 }, (_, i) => i));
+        term.dripWrite(data, 240, err => {
+            assert.ifError(err);
+            assert.deepStrictEqual(output.data, data);
+            //  Confirm it actually chunked (more than one write call).
+            assert.ok(output.writeCount > 1, 'expected multiple write calls');
+            done();
+        });
+    });
+
+    it('propagates socket write errors through cb', done => {
+        const output = {
+            writable: true,
+            write(_chunk, cb) {
+                cb(new Error('socket gone'));
+            },
+        };
+        const term = new ClientTerminal(output);
+        term.dripWrite(Buffer.from('test'), 9600, err => {
+            assert.ok(err instanceof Error);
+            assert.strictEqual(err.message, 'socket gone');
+            done();
+        });
+    });
+
+    it('errors when output becomes unwritable between ticks', done => {
+        let calls = 0;
+        const output = {
+            get writable() {
+                return calls === 0;
+            },
+            write(chunk, cb) {
+                calls++;
+                cb(null);
+            },
+        };
+        const term = new ClientTerminal(output);
+        //  Very slow rate forces multiple ticks; output goes unwritable after tick 1.
+        const data = Buffer.alloc(200, 0x41);
+        term.dripWrite(data, 10, err => {
+            assert.ok(err instanceof Error);
+            done();
+        });
+    });
+});
+
+// ─── art.display() baud rate path ─────────────────────────────────────────────
+
+describe('art.display() baud rate emulation', () => {
+    //  Plain art with no MCI codes and no ANSI escapes — purely literal text.
+    const PLAIN_ART = 'Hello BBS\r\nSecond line\r\n';
+
+    it('without baudRate: writes directly via rawWrite, cb fires synchronously', done => {
+        const client = makeMockClient();
+        display(client, PLAIN_ART, {}, (err, mciMap) => {
+            assert.ifError(err);
+            assert.ok(client.term.rawWritten.length > 0, 'expected bytes written');
+            assert.ok(typeof mciMap === 'object');
+            done();
+        });
+    });
+
+    it('with baudRate: calls dripWrite instead of rawWrite', done => {
+        let dripBuf = null;
+        let dripBytesPerSec = null;
+
+        const dripSpy = (buf, bytesPerSec, cb) => {
+            dripBuf = buf;
+            dripBytesPerSec = bytesPerSec;
+            cb(null); //  resolve immediately
+        };
+
+        const client = makeMockClient({ dripSpy });
+        display(client, PLAIN_ART, { baudRate: 2400 }, (err, mciMap) => {
+            assert.ifError(err);
+            //  dripWrite should have been called
+            assert.ok(dripBuf !== null, 'dripWrite was not called');
+            //  2400 baud → 240 bytes/sec
+            assert.strictEqual(dripBytesPerSec, 240);
+            //  The drip buffer should contain the art content
+            assert.ok(dripBuf.length > 0);
+            //  rawWrite should not have been called for art content
+            assert.strictEqual(client.term.rawWritten.length, 0);
+            assert.ok(typeof mciMap === 'object');
+            done();
+        });
+    });
+
+    it('with baudRate: cb fires only after dripWrite completes', done => {
+        const events = [];
+        const dripSpy = (_buf, _bps, cb) => {
+            events.push('dripStart');
+            setImmediate(() => {
+                events.push('dripEnd');
+                cb(null);
+            });
+        };
+
+        const client = makeMockClient({ dripSpy });
+        display(client, PLAIN_ART, { baudRate: 9600 }, err => {
+            assert.ifError(err);
+            assert.deepStrictEqual(events, ['dripStart', 'dripEnd']);
+            done();
+        });
+    });
+
+    it('with baudRate: dripWrite error is forwarded to cb', done => {
+        const dripSpy = (_buf, _bps, cb) => cb(new Error('drip failed'));
+
+        const client = makeMockClient({ dripSpy });
+        display(client, PLAIN_ART, { baudRate: 9600 }, err => {
+            assert.ok(err instanceof Error);
+            assert.strictEqual(err.message, 'drip failed');
+            done();
+        });
+    });
+
+    it('with baudRate: mciMap is still populated correctly', done => {
+        //  Art with a single MCI code embedded.
+        const artWithMci = 'Before %TI1 after\r\n';
+        const dripSpy = (_buf, _bps, cb) => cb(null);
+
+        const client = makeMockClient({ dripSpy });
+        display(client, artWithMci, { baudRate: 9600 }, (err, mciMap) => {
+            assert.ifError(err);
+            //  %TI1 → key 'TI1'
+            assert.ok('TI1' in mciMap, 'mciMap should contain TI1');
+            done();
+        });
+    });
+
+    it('baudRate 0 falls through to immediate write (no drip)', done => {
+        let dripCalled = false;
+        const dripSpy = (_buf, _bps, cb) => {
+            dripCalled = true;
+            cb(null);
+        };
+
+        const client = makeMockClient({ dripSpy });
+        display(client, PLAIN_ART, { baudRate: 0 }, err => {
+            assert.ifError(err);
+            assert.strictEqual(
+                dripCalled,
+                false,
+                'dripWrite should not be called for baudRate 0'
+            );
+            done();
+        });
+    });
+});


### PR DESCRIPTION
Replace the SyncTERM/cterm escape-sequence approach to baud emulation with a collect-and-drip mechanism that runs entirely on the server.

Previously, art.display() wrote all bytes to the socket immediately and sent a proprietary ESC sequence asking the terminal client to throttle its own rendering. This only worked in SyncTERM-compatible clients, and the rate was "sticky" — persisting across menus until another menu explicitly reset it, or the session ended.

Now, when a menu config specifies `baudRate`, art.display() collects all encoded output (literals + ANSI control sequences) into a buffer during the synchronous parse phase, then drips it to the socket at the calculated byte rate (~60fps chunk cadence) via a new ClientTerminal.dripWrite() method. The completion callback fires only after the last byte is sent, keeping MCI view setup correctly sequenced. The rate resets automatically when display ends — no escape sequence, no terminal state to clean up.

- core/client_term.js: add dripWrite(buf, bytesPerSec, cb)
- core/art.js: collect-and-drip path when options.baudRate > 0
- core/theme.js: forward baudRate through displayPreparedArt()
- core/menu_module.js: remove setEmulatedBaudRate() escape sequence from beforeArt(); baud handling is now inside art.display()
- core/ansi_term.js: remove setEmulatedBaudRate(), its export, and the emulationSpeed control code entry (no remaining callers)
- test/baud_emulation.test.js: 12 tests covering dripWrite behaviour and the art.display() baud path
- docs + WHATSNEW.md: update baudRate docs; add modem era reference table; correct beforeArt() description in menu-modules.md