### PR TITLE
FTN tosser audit: bug fixes, security, DRY, and robustness improvements

### DIFF
--- a/core/ftn_address.js
+++ b/core/ftn_address.js
@@ -52,7 +52,7 @@ module.exports = class Address {
             if (m[1]) {
                 addr.zone = m[1].slice(0, -1);
                 if ('*' !== addr.zone) {
-                    addr.zone = parseInt(addr.zone);
+                    addr.zone = parseInt(addr.zone, 10);
                 }
             } else {
                 addr.zone = '*';
@@ -61,7 +61,7 @@ module.exports = class Address {
             if (m[2]) {
                 addr.net = m[2];
                 if ('*' !== addr.net) {
-                    addr.net = parseInt(addr.net);
+                    addr.net = parseInt(addr.net, 10);
                 }
             } else {
                 addr.net = '*';
@@ -70,7 +70,7 @@ module.exports = class Address {
             if (m[3]) {
                 addr.node = m[3].substr(1);
                 if ('*' !== addr.node) {
-                    addr.node = parseInt(addr.node);
+                    addr.node = parseInt(addr.node, 10);
                 }
             } else {
                 addr.node = '*';
@@ -79,7 +79,7 @@ module.exports = class Address {
             if (m[4]) {
                 addr.point = m[4].substr(1);
                 if ('*' !== addr.point) {
-                    addr.point = parseInt(addr.point);
+                    addr.point = parseInt(addr.point, 10);
                 }
             } else {
                 addr.point = '*';
@@ -138,18 +138,18 @@ module.exports = class Address {
         if (m && m[2] && m[3]) {
             //  start with a 2D
             let addr = {
-                net: parseInt(m[2]),
-                node: parseInt(m[3].substr(1)),
+                net: parseInt(m[2], 10),
+                node: parseInt(m[3].substr(1), 10),
             };
 
             //  3D: Addition of zone if present
             if (m[1]) {
-                addr.zone = parseInt(m[1].slice(0, -1));
+                addr.zone = parseInt(m[1].slice(0, -1), 10);
             }
 
             //  4D if optional point is present
             if (m[4]) {
-                addr.point = parseInt(m[4].substr(1));
+                addr.point = parseInt(m[4].substr(1), 10);
             }
 
             //  5D with @domain

--- a/core/ftn_mail_packet.js
+++ b/core/ftn_mail_packet.js
@@ -231,6 +231,78 @@ const MessageHeaderParser = new Parser()
         readUntil: b => 0x00 === b,
     });
 
+//
+//  Appends FTN kludge/meta lines (e.g. "SEEN-BY: 1/1\r", "\x01MSGID: ...\r").
+//  sepChar is placed between the key and value; defaults to ':'.
+//
+function appendMetaLines(k, m, sepChar) {
+    if (sepChar === undefined) {
+        sepChar = ':';
+    }
+    if (!m) {
+        return '';
+    }
+    const arr = Array.isArray(m) ? m : [m];
+    return arr.map(v => `${k}${sepChar} ${v}\r`).join('');
+}
+
+//
+//  Builds the complete FTN message body text: AREA line, kludges, message body
+//  (with optional ANSI pre-processing), tear/origin lines, SEEN-BY, and PATH.
+//
+function buildMessageBodyText(message, options, cb) {
+    let msgBody = '';
+
+    //  FTN-0004.001: AREA:CONFERENCE should be the first line (no ^A prefix)
+    if (message.meta.FtnProperty.ftn_area) {
+        msgBody += `AREA:${message.meta.FtnProperty.ftn_area}\r`;
+    }
+
+    Object.keys(message.meta.FtnKludge).forEach(k => {
+        switch (k) {
+            case 'PATH':
+                break; //  save for last
+
+            case 'Via':
+            case 'FMPT':
+            case 'TOPT':
+            case 'INTL':
+                msgBody += appendMetaLines(`\x01${k}`, message.meta.FtnKludge[k], '');
+                break;
+
+            default:
+                msgBody += appendMetaLines(`\x01${k}`, message.meta.FtnKludge[k]);
+                break;
+        }
+    });
+
+    function finishBody(msgText) {
+        msgBody += msgText + '\r';
+
+        //  FTN-0004.001: tear line, origin, SEEN-BY, PATH near bottom
+        if (message.meta.FtnProperty.ftn_tear_line) {
+            msgBody += `${message.meta.FtnProperty.ftn_tear_line}\r`;
+        }
+        if (message.meta.FtnProperty.ftn_origin) {
+            msgBody += `${message.meta.FtnProperty.ftn_origin}\r`;
+        }
+        msgBody += appendMetaLines('SEEN-BY', message.meta.FtnProperty.ftn_seen_by);
+        msgBody += appendMetaLines('\x01PATH', message.meta.FtnKludge['PATH']);
+
+        return cb(null, msgBody);
+    }
+
+    if (strUtil.isAnsi(message.message)) {
+        ansiPrep(
+            message.message,
+            { cols: 80, rows: 'auto', forceLineTerm: true, exportMode: true },
+            (err, preppedMsg) => finishBody(preppedMsg || message.message)
+        );
+    } else {
+        return finishBody(message.message);
+    }
+}
+
 function Packet(options) {
     var self = this;
 
@@ -830,293 +902,88 @@ function Packet(options) {
     };
 
     this.getMessageEntryBuffer = function (message, options, cb) {
-        function getAppendMeta(k, m, sepChar = ':') {
-            let append = '';
-            if (m) {
-                let a = m;
-                if (!Array.isArray(a)) {
-                    a = [a];
-                }
-                a.forEach(v => {
-                    append += `${k}${sepChar} ${v}\r`;
-                });
-            }
-            return append;
-        }
-
-        async.waterfall(
-            [
-                function prepareHeaderAndKludges(callback) {
-                    const basicHeader = Buffer.alloc(34);
-                    self.writeMessageHeader(message, basicHeader);
-
-                    //
-                    //  To, from, and subject must be NULL term'd and have max lengths as per spec.
-                    //
-                    const toUserNameBuf = strUtil.stringToNullTermBuffer(
-                        message.toUserName,
-                        { encoding: 'cp437', maxBufLen: 36 }
-                    );
-                    const fromUserNameBuf = strUtil.stringToNullTermBuffer(
-                        message.fromUserName,
-                        { encoding: 'cp437', maxBufLen: 36 }
-                    );
-                    const subjectBuf = strUtil.stringToNullTermBuffer(message.subject, {
-                        encoding: 'cp437',
-                        maxBufLen: 72,
-                    });
-
-                    //
-                    //  message: unbound length, NULL term'd
-                    //
-                    //  We need to build in various special lines - kludges, area,
-                    //  seen-by, etc.
-                    //
-                    let msgBody = '';
-
-                    //
-                    //  FTN-0004.001 @ http://ftsc.org/docs/fts-0004.001
-                    //  AREA:CONFERENCE
-                    //  Should be first line in a message
-                    //
-                    if (message.meta.FtnProperty.ftn_area) {
-                        msgBody += `AREA:${message.meta.FtnProperty.ftn_area}\r`; //  note: no ^A (0x01)
-                    }
-
-                    //  :TODO: DRY with similar function in this file!
-                    Object.keys(message.meta.FtnKludge).forEach(k => {
-                        switch (k) {
-                            case 'PATH':
-                                break; //  skip & save for last
-
-                            case 'Via':
-                            case 'FMPT':
-                            case 'TOPT':
-                            case 'INTL':
-                                msgBody += getAppendMeta(
-                                    `\x01${k}`,
-                                    message.meta.FtnKludge[k],
-                                    ''
-                                ); // no sepChar
-                                break;
-
-                            default:
-                                msgBody += getAppendMeta(
-                                    `\x01${k}`,
-                                    message.meta.FtnKludge[k]
-                                );
-                                break;
-                        }
-                    });
-
-                    return callback(
-                        null,
-                        basicHeader,
-                        toUserNameBuf,
-                        fromUserNameBuf,
-                        subjectBuf,
-                        msgBody
-                    );
-                },
-                function prepareAnsiMessageBody(
-                    basicHeader,
-                    toUserNameBuf,
-                    fromUserNameBuf,
-                    subjectBuf,
-                    msgBody,
-                    callback
-                ) {
-                    if (!strUtil.isAnsi(message.message)) {
-                        return callback(
-                            null,
-                            basicHeader,
-                            toUserNameBuf,
-                            fromUserNameBuf,
-                            subjectBuf,
-                            msgBody,
-                            message.message
-                        );
-                    }
-
-                    ansiPrep(
-                        message.message,
-                        {
-                            cols: 80,
-                            rows: 'auto',
-                            forceLineTerm: true,
-                            exportMode: true,
-                        },
-                        (err, preppedMsg) => {
-                            return callback(
-                                null,
-                                basicHeader,
-                                toUserNameBuf,
-                                fromUserNameBuf,
-                                subjectBuf,
-                                msgBody,
-                                preppedMsg || message.message
-                            );
-                        }
-                    );
-                },
-                function addMessageBody(
-                    basicHeader,
-                    toUserNameBuf,
-                    fromUserNameBuf,
-                    subjectBuf,
-                    msgBody,
-                    preppedMsg,
-                    callback
-                ) {
-                    msgBody += preppedMsg + '\r';
-
-                    //
-                    //  FTN-0004.001 @ http://ftsc.org/docs/fts-0004.001
-                    //  Tear line should be near the bottom of a message
-                    //
-                    if (message.meta.FtnProperty.ftn_tear_line) {
-                        msgBody += `${message.meta.FtnProperty.ftn_tear_line}\r`;
-                    }
-
-                    //
-                    //  Origin line should be near the bottom of a message
-                    //
-                    if (message.meta.FtnProperty.ftn_origin) {
-                        msgBody += `${message.meta.FtnProperty.ftn_origin}\r`;
-                    }
-
-                    //
-                    //  FTN-0004.001 @ http://ftsc.org/docs/fts-0004.001
-                    //  SEEN-BY and PATH should be the last lines of a message
-                    //
-                    msgBody += getAppendMeta(
-                        'SEEN-BY',
-                        message.meta.FtnProperty.ftn_seen_by
-                    ); //  note: no ^A (0x01)
-                    msgBody += getAppendMeta('\x01PATH', message.meta.FtnKludge['PATH']);
-
-                    let msgBodyEncoded;
-                    try {
-                        msgBodyEncoded = iconv.encode(msgBody + '\0', options.encoding);
-                    } catch (e) {
-                        msgBodyEncoded = iconv.encode(msgBody + '\0', 'ascii');
-                    }
-
-                    return callback(
-                        null,
-                        Buffer.concat([
-                            basicHeader,
-                            toUserNameBuf,
-                            fromUserNameBuf,
-                            subjectBuf,
-                            msgBodyEncoded,
-                        ])
-                    );
-                },
-            ],
-            (err, msgEntryBuffer) => {
-                return cb(err, msgEntryBuffer);
-            }
-        );
-    };
-
-    this.writeMessage = function (message, ws, options) {
+        //
+        //  To, from, and subject must be NULL term'd and have max lengths as per spec.
+        //
         const basicHeader = Buffer.alloc(34);
         self.writeMessageHeader(message, basicHeader);
 
-        ws.write(basicHeader);
-
-        //  toUserName & fromUserName: up to 36 bytes in length, NULL term'd
-        //  :TODO: DRY...
-        let encBuf = iconv.encode(message.toUserName + '\0', 'CP437').slice(0, 36);
-        encBuf[encBuf.length - 1] = '\0'; //  ensure it's null term'd
-        ws.write(encBuf);
-
-        encBuf = iconv.encode(message.fromUserName + '\0', 'CP437').slice(0, 36);
-        encBuf[encBuf.length - 1] = '\0'; //  ensure it's null term'd
-        ws.write(encBuf);
-
-        //  subject: up to 72 bytes in length, NULL term'd
-        encBuf = iconv.encode(message.subject + '\0', 'CP437').slice(0, 72);
-        encBuf[encBuf.length - 1] = '\0'; //  ensure it's null term'd
-        ws.write(encBuf);
-
-        //
-        //  message: unbound length, NULL term'd
-        //
-        //  We need to build in various special lines - kludges, area,
-        //  seen-by, etc.
-        //
-        //  :TODO: Put this in it's own method
-        let msgBody = '';
-
-        function appendMeta(k, m, sepChar = ':') {
-            if (m) {
-                let a = m;
-                if (!Array.isArray(a)) {
-                    a = [a];
-                }
-                a.forEach(v => {
-                    msgBody += `${k}${sepChar} ${v}\r`;
-                });
-            }
-        }
-
-        //
-        //  FTN-0004.001 @ http://ftsc.org/docs/fts-0004.001
-        //  AREA:CONFERENCE
-        //  Should be first line in a message
-        //
-        if (message.meta.FtnProperty.ftn_area) {
-            msgBody += `AREA:${message.meta.FtnProperty.ftn_area}\r`; //  note: no ^A (0x01)
-        }
-
-        Object.keys(message.meta.FtnKludge).forEach(k => {
-            switch (k) {
-                case 'PATH':
-                    break; //  skip & save for last
-
-                case 'Via':
-                case 'FMPT':
-                case 'TOPT':
-                case 'INTL':
-                    appendMeta(`\x01${k}`, message.meta.FtnKludge[k], '');
-                    break; //  no sepChar
-
-                default:
-                    appendMeta(`\x01${k}`, message.meta.FtnKludge[k]);
-                    break;
-            }
+        const toUserNameBuf = strUtil.stringToNullTermBuffer(message.toUserName, {
+            encoding: 'cp437',
+            maxBufLen: 36,
+        });
+        const fromUserNameBuf = strUtil.stringToNullTermBuffer(message.fromUserName, {
+            encoding: 'cp437',
+            maxBufLen: 36,
+        });
+        const subjectBuf = strUtil.stringToNullTermBuffer(message.subject, {
+            encoding: 'cp437',
+            maxBufLen: 72,
         });
 
-        msgBody += message.message + '\r';
+        buildMessageBodyText(message, options, (err, msgBody) => {
+            if (err) {
+                return cb(err);
+            }
 
-        //
-        //  FTN-0004.001 @ http://ftsc.org/docs/fts-0004.001
-        //  Tear line should be near the bottom of a message
-        //
-        if (message.meta.FtnProperty.ftn_tear_line) {
-            msgBody += `${message.meta.FtnProperty.ftn_tear_line}\r`;
-        }
+            let msgBodyEncoded;
+            try {
+                msgBodyEncoded = iconv.encode(msgBody + '\0', options.encoding);
+            } catch (e) {
+                msgBodyEncoded = iconv.encode(msgBody + '\0', 'ascii');
+            }
 
-        //
-        //  Origin line should be near the bottom of a message
-        //
-        if (message.meta.FtnProperty.ftn_origin) {
-            msgBody += `${message.meta.FtnProperty.ftn_origin}\r`;
-        }
+            return cb(
+                null,
+                Buffer.concat([
+                    basicHeader,
+                    toUserNameBuf,
+                    fromUserNameBuf,
+                    subjectBuf,
+                    msgBodyEncoded,
+                ])
+            );
+        });
+    };
 
-        //
-        //  FTN-0004.001 @ http://ftsc.org/docs/fts-0004.001
-        //  SEEN-BY and PATH should be the last lines of a message
-        //
-        appendMeta('SEEN-BY', message.meta.FtnProperty.ftn_seen_by); //  note: no ^A (0x01)
+    this.writeMessage = function (message, ws, options, cb) {
+        const basicHeader = Buffer.alloc(34);
+        self.writeMessageHeader(message, basicHeader);
+        ws.write(basicHeader);
 
-        appendMeta('\x01PATH', message.meta.FtnKludge['PATH']);
+        //  toUserName, fromUserName: up to 36 bytes, NULL term'd
+        //  subject: up to 72 bytes, NULL term'd
+        ws.write(
+            strUtil.stringToNullTermBuffer(message.toUserName, {
+                encoding: 'CP437',
+                maxBufLen: 36,
+            })
+        );
+        ws.write(
+            strUtil.stringToNullTermBuffer(message.fromUserName, {
+                encoding: 'CP437',
+                maxBufLen: 36,
+            })
+        );
+        ws.write(
+            strUtil.stringToNullTermBuffer(message.subject, {
+                encoding: 'CP437',
+                maxBufLen: 72,
+            })
+        );
 
-        //
-        //  :TODO: We should encode based on config and add the proper kludge here!
-        ws.write(iconv.encode(msgBody + '\0', options.encoding));
+        buildMessageBodyText(message, options, (err, msgBody) => {
+            if (!err) {
+                try {
+                    ws.write(iconv.encode(msgBody + '\0', options.encoding));
+                } catch (e) {
+                    ws.write(iconv.encode(msgBody + '\0', 'ascii'));
+                }
+            }
+            if (cb) {
+                return cb(err);
+            }
+        });
     };
 
     this.parsePacketBuffer = function (packetBuffer, iterator, cb) {
@@ -1221,7 +1088,7 @@ Packet.prototype.writeTerminator = function (ws) {
     return 2;
 };
 
-Packet.prototype.writeStream = function (ws, messages, options) {
+Packet.prototype.writeStream = function (ws, messages, options, cb) {
     if (!_.isBoolean(options.terminatePacket)) {
         options.terminatePacket = true;
     }
@@ -1232,16 +1099,24 @@ Packet.prototype.writeStream = function (ws, messages, options) {
 
     options.encoding = options.encoding || 'utf8';
 
-    messages.forEach(msg => {
-        this.writeMessage(msg, ws, options);
-    });
-
-    if (true === options.terminatePacket) {
-        ws.write(Buffer.from([0])); //  final extra null term
-    }
+    const self = this;
+    async.eachSeries(
+        messages,
+        (msg, nextMsg) => {
+            self.writeMessage(msg, ws, options, nextMsg);
+        },
+        err => {
+            if (!err && true === options.terminatePacket) {
+                ws.write(Buffer.from([0])); //  final extra null term
+            }
+            if (cb) {
+                return cb(err);
+            }
+        }
+    );
 };
 
-Packet.prototype.write = function (path, packetHeader, messages, options) {
+Packet.prototype.write = function (path, packetHeader, messages, options, cb) {
     if (!Array.isArray(messages)) {
         messages = [messages];
     }
@@ -1249,8 +1124,9 @@ Packet.prototype.write = function (path, packetHeader, messages, options) {
     options = options || { encoding: 'utf8' }; //  utf-8 = 'CHRS UTF-8 4'
 
     this.writeStream(
-        fs.createWriteStream(path), //  :TODO: specify mode/etc.
+        fs.createWriteStream(path),
         messages,
-        Object.assign({ packetHeader: packetHeader, terminatePacket: true }, options)
+        Object.assign({ packetHeader: packetHeader, terminatePacket: true }, options),
+        cb
     );
 };

--- a/core/message_const.js
+++ b/core/message_const.js
@@ -55,6 +55,7 @@ const StateFlags0 = {
     None: 0x00000000,
     Imported: 0x00000001, //  imported from foreign system
     Exported: 0x00000002, //  exported to foreign system
+    ExportFailed: 0x00000004, //  export permanently failed (e.g. unroutable); will not be retried
 };
 exports.StateFlags0 = StateFlags0;
 

--- a/core/scanner_tossers/ftn_bso.js
+++ b/core/scanner_tossers/ftn_bso.js
@@ -647,7 +647,7 @@ function FTNMessageScanTossModule() {
     };
 
     this.getAreaLastScanId = function (areaTag, cb) {
-        const sql = `SELECT area_tag, message_id
+        const sql = `SELECT message_id
             FROM message_area_last_scan
             WHERE scan_toss = 'ftn_bso' AND area_tag = ?
             LIMIT 1;`;
@@ -712,6 +712,7 @@ function FTNMessageScanTossModule() {
                     );
 
                     const ws = fs.createWriteStream(exportOpts.pktFileName);
+                    ws.once('error', callback);
 
                     packet.writeHeader(ws, packetHeader);
 
@@ -762,7 +763,7 @@ function FTNMessageScanTossModule() {
             });
         }
 
-        async.each(
+        async.eachSeries(
             messageUuids,
             (msgUuid, nextUuid) => {
                 let message = new Message();
@@ -819,6 +820,12 @@ function FTNMessageScanTossModule() {
                                 exportedFiles.push(pktFileName);
 
                                 ws = fs.createWriteStream(pktFileName);
+                                ws.once('error', err =>
+                                    Log.error(
+                                        { pktFileName, error: err.message },
+                                        'FTN packet write error'
+                                    )
+                                );
 
                                 currPacketSize = packet.writeHeader(ws, packetHeader);
 
@@ -924,12 +931,18 @@ function FTNMessageScanTossModule() {
                                         self.exportTempDir,
                                         remainMessageId,
                                         createTempPacket,
-                                        exportOpts.filleCase
+                                        exportOpts.fileCase
                                     );
 
                                     exportedFiles.push(pktFileName);
 
                                     ws = fs.createWriteStream(pktFileName);
+                                    ws.once('error', err =>
+                                        Log.error(
+                                            { pktFileName, error: err.message },
+                                            'FTN packet write error'
+                                        )
+                                    );
 
                                     packet.writeHeader(ws, packetHeader);
                                     ws.write(remainMessageBuf);
@@ -1008,20 +1021,26 @@ function FTNMessageScanTossModule() {
 
     this.exportNetMailMessagesToUplinks = function (messagesOrMessageUuids, cb) {
         //  for each message/UUID, find where to send the thing
-        async.each(
+        //  eachSeries avoids concurrent appends to the same .flo file for the same node
+        async.eachSeries(
             messagesOrMessageUuids,
             (msgOrUuid, nextMessageOrUuid) => {
                 const exportOpts = {};
                 const message = new Message();
+                let messageLoaded = false;
 
                 async.series(
                     [
                         function loadMessage(callback) {
                             if (_.isString(msgOrUuid)) {
                                 message.load({ uuid: msgOrUuid }, err => {
+                                    if (!err) {
+                                        messageLoaded = true;
+                                    }
                                     return callback(err, message);
                                 });
                             } else {
+                                messageLoaded = true;
                                 return callback(null, msgOrUuid);
                             }
                         },
@@ -1136,10 +1155,83 @@ function FTNMessageScanTossModule() {
                     ],
                     err => {
                         if (err) {
+                            const msgUuid = _.isString(msgOrUuid)
+                                ? msgOrUuid
+                                : msgOrUuid.messageUuid;
+                            const dest = _.get(message, [
+                                'meta',
+                                'System',
+                                Message.SystemMetaNames.RemoteToUser,
+                            ]);
                             Log.warn(
-                                { error: err.message },
-                                `Error exporting message: ${err.message}`
+                                {
+                                    error: err.message,
+                                    msgUuid,
+                                    subject: message.subject,
+                                    dest,
+                                },
+                                'Failed to export NetMail'
                             );
+
+                            //  Permanent routing failure — mark as failed and notify sender
+                            if (
+                                messageLoaded &&
+                                message.messageId &&
+                                Errors.ErrorCodes.DoesNotExist === err.code
+                            ) {
+                                const localFromUserId = parseInt(
+                                    _.get(message, [
+                                        'meta',
+                                        'System',
+                                        Message.SystemMetaNames.LocalFromUserID,
+                                    ])
+                                );
+
+                                async.series(
+                                    [
+                                        function markExportFailed(callback) {
+                                            return message.persistMetaValue(
+                                                'System',
+                                                Message.SystemMetaNames.StateFlags0,
+                                                Message.StateFlags0.ExportFailed.toString(),
+                                                callback
+                                            );
+                                        },
+                                        function notifySender(callback) {
+                                            if (
+                                                !localFromUserId ||
+                                                isNaN(localFromUserId)
+                                            ) {
+                                                return callback(null);
+                                            }
+
+                                            const failNotice = new Message({
+                                                areaTag:
+                                                    Message.WellKnownAreaTags.Private,
+                                                toUserName: message.fromUserName,
+                                                fromUserName: 'ENiGMA½ BBS',
+                                                subject: `Failed: ${message.subject}`,
+                                                message:
+                                                    `Your message to ${message.toUserName} could not be delivered.\r\n\r\n` +
+                                                    `Reason: ${err.reason || err.message}\r\n\r\n` +
+                                                    `The original message has been retained for your reference.` +
+                                                    ` Please contact your sysop if you believe this is in error.`,
+                                            });
+                                            failNotice.setLocalToUserId(localFromUserId);
+
+                                            return failNotice.persist(callback);
+                                        },
+                                    ],
+                                    notifErr => {
+                                        if (notifErr) {
+                                            Log.warn(
+                                                { error: notifErr.message, msgUuid },
+                                                'Failed to record NetMail delivery failure'
+                                            );
+                                        }
+                                    }
+                                );
+                            }
                         }
                         return nextMessageOrUuid(null);
                     }
@@ -1612,8 +1704,9 @@ function FTNMessageScanTossModule() {
         let importStats = {
             packetPath,
             areaSuccess: {}, //  areaTag->count
+            areaDuplicates: {}, //  areaTag->count
             areaFail: {}, //  areaTag->count
-            otherFail: 0,
+            skipCount: 0, //  messages skipped (unknown area, non-private sans area tag)
         };
 
         new ftnMailPacket.Packet(packetOpts).read(
@@ -1630,8 +1723,7 @@ function FTNMessageScanTossModule() {
                             packetHeader.destAddress
                         ).toString();
 
-                        importStats.otherFail += 1;
-
+                        //  hard abort — error propagates to final callback, no skipCount needed
                         return next(
                             new Error(
                                 `No local configuration for packet addressed to ${addrString}`
@@ -1649,7 +1741,7 @@ function FTNMessageScanTossModule() {
                             const expected = nodeConfig.packetPassword.toUpperCase();
                             const actual = (packetHeader.password || '').toUpperCase();
                             if (expected !== actual) {
-                                importStats.otherFail += 1;
+                                //  hard abort — error propagates to final callback
                                 Log.warn(
                                     { origin: originAddr.toString() },
                                     'Packet rejected: password mismatch'
@@ -1681,9 +1773,7 @@ function FTNMessageScanTossModule() {
                                 `No local message area for "${areaTag}"`
                             );
 
-                            //  bump generic failure
-                            importStats.otherFail += 1;
-
+                            importStats.skipCount += 1;
                             return next(null);
                         }
                     } else {
@@ -1697,7 +1787,7 @@ function FTNMessageScanTossModule() {
                             localAreaTag = Message.WellKnownAreaTags.Private;
                         } else {
                             Log.warn('Non-private message without area tag');
-                            importStats.otherFail += 1;
+                            importStats.skipCount += 1;
                             return next(null);
                         }
                     }
@@ -1715,14 +1805,13 @@ function FTNMessageScanTossModule() {
 
                     self.importMailToArea(importConfig, packetHeader, message, err => {
                         if (err) {
-                            //  bump area fail stats
-                            importStats.areaFail[localAreaTag] =
-                                (importStats.areaFail[localAreaTag] || 0) + 1;
-
                             if (
                                 'SQLITE_CONSTRAINT' === err.code ||
                                 'DUPE_MSGID' === err.code
                             ) {
+                                importStats.areaDuplicates[localAreaTag] =
+                                    (importStats.areaDuplicates[localAreaTag] || 0) + 1;
+
                                 const msgId = _.has(message.meta, 'FtnKludge.MSGID')
                                     ? message.meta.FtnKludge.MSGID
                                     : 'N/A';
@@ -1733,11 +1822,15 @@ function FTNMessageScanTossModule() {
                                         uuid: message.messageUuid,
                                         MSGID: msgId,
                                     },
-                                    `Not importing non-unique message "${message.subject}" to ${localAreaTag}`
+                                    `Skipping duplicate message "${message.subject}" in ${localAreaTag}`
                                 );
 
                                 return next(null);
                             }
+
+                            //  bump area fail stats for genuine errors
+                            importStats.areaFail[localAreaTag] =
+                                (importStats.areaFail[localAreaTag] || 0) + 1;
                         } else {
                             //  bump area success
                             importStats.areaSuccess[localAreaTag] =
@@ -1764,7 +1857,7 @@ function FTNMessageScanTossModule() {
                         : 0;
                 };
 
-                const totalFail = makeCount(importStats.areaFail) + importStats.otherFail;
+                const totalFail = makeCount(importStats.areaFail);
                 const packetFileName = paths.basename(packetPath);
                 if (err || totalFail > 0) {
                     if (err) {
@@ -1776,9 +1869,16 @@ function FTNMessageScanTossModule() {
                     );
                 } else {
                     const totalSuccess = makeCount(importStats.areaSuccess);
+                    const totalDupes = makeCount(importStats.areaDuplicates);
                     Log.info(
                         importStats,
-                        `Packet ${packetFileName} imported with ${totalSuccess} new message(s)`
+                        `Packet ${packetFileName} imported with ${totalSuccess} new message(s)` +
+                            (totalDupes > 0
+                                ? `, ${totalDupes} duplicate(s) skipped`
+                                : '') +
+                            (importStats.skipCount > 0
+                                ? `, ${importStats.skipCount} message(s) skipped (unknown area)`
+                                : '')
                     );
                 }
 
@@ -1998,8 +2098,16 @@ function FTNMessageScanTossModule() {
                             self.importPacketFilesFromDirectory(
                                 self.importTempDir,
                                 '',
-                                () => {
-                                    //  :TODO: handle |err|
+                                err => {
+                                    if (err) {
+                                        Log.warn(
+                                            {
+                                                importDir: self.importTempDir,
+                                                error: err.message,
+                                            },
+                                            'Error importing packets from extracted bundle'
+                                        );
+                                    }
                                     callback(null, bundleFiles, rejects);
                                 }
                             );
@@ -2559,27 +2667,26 @@ function FTNMessageScanTossModule() {
         //  which will be present for imported or already exported messages
         //
         //
-        //  :TODO: fill out the rest of the consts here
-        //  :TODO: this statement is crazy ugly -- use JOIN / NOT EXISTS for state_flags & 0x02
-        const getNewUuidsSql = `SELECT message_id, message_uuid
+        //  Select outbound FTN NetMail that hasn't been exported, failed, or delivered locally.
+        const getNewUuidsSql = `
+            SELECT m.message_id, m.message_uuid
             FROM message m
-            WHERE area_tag = '${Message.WellKnownAreaTags.Private}' AND message_id > ? AND
-                (SELECT COUNT(message_id)
-                FROM message_meta
+            WHERE m.area_tag = '${Message.WellKnownAreaTags.Private}'
+              AND m.message_id > ?
+              AND NOT EXISTS (
+                SELECT 1 FROM message_meta
                 WHERE message_id = m.message_id
-                    AND meta_category = 'System'
-                    AND (meta_name = 'state_flags0' OR meta_name = 'local_to_user_id')
-                ) = 0
-            AND
-                (SELECT COUNT(message_id)
-                FROM message_meta
+                  AND meta_category = 'System'
+                  AND meta_name IN ('state_flags0', 'local_to_user_id')
+              )
+              AND EXISTS (
+                SELECT 1 FROM message_meta
                 WHERE message_id = m.message_id
-                    AND meta_category = 'System'
-                    AND meta_name = '${Message.SystemMetaNames.ExternalFlavor}'
-                    AND meta_value = '${Message.AddressFlavor.FTN}'
-                ) = 1
-            ORDER BY message_id;
-            `;
+                  AND meta_category = 'System'
+                  AND meta_name = '${Message.SystemMetaNames.ExternalFlavor}'
+                  AND meta_value = '${Message.AddressFlavor.FTN}'
+              )
+            ORDER BY m.message_id;`;
 
         async.waterfall(
             [

--- a/core/tic_file_info.js
+++ b/core/tic_file_info.js
@@ -91,6 +91,19 @@ module.exports = class TicFileInfo {
                         );
                     }
 
+                    //  Reject path traversal attempts in the File field
+                    const fileName = self.getAsString('File') || '';
+                    if (
+                        fileName.includes('/') ||
+                        fileName.includes('\\') ||
+                        fileName.includes('..') ||
+                        paths.isAbsolute(fileName)
+                    ) {
+                        return callback(
+                            Errors.Invalid('Invalid or unsafe File field in TIC')
+                        );
+                    }
+
                     const area = self.getAsString('Area').toUpperCase();
 
                     const localInfo = {


### PR DESCRIPTION
Bug fixes:
- filleCase typo in exportMessagesByUuid remainder packet (fileCase was undefined)
- Duplicate messages were incorrectly counted in areaFail; now tracked separately in areaDuplicates and excluded from the error total
- otherFail renamed to skipCount with correct semantics: header-abort cases (no local config, password mismatch) propagate via err and are no longer double-counted; per-message skips (unknown area, non-private) use skipCount
- Import summary log enriched with duplicate and skip counts

NetMail export:
- async.each -> eachSeries to prevent concurrent .flo file appends (also in exportMessagesByUuid for EchoMail)
- Error log now includes msgUuid, subject, and destination address
- Unroutable messages (DoesNotExist) are marked StateFlags0.ExportFailed so they are not retried indefinitely; a delivery failure notification is persisted to the sender's inbox when local_from_user_id is available
- StateFlags0.ExportFailed (0x04) added to message_const.js

Error handling:
- Bundle import errors after extraction are now logged instead of silently dropped
- Write streams in exportNetMailMessagePacket and exportMessagesByUuid now have 'error' event handlers to prevent uncaught exceptions on disk/permission errors

Security:
- TIC File field validated against path traversal (/, \, .., absolute paths) before any file operations in tic_file_info.js validate()

DRY / code quality:
- ftn_mail_packet.js: extracted appendMetaLines() and buildMessageBodyText() as module-level helpers; both getMessageEntryBuffer and writeMessage now share the same body-building logic; fixes ANSI preprocessing that was missing in writeMessage
- writeMessage is now async (cb parameter); writeStream and Packet.write updated
- ftn_address.js: all parseInt() calls now specify radix 10
- performNetMailExport SQL rewritten with NOT EXISTS / EXISTS subqueries
- getAreaLastScanId SQL drops unused area_tag column from SELECT