### PR TITLE
Hot reload: debounce, merge correctness, and robustness fixes

### DIFF
--- a/core/client.js
+++ b/core/client.js
@@ -88,7 +88,11 @@ function Client(/*input, output*/) {
     const self = this;
 
     this.user = new User();
-    this.currentThemeConfig = { info: { name: 'N/A', description: 'None' } };
+    //  Sentinel value before a real theme is loaded.  Exposes get() so the
+    //  currentTheme getter below can always call .get() unconditionally.
+    this.currentThemeConfig = {
+        get: () => ({ info: { name: 'N/A', description: 'None' } }),
+    };
     this.lastActivityTime = Date.now();
     this.menuStack = new MenuStack(this);
     this.acs = new ACS({ client: this, user: this.user });
@@ -96,23 +100,7 @@ function Client(/*input, output*/) {
 
     Object.defineProperty(this, 'currentTheme', {
         get: () => {
-            if (this.currentThemeConfig) {
-                // :TODO: clean this up: We have a ugly transition state in which we have a pure raw config vs a ConfigLoader in which get() must be called
-                try {
-                    return this.currentThemeConfig.get();
-                } catch (e) {
-                    return this.currentThemeConfig;
-                }
-            } else {
-                return {
-                    info: {
-                        name: 'N/A',
-                        author: 'N/A',
-                        description: 'N/A',
-                        group: 'N/A',
-                    },
-                };
-            }
+            return this.currentThemeConfig.get();
         },
         set: theme => {
             this.currentThemeConfig = theme;

--- a/core/config_loader.js
+++ b/core/config_loader.js
@@ -23,12 +23,24 @@ module.exports = class ConfigLoader {
         }
     ) {
         this.current = {};
+        this.rawConfig = undefined;
 
         this.hotReload = hotReload;
         this.defaultConfig = defaultConfig;
         this.defaultsCustomizer = defaultsCustomizer;
         this.onReload = onReload;
         this.keepWsc = keepWsc;
+
+        //  Coalesce rapid/burst file-change events into a single reload.
+        //  300 ms absorbs editor atomic-save patterns (write-tmp + rename = 2 events)
+        //  without feeling sluggish to operators.
+        this._scheduleReload = _.debounce(() => {
+            this._reload(this.baseConfigPath, err => {
+                if (_.isFunction(this.onReload)) {
+                    this.onReload(err);
+                }
+            });
+        }, 300);
     }
 
     init(baseConfigPath, cb) {
@@ -36,8 +48,16 @@ module.exports = class ConfigLoader {
         return this._reload(baseConfigPath, cb);
     }
 
+    //  Returns the current effective config.  When theme.js finalises a merged
+    //  theme it writes back to this.current directly; get() surfaces that value.
     get() {
         return this.current;
+    }
+
+    //  Returns the raw parsed config from disk, unaffected by any external
+    //  overlay (e.g. the theme/menu merge written to this.current by ThemeManager).
+    getRaw() {
+        return this.rawConfig !== undefined ? this.rawConfig : this.current;
     }
 
     _reload(baseConfigPath, cb) {
@@ -113,6 +133,7 @@ module.exports = class ConfigLoader {
             ],
             (err, config) => {
                 if (!err) {
+                    this.rawConfig = config;
                     this.current = config;
                 }
                 return cb(err);
@@ -200,12 +221,10 @@ module.exports = class ConfigLoader {
 
     _configFileChanged({ fileName, fileRoot }) {
         const reCachedPath = paths.join(fileRoot, fileName);
-        if (this.configPaths.includes(reCachedPath)) {
-            this._reload(this.baseConfigPath, err => {
-                if (_.isFunction(this.onReload)) {
-                    this.onReload(err, reCachedPath);
-                }
-            });
+        //  configPaths is set only after the first _resolveIncludes completes;
+        //  guard against a watcher firing during the initial async load.
+        if (this.configPaths && this.configPaths.includes(reCachedPath)) {
+            this._scheduleReload();
         }
     }
 

--- a/core/scanner_tossers/ftn_bso.js
+++ b/core/scanner_tossers/ftn_bso.js
@@ -4,6 +4,7 @@
 //  ENiGMA½
 const MessageScanTossModule = require('../msg_scan_toss_module.js').MessageScanTossModule;
 const Config = require('../config.js').get;
+const Events = require('../events.js');
 const ftnMailPacket = require('../ftn_mail_packet.js');
 const ftnUtil = require('../ftn_util.js');
 const Address = require('../ftn_address.js');
@@ -2833,6 +2834,15 @@ FTNMessageScanTossModule.prototype.startup = function (cb) {
 
     this.hasValidConfiguration({ shouldLog: true }); //  just check and log
 
+    //  Refresh cached top-level module config when config.hjson is hot-reloaded
+    this._onConfigChanged = () => {
+        const config = Config();
+        if (_.has(config, 'scannerTossers.ftn_bso')) {
+            this.moduleConfig = config.scannerTossers.ftn_bso;
+        }
+    };
+    Events.on(Events.getSystemEvents().ConfigChanged, this._onConfigChanged);
+
     let importing = false;
 
     let self = this;
@@ -2974,6 +2984,13 @@ FTNMessageScanTossModule.prototype.startup = function (cb) {
 FTNMessageScanTossModule.prototype.shutdown = function (cb) {
     Log.info('FidoNet Scanner/Tosser shutting down');
 
+    if (this._onConfigChanged) {
+        Events.removeListener(
+            Events.getSystemEvents().ConfigChanged,
+            this._onConfigChanged
+        );
+    }
+
     if (this.exportTimer) {
         this.exportTimer.clear();
     }
@@ -2997,8 +3014,6 @@ FTNMessageScanTossModule.prototype.shutdown = function (cb) {
 
         FTNMessageScanTossModule.super_.prototype.shutdown.call(this, cb);
     });
-
-    FTNMessageScanTossModule.super_.prototype.shutdown.call(this, cb);
 };
 
 //

--- a/core/theme.js
+++ b/core/theme.js
@@ -71,7 +71,14 @@ exports.ThemeManager = class ThemeManager {
                     //  all themes, so they must be reloaded
                     Events.emit(Events.getSystemEvents().MenusChanged);
 
-                    this._reloadAllThemes();
+                    this._reloadAllThemes(reloadErr => {
+                        if (reloadErr) {
+                            Log.warn(
+                                { error: reloadErr.message },
+                                'Error reloading themes after menu change'
+                            );
+                        }
+                    });
                 }
             },
         });
@@ -128,14 +135,8 @@ exports.ThemeManager = class ThemeManager {
         const themeConfig = new ConfigLoader({
             onReload: err => {
                 if (!err) {
-                    //  this particular theme has changed
-                    this._themeLoaded(themeId, themeConfig, err => {
-                        if (!err) {
-                            Events.emit(Events.getSystemEvents().ThemeChanged, {
-                                themeId,
-                            });
-                        }
-                    });
+                    //  this particular theme.hjson has changed; re-finalize and notify clients
+                    this._themeLoaded(themeId, themeConfig);
                 }
             },
         });
@@ -153,7 +154,8 @@ exports.ThemeManager = class ThemeManager {
     }
 
     _themeLoaded(themeId, themeConfig) {
-        const theme = themeConfig.get();
+        //  Validate against raw theme.hjson content, not the merged overlay
+        const theme = themeConfig.getRaw();
 
         //  do some basic validation
         //  :TODO: schema validation here
@@ -190,7 +192,9 @@ exports.ThemeManager = class ThemeManager {
         //  start out with menu.hjson
         const mergedTheme = structuredClone(this.menuConfig.get());
 
-        const theme = themeConfig.get();
+        //  Use raw theme.hjson data so re-finalizations don't read back a previously
+        //  merged overlay and double-apply theme customizations
+        const theme = themeConfig.getRaw();
 
         //  some data brought directly over
         mergedTheme.info = Object.assign({}, theme.info, { themeId });
@@ -285,8 +289,9 @@ exports.ThemeManager = class ThemeManager {
                 const menuTheme = _.get(theme, ['customization', sectionName, entryName]);
                 if (menuTheme) {
                     if (menuTheme.config) {
-                        //  :TODO: should this be _.merge() ?
-                        mergedThemeMenu.config = Object.assign(
+                        //  Deep merge so nested config objects in theme.hjson can partially
+                        //  override menu.hjson values without wiping sibling keys
+                        mergedThemeMenu.config = _.merge(
                             mergedThemeMenu.config || {},
                             menuTheme.config
                         );
@@ -392,15 +397,22 @@ exports.ThemeManager = class ThemeManager {
         };
     }
 
-    _reloadAllThemes() {
-        async.each([...this.availableThemes.keys()], (themeId, nextThemeId) => {
-            this._loadTheme(themeId, err => {
-                if (!err) {
+    _reloadAllThemes(cb) {
+        //  Re-finalize each existing theme against the updated menu config.
+        //  Reusing the existing ConfigLoader avoids spawning extra file watchers on
+        //  every menu.hjson change and keeps theme.hjson raw data intact.
+        async.each(
+            [...this.availableThemes.keys()],
+            (themeId, nextThemeId) => {
+                const themeConfig = this.availableThemes.get(themeId);
+                if (themeConfig) {
+                    this._themeLoaded(themeId, themeConfig);
                     Log.info({ themeId }, `Theme "${themeId}" reloaded`);
                 }
-                return nextThemeId(null); //  always proceed
-            });
-        });
+                return nextThemeId(null); //  always proceed; errors logged per theme
+            },
+            cb
+        );
     }
 };
 

--- a/test/config_loader.test.js
+++ b/test/config_loader.test.js
@@ -1,0 +1,172 @@
+'use strict';
+
+const { strict: assert } = require('assert');
+const paths = require('path');
+
+//  ConfigLoader has no load-time Config() dependency — require directly.
+const ConfigLoader = require('../core/config_loader');
+
+// ─── getRaw() ────────────────────────────────────────────────────────────────
+
+describe('ConfigLoader.getRaw()', () => {
+    it('returns this.current when rawConfig has not been set', () => {
+        const loader = new ConfigLoader();
+        loader.current = { foo: 'bar' };
+        assert.deepEqual(loader.getRaw(), { foo: 'bar' });
+    });
+
+    it('returns rawConfig even after current is overwritten externally', () => {
+        const loader = new ConfigLoader();
+        loader.rawConfig = { raw: true };
+        loader.current = { merged: true }; //  simulates what _finalizeTheme does
+        assert.deepEqual(loader.getRaw(), { raw: true });
+        assert.deepEqual(loader.get(), { merged: true });
+    });
+
+    it('rawConfig is populated by _reload completion', done => {
+        const loader = new ConfigLoader({ hotReload: false });
+        loader.baseConfigPath = '/fake/config.hjson';
+
+        //  Stub _loadConfigFile to avoid real FS; feed back a known config.
+        loader._loadConfigFile = (filePath, cb) => cb(null, { key: 'value' });
+        loader._resolveIncludes = (root, config, cb) => {
+            loader.configPaths = [loader.baseConfigPath];
+            return cb(null, config);
+        };
+
+        loader._reload(loader.baseConfigPath, err => {
+            assert.ifError(err);
+            assert.deepEqual(loader.rawConfig, { key: 'value' });
+            assert.deepEqual(loader.current, { key: 'value' });
+            done();
+        });
+    });
+
+    it('rawConfig survives a subsequent external write to current', done => {
+        const loader = new ConfigLoader({ hotReload: false });
+        loader.baseConfigPath = '/fake/config.hjson';
+
+        loader._loadConfigFile = (filePath, cb) => cb(null, { original: true });
+        loader._resolveIncludes = (root, config, cb) => {
+            loader.configPaths = ['/fake/config.hjson'];
+            return cb(null, config);
+        };
+
+        loader._reload(loader.baseConfigPath, err => {
+            assert.ifError(err);
+            //  Simulate what ThemeManager._finalizeTheme does
+            loader.current = { merged: true, menus: {}, original: true };
+            assert.deepEqual(loader.getRaw(), { original: true });
+            assert.deepEqual(loader.get(), { merged: true, menus: {}, original: true });
+            done();
+        });
+    });
+});
+
+// ─── _configFileChanged guard ─────────────────────────────────────────────────
+
+describe('ConfigLoader._configFileChanged()', () => {
+    it('does not throw when configPaths is undefined (guard against early watcher fire)', () => {
+        const loader = new ConfigLoader({ hotReload: false });
+        loader.baseConfigPath = '/fake/config.hjson';
+        //  configPaths intentionally NOT set — simulates watcher firing before init completes
+
+        assert.doesNotThrow(() => {
+            loader._configFileChanged({ fileName: 'config.hjson', fileRoot: '/fake' });
+        });
+    });
+
+    it('does not schedule a reload when the changed path is not tracked', () => {
+        const loader = new ConfigLoader({ hotReload: false });
+        loader.baseConfigPath = '/fake/config.hjson';
+        loader.configPaths = ['/fake/config.hjson'];
+
+        let scheduled = false;
+        loader._scheduleReload = () => {
+            scheduled = true;
+        };
+
+        loader._configFileChanged({ fileName: 'other.hjson', fileRoot: '/fake' });
+        assert.equal(scheduled, false);
+    });
+
+    it('schedules a reload when a tracked path changes', () => {
+        const loader = new ConfigLoader({ hotReload: false });
+        loader.baseConfigPath = '/fake/config.hjson';
+        loader.configPaths = ['/fake/config.hjson'];
+
+        let scheduled = false;
+        loader._scheduleReload = () => {
+            scheduled = true;
+        };
+
+        loader._configFileChanged({ fileName: 'config.hjson', fileRoot: '/fake' });
+        assert.equal(scheduled, true);
+    });
+});
+
+// ─── debounce ─────────────────────────────────────────────────────────────────
+
+describe('ConfigLoader debounce (_scheduleReload)', () => {
+    it('_scheduleReload is a lodash debounced function (has .flush and .cancel)', () => {
+        const loader = new ConfigLoader({ hotReload: false });
+        assert.equal(typeof loader._scheduleReload.flush, 'function');
+        assert.equal(typeof loader._scheduleReload.cancel, 'function');
+    });
+
+    it('coalesces multiple rapid _configFileChanged calls into a single _reload', () => {
+        const loader = new ConfigLoader({ hotReload: false });
+        loader.baseConfigPath = '/fake/config.hjson';
+        loader.configPaths = ['/fake/config.hjson'];
+
+        let reloadCount = 0;
+        //  _scheduleReload is a debounced wrapper around this._reload; replace _reload
+        //  to count invocations without doing real work.
+        loader._reload = (p, cb) => {
+            reloadCount++;
+            cb(null);
+        };
+
+        //  Trigger three rapid changes
+        loader._configFileChanged({ fileName: 'config.hjson', fileRoot: '/fake' });
+        loader._configFileChanged({ fileName: 'config.hjson', fileRoot: '/fake' });
+        loader._configFileChanged({ fileName: 'config.hjson', fileRoot: '/fake' });
+
+        //  Debounce has not fired yet
+        assert.equal(reloadCount, 0);
+
+        //  Force the pending debounced call to fire immediately
+        loader._scheduleReload.flush();
+
+        assert.equal(
+            reloadCount,
+            1,
+            'Expected exactly one _reload despite three rapid changes'
+        );
+    });
+
+    it('fires onReload callback once after debounced flush', done => {
+        let onReloadCount = 0;
+        const loader = new ConfigLoader({
+            hotReload: false,
+            onReload: () => {
+                onReloadCount++;
+            },
+        });
+        loader.baseConfigPath = '/fake/config.hjson';
+        loader.configPaths = ['/fake/config.hjson'];
+
+        loader._reload = (p, cb) => cb(null);
+
+        loader._configFileChanged({ fileName: 'config.hjson', fileRoot: '/fake' });
+        loader._configFileChanged({ fileName: 'config.hjson', fileRoot: '/fake' });
+
+        loader._scheduleReload.flush();
+
+        //  onReload is called inside the _reload callback which is sync here
+        setImmediate(() => {
+            assert.equal(onReloadCount, 1);
+            done();
+        });
+    });
+});

--- a/test/theme_merge.test.js
+++ b/test/theme_merge.test.js
@@ -1,0 +1,220 @@
+'use strict';
+
+const { strict: assert } = require('assert');
+const _ = require('lodash');
+
+//
+//  Config mock — must be in place before requiring theme.js
+//
+const configModule = require('../core/config.js');
+configModule.get = () => ({
+    debug: { assertsEnabled: false },
+    theme: {
+        passwordChar: '*',
+        dateFormat: { short: 'MM/DD/YYYY', long: 'dddd, MMMM Do YYYY' },
+        timeFormat: { short: 'h:mm a', long: 'h:mm:ss a' },
+        dateTimeFormat: {
+            short: 'MM/DD/YYYY h:mm a',
+            long: 'dddd, MMMM Do YYYY h:mm:ss a',
+        },
+        statusAvailableIndicators: ['Y', 'N'],
+        statusVisibleIndicators: ['Y', 'N'],
+    },
+    general: {},
+    paths: {},
+});
+
+const { ThemeManager } = require('../core/theme.js');
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function makeThemeManager(menuData) {
+    const tm = new ThemeManager();
+    tm.menuConfig = {
+        get: () => menuData,
+    };
+    return tm;
+}
+
+function makeThemeConfig(rawThemeData) {
+    return {
+        getRaw: () => rawThemeData,
+        get: () => rawThemeData,
+        current: null,
+    };
+}
+
+// ─── config block merge ───────────────────────────────────────────────────────
+
+describe('ThemeManager._finalizeTheme() — config block merging', () => {
+    it('deep-merges nested config objects so sibling keys are preserved', () => {
+        const menuData = {
+            menus: {
+                mainMenu: {
+                    config: {
+                        display: { style: 'bold', color: 'blue' },
+                        cls: true,
+                    },
+                },
+            },
+            prompts: {},
+        };
+
+        const themeData = {
+            info: { name: 'TestTheme', author: 'Tester', enabled: true },
+            customization: {
+                menus: {
+                    mainMenu: {
+                        config: {
+                            //  Only override color — style must survive the merge
+                            display: { color: 'red' },
+                        },
+                    },
+                },
+            },
+        };
+
+        const tm = makeThemeManager(menuData);
+        const themeConfig = makeThemeConfig(themeData);
+
+        tm._finalizeTheme('testTheme', themeConfig);
+
+        const merged = themeConfig.current;
+        assert.equal(
+            merged.menus.mainMenu.config.display.color,
+            'red',
+            'Theme override for color should be applied'
+        );
+        assert.equal(
+            merged.menus.mainMenu.config.display.style,
+            'bold',
+            'Menu base style should be preserved after deep merge'
+        );
+        assert.equal(
+            merged.menus.mainMenu.config.cls,
+            true,
+            'Other config keys at same level should be preserved'
+        );
+    });
+
+    it('shallow Object.assign behaviour (old bug) would have dropped sibling keys', () => {
+        //  This test documents the old broken behaviour to ensure we don't regress.
+        //  Object.assign({display:{style:'bold',color:'blue'}}, {display:{color:'red'}})
+        //  produces {display:{color:'red'}} — style is lost.
+        const baseConfig = { display: { style: 'bold', color: 'blue' } };
+        const themeOverride = { display: { color: 'red' } };
+        const brokenResult = Object.assign({}, baseConfig, themeOverride);
+        //  Confirm the bug: style is lost with Object.assign
+        assert.equal(brokenResult.display.style, undefined);
+
+        //  Confirm the fix: style is preserved with _.merge
+        const fixedResult = _.merge({}, baseConfig, themeOverride);
+        assert.equal(fixedResult.display.style, 'bold');
+        assert.equal(fixedResult.display.color, 'red');
+    });
+});
+
+// ─── getRaw() used for theme customization ────────────────────────────────────
+
+describe('ThemeManager._finalizeTheme() — uses getRaw() for theme data', () => {
+    it('re-finalization uses raw theme data, not a previously merged overlay', () => {
+        const menuData = {
+            menus: {
+                main: { config: { cls: false } },
+            },
+            prompts: {},
+        };
+
+        const rawThemeData = {
+            info: { name: 'T', author: 'A', enabled: true },
+            customization: {
+                menus: {
+                    main: { config: { cls: true } },
+                },
+            },
+        };
+
+        const tm = makeThemeManager(menuData);
+        const themeConfig = {
+            getRaw: () => rawThemeData,
+            //  Simulate a previously merged current that has extra junk in it
+            get: () => Object.assign({}, rawThemeData, { menus: { extra: {} } }),
+            current: null,
+        };
+
+        tm._finalizeTheme('t', themeConfig);
+
+        //  Raw theme data override should be applied
+        assert.equal(themeConfig.current.menus.main.config.cls, true);
+        //  The "extra" menu from the polluted get() result must NOT appear
+        assert.equal(themeConfig.current.menus.extra, undefined);
+    });
+});
+
+// ─── info block ───────────────────────────────────────────────────────────────
+
+describe('ThemeManager._finalizeTheme() — info block', () => {
+    it('sets info from raw theme data and injects themeId', () => {
+        const menuData = { menus: { m: {} }, prompts: {} };
+        const themeData = {
+            info: { name: 'My Theme', author: 'NuSkooler', enabled: true },
+            customization: {},
+        };
+
+        const tm = makeThemeManager(menuData);
+        const themeConfig = makeThemeConfig(themeData);
+
+        tm._finalizeTheme('myTheme', themeConfig);
+
+        assert.equal(themeConfig.current.info.name, 'My Theme');
+        assert.equal(themeConfig.current.info.author, 'NuSkooler');
+        assert.equal(themeConfig.current.info.themeId, 'myTheme');
+    });
+});
+
+// ─── MCI immutable properties ─────────────────────────────────────────────────
+
+describe('ThemeManager._finalizeTheme() — MCI immutable properties', () => {
+    it('theme cannot override maxLength on a form MCI entry', () => {
+        const menuData = {
+            menus: {
+                loginForm: {
+                    form: {
+                        0: {
+                            mci: {
+                                ET1: { maxLength: 20, textStyle: 'normal' },
+                            },
+                        },
+                    },
+                },
+            },
+            prompts: {},
+        };
+
+        const themeData = {
+            info: { name: 'T', author: 'A', enabled: true },
+            customization: {
+                menus: {
+                    loginForm: {
+                        mci: {
+                            ET1: { maxLength: 999, textStyle: 'upper' },
+                        },
+                    },
+                },
+            },
+        };
+
+        const tm = makeThemeManager(menuData);
+        const themeConfig = makeThemeConfig(themeData);
+
+        tm._finalizeTheme('t', themeConfig);
+
+        const mci = themeConfig.current.menus.loginForm.form[0].mci.ET1;
+        assert.equal(mci.maxLength, 20, 'maxLength must not be overridden by theme');
+        assert.equal(
+            mci.textStyle,
+            'upper',
+            'non-immutable property should be overridden'
+        );
+    });
+});


### PR DESCRIPTION
config_loader.js:
- Debounce _configFileChanged (300ms) to coalesce rapid/burst file-change events (editor atomic-saves, include chains) into a single reload
- Guard against watcher firing before configPaths is initialized
- Track rawConfig separately from current so getRaw() always returns the original parsed-from-disk data, unaffected by external overlays (e.g. the theme/menu merge that ThemeManager writes back to current)

theme.js:
- _finalizeTheme: use themeConfig.getRaw() for theme customization data so re-finalizations don't double-apply theme overrides from a stale previously-merged current
- _finalizeTheme: Object.assign -> _.merge for config block overrides; nested theme overrides no longer wipe sibling keys from menu.hjson (resolves the pre-existing :TODO: comment at that site)
- _themeLoaded: validate against getRaw() rather than the merged overlay
- _reloadAllThemes: re-finalize existing ConfigLoader instances instead of creating new ones on every menu.hjson reload, preventing watcher accumulation; add proper completion callback
- menuConfig.onReload: pass error-handling callback to _reloadAllThemes
- _loadTheme onReload: remove dead callback that would have emitted ThemeChanged a second time (callback arg was silently ignored by _themeLoaded's two-param signature)

client.js:
- Give the pre-theme sentinel a get() method so currentTheme getter can call .get() unconditionally; removes the try/catch duck-type hack

ftn_bso.js:
- Register ConfigChanged listener in startup() to refresh this.moduleConfig (top-level scannerTossers.ftn_bso defaults) on hot reload; clean up in shutdown()
- Remove duplicate super_.prototype.shutdown.call that was firing cb twice