### PR TITLE
Email: per-user From, body code-stripping, \Seen on failed inbound

### DIFF
--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -2,6 +2,14 @@
 This document attempts to track **major** changes and additions in ENiGMA½. For details, see GitHub.
 
 ## 0.4.0-beta
+
+* **Internet Mail (send & receive)** — users can now send and receive internet email directly from the BBS private message system, via a new `email` scanner/tosser module. See [Email Configuration](./docs/_docs/configuration/email.md) and [Internet Mail](./docs/_docs/messageareas/internet-mail.md).
+
+  * **Send**: private messages addressed to `user@domain.com` are delivered through your configured SMTP transport (Nodemailer-compatible — any provider, or service shortcut like Zoho/Fastmail).
+  * **Receive**: inbound email is pulled from a single IMAP mailbox (polling or `IMAP IDLE`) and routed to the local user whose name matches the To: local-part. Successfully imported messages are marked `\Seen` and optionally moved to `inbound.imap.processedFolder`. Unmatched / unparseable mail is preserved as `.eml` in `mail/email/failed/`, marked `\Seen` to prevent re-fetch loops, and optionally moved to `inbound.imap.failedFolder`. ENiGMA½ never deletes mail from your IMAP server — retention is up to you or your provider.
+  * **Per-user `From:` header** — when `email.outbound.fromDomain` is set, outbound mail is sent as `"UserName" <sanitized@fromDomain>` instead of the static `defaultFrom`. The SMTP `Sender:` header and envelope `MAIL FROM` are kept as the authenticated mailbox so bounces stay deliverable and receivers display the standard "on behalf of" attribution. Local-part derivation respects `users.badUserNames` — reserved names fall back to `defaultFrom`. Replacement char for invalid username characters is configurable via `email.outbound.usernameReplaceChar` (default `_`).
+  * **Signature / pipe-code stripping on export** — outbound message bodies are run through the same ANSI + MCI pipe-code stripping pipeline used by the NNTP export, so signatures render cleanly in external mail clients.
+
 * Full log viewer from WFC. Defaults to `l` key.
 
 * Major FTN compatibility fixes, especially for those wanting to run a point.
@@ -20,6 +28,7 @@ This document attempts to track **major** changes and additions in ENiGMA½. For
 
 
 ## 0.3.0-beta
+Various fixes
 
 ## 0.2.0-beta
 

--- a/core/config_default.js
+++ b/core/config_default.js
@@ -961,6 +961,14 @@ module.exports = () => {
         },
 
         email: {
+            outbound: {
+                //  When set, outbound mail From is built per-user as
+                //  "UserName" <sanitized@fromDomain>. Unset falls back to defaultFrom.
+                fromDomain: null,
+                //  Character used to replace invalid local-part characters
+                //  when deriving the local-part from a BBS username.
+                usernameReplaceChar: '_',
+            },
             inbound: {
                 enabled: false,
                 imap: {

--- a/core/scanner_tossers/email.js
+++ b/core/scanner_tossers/email.js
@@ -14,6 +14,8 @@ const { sendMail } = require('../email');
 const User = require('../user');
 const Config = require('../config').get;
 const Log = require('../logger').log;
+const { stripAnsiControlCodes } = require('../string_util');
+const { stripMciColorCodes } = require('../color_codes');
 
 //  deps
 const { ImapFlow } = require('imapflow');
@@ -125,11 +127,25 @@ exports.getModule = class EmailScannerTosser extends MessageScanTossModule {
             return;
         }
 
+        const bodyText = stripMciColorCodes(
+            stripAnsiControlCodes(message.message || '', { all: true })
+        );
+
         const mailOptions = {
             to: toAddress,
             subject: message.subject || '(no subject)',
-            text: message.message,
+            text: bodyText,
         };
+
+        const fromAddress = this._buildFromAddress(config, message.fromUserName);
+        if (fromAddress) {
+            mailOptions.from = fromAddress;
+            //  Honest third-party submission: receivers show "X on behalf of Y"
+            //  and bounces go to the authenticated mailbox rather than the user.
+            if (config.defaultFrom) {
+                mailOptions.sender = config.defaultFrom;
+            }
+        }
 
         sendMail(mailOptions, err => {
             if (err) {
@@ -150,6 +166,47 @@ exports.getModule = class EmailScannerTosser extends MessageScanTossModule {
                 () => {}
             );
         });
+    }
+
+    _buildFromAddress(emailConfig, fromUserName) {
+        const fromDomain = _.get(emailConfig, 'outbound.fromDomain');
+        if (!fromDomain || !fromUserName) {
+            return null;
+        }
+
+        const replaceChar = _.get(emailConfig, 'outbound.usernameReplaceChar', '_');
+        const localPart = this._sanitizeLocalPart(fromUserName, replaceChar);
+        if (!localPart) {
+            return null;
+        }
+
+        const bannedNames = _.get(Config(), 'users.badUserNames', []);
+        if (bannedNames.includes(localPart.toLowerCase())) {
+            this.log.warn(
+                { fromUserName, localPart },
+                'Sanitized local-part is a reserved/banned name; falling back to defaultFrom'
+            );
+            return null;
+        }
+
+        return {
+            name: fromUserName,
+            address: `${localPart}@${fromDomain}`,
+        };
+    }
+
+    _sanitizeLocalPart(name, replaceChar) {
+        //  RFC 5321 local-parts allow a broader set, but restrict to the
+        //  conservative subset (letters, digits, dot, hyphen, underscore)
+        //  that virtually every receiver handles without surprise.
+        let local = String(name).replace(/[^a-zA-Z0-9._-]+/g, replaceChar);
+        //  Trim leading/trailing separators and collapse repeats
+        local = local.replace(/^[._-]+|[._-]+$/g, '');
+        if (replaceChar) {
+            const esc = replaceChar.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+            local = local.replace(new RegExp(`${esc}{2,}`, 'g'), replaceChar);
+        }
+        return local;
     }
 
     _startInbound() {
@@ -234,22 +291,26 @@ exports.getModule = class EmailScannerTosser extends MessageScanTossModule {
 
                 for (const rawMsg of messages) {
                     const imported = await this._importMessage(rawMsg.source);
-                    if (imported) {
-                        await client.messageFlagsAdd(rawMsg.uid, ['\\Seen'], {
-                            uid: true,
-                        });
 
-                        const processedFolder = _.get(imapConfig, 'processedFolder');
-                        if (processedFolder) {
-                            await client
-                                .messageMove([rawMsg.uid], processedFolder, { uid: true })
-                                .catch(err =>
-                                    this.log.warn(
-                                        { err, processedFolder },
-                                        'Could not move message to processed folder'
-                                    )
-                                );
-                        }
+                    //  Mark seen on both success and failure so a repeatedly-
+                    //  failing message (unknown recipient, parse error) does not
+                    //  get re-fetched on every poll and duplicated into failed/.
+                    await client.messageFlagsAdd(rawMsg.uid, ['\\Seen'], {
+                        uid: true,
+                    });
+
+                    const destFolder = imported
+                        ? _.get(imapConfig, 'processedFolder')
+                        : _.get(imapConfig, 'failedFolder');
+                    if (destFolder) {
+                        await client
+                            .messageMove([rawMsg.uid], destFolder, { uid: true })
+                            .catch(err =>
+                                this.log.warn(
+                                    { err, destFolder, imported },
+                                    'Could not move message to destination folder'
+                                )
+                            );
                     }
                 }
             } finally {

--- a/docs/_docs/configuration/email.md
+++ b/docs/_docs/configuration/email.md
@@ -4,17 +4,37 @@ title: Email
 ---
 ## Email Support
 
-ENiGMA½ uses email for system notifications (password resets, 2FA registration) as well as user-to-internet email send/receive via the [Internet Mail](../messageareas/internet-mail.md) scanner/tosser.
+ENiGMA½ uses email for:
 
-Email is powered by [Nodemailer](https://nodemailer.com/about/), which supports SMTP directly as well as many pre-defined service shortcuts. The `transport` block within `email` must be Nodemailer-compatible.
+- **System notifications** — password resets, 2FA registration, account unlock flows.
+- **Internet mail** — user-to-internet email send/receive via the [Internet Mail](../messageareas/internet-mail.md) scanner/tosser.
+
+All email is powered by [Nodemailer](https://nodemailer.com/about/), which supports SMTP directly as well as many pre-defined service shortcuts (Zoho, Fastmail, Sendgrid, etc.). The `transport` block within `email` must be Nodemailer-compatible.
+
+## Configuration Reference
+
+All email configuration lives under the `email` block in `config.hjson`.
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `defaultFrom` | — | Default `From:` header, e.g. `"Sysop <sysop@yourbbs.net>"`. Also used as `Sender:` and envelope `MAIL FROM` when per-user `From:` is active. |
+| `transport` | — | Nodemailer transport options (SMTP host/port/auth, or a Nodemailer service shortcut). See examples below. |
+| `outbound.fromDomain` | *(unset)* | If set, outbound mail is sent as `"UserName" <sanitized@fromDomain>` instead of `defaultFrom`. See [Internet Mail → Outbound Configuration](../messageareas/internet-mail.md#configuration) for details and the honesty headers (`Sender:`, envelope `MAIL FROM`) it sets alongside. |
+| `outbound.usernameReplaceChar` | `_` | Replacement character for invalid local-part characters when deriving a local-part from a BBS username (e.g. spaces). |
+| `inbound` | *(disabled)* | Inbound IMAP polling configuration. See [Internet Mail → Inbound Configuration](../messageareas/internet-mail.md#inbound-configuration-reference). |
+
+> :information_source: Only `defaultFrom` and `transport` are required for system notifications (password reset, etc.). Everything under `outbound` and `inbound` is opt-in for internet-mail send/receive.
 
 ## Services
 
-If you don't have an SMTP server to send from, [Sendgrid](https://sendgrid.com/) and [Zoho](https://www.zoho.com/mail/) both provide reliable and free (or low-cost) services.
+If you don't have an SMTP server to send from, [Sendgrid](https://sendgrid.com/), [Zoho](https://www.zoho.com/mail/), [Fastmail](https://www.fastmail.com/), [Purelymail](https://purelymail.com/), and similar providers all work out of the box — both for outbound SMTP and inbound IMAP.
 
 ## Example Configurations
 
-Example 1 — SMTP:
+### Example 1 — System notifications only (SMTP)
+
+Just enough to send password-reset emails from the sysop address:
+
 ```hjson
 email: {
     defaultFrom: "Sysop <sysop@bbs.awesome.com>"
@@ -31,7 +51,8 @@ email: {
 }
 ```
 
-Example 2 — Zoho:
+### Example 2 — Nodemailer service shortcut (Zoho)
+
 ```hjson
 email: {
     defaultFrom: "Sysop <sysop@bbs.awesome.com>"
@@ -46,10 +67,55 @@ email: {
 }
 ```
 
+### Example 3 — Full internet-mail setup (per-user `From:` + inbound IMAP)
+
+```hjson
+email: {
+    defaultFrom: "ENiGMA½ BBS <noreply@yourbbs.net>"
+
+    transport: {
+        host: smtp.yourdomain.com
+        port: 587
+        requireTLS: true
+        auth: {
+            user: noreply@yourbbs.net
+            pass: yourpassword
+        }
+    }
+
+    //  Send as "<UserName>" <username@yourbbs.net> instead of defaultFrom.
+    //  Requires your SMTP provider to allow the authenticated account to
+    //  send as other local-parts within the domain.
+    outbound: {
+        fromDomain: yourbbs.net
+    }
+
+    //  Poll a shared IMAP mailbox and route mail to local users by
+    //  To: local-part (usually needs a catch-all rule at your provider).
+    inbound: {
+        enabled: true
+
+        imap: {
+            host: imap.yourdomain.com
+            port: 993
+            secure: true
+            user: noreply@yourbbs.net
+            password: yourpassword
+            pollIntervalMs: 300000
+            processedFolder: "BBS-Processed"
+            failedFolder: "BBS-Failed"
+        }
+    }
+}
+```
+
+See [Internet Mail](../messageareas/internet-mail.md) for the full reference, inbound flow details, failed-message handling, and provider-specific tips (app passwords, catch-all rules, etc.).
+
 ## Password Reset / Account Unlock
 
 If email is configured and you allow email-driven password resets, you may also allow locked accounts to be unlocked at reset time. This is controlled by `users.unlockAtEmailPwReset`. If an account is locked due to too many failed login attempts, the user can reset their password to remedy the situation themselves.
 
-## Internet Mail (Send & Receive)
+## See Also
 
-To enable users to send and receive internet email from within ENiGMA½, see [Internet Mail](../messageareas/internet-mail.md).
+- [Internet Mail](../messageareas/internet-mail.md) — full send/receive setup, inbound routing, per-user `From:` behavior
+- [Message Networks](../messageareas/message-networks.md) — overview of all supported networks

--- a/docs/_docs/messageareas/internet-mail.md
+++ b/docs/_docs/messageareas/internet-mail.md
@@ -33,6 +33,19 @@ Messages that cannot be matched to a local user are saved as `.eml` files in `ma
 
 All email configuration lives under the `email` block in `config.hjson`.
 
+### Outbound Configuration Reference
+
+| Key | Default | Description |
+|-----|---------|-------------|
+| `outbound.fromDomain` | *(unset)* | When set, outbound mail is sent as `"UserName" <sanitized@fromDomain>` where the local-part is derived from the BBS user's name. When unset, all outbound mail uses `defaultFrom`. |
+| `outbound.usernameReplaceChar` | `_` | Character used to replace invalid characters when deriving the local-part from a BBS username (e.g. spaces → `_`). |
+
+When `outbound.fromDomain` is set, the `From:` header reflects the sending BBS user while the SMTP `Sender:` header and envelope MAIL FROM are set to `defaultFrom`. This matches the standard "on behalf of" pattern used by mailing lists and keeps bounces deliverable to the authenticated mailbox.
+
+> :warning: Your SMTP provider must allow the authenticated account to send as other local-parts within the configured domain. Verify this in your provider's settings (most providers allow this for any address in a verified domain).
+
+> :information_source: The sanitized local-part is checked against `users.badUserNames` before use. If a user's sanitized name collides with a reserved name, that message falls back to `defaultFrom`.
+
 ### Inbound Configuration Reference
 
 | Key | Default | Description |
@@ -44,8 +57,11 @@ All email configuration lives under the `email` block in `config.hjson`.
 | `inbound.imap.user` | — | IMAP login username |
 | `inbound.imap.password` | — | IMAP login password |
 | `inbound.imap.pollIntervalMs` | `300000` | How often to check for new messages (ms). Set to `0` to use IMAP IDLE (push-like, persistent connection) |
-| `inbound.imap.processedFolder` | *(none)* | IMAP folder to move processed messages into. If omitted, messages are only marked `\Seen` |
+| `inbound.imap.processedFolder` | *(none)* | IMAP folder to move successfully imported messages into. If omitted, messages stay in INBOX marked `\Seen` |
+| `inbound.imap.failedFolder` | *(none)* | IMAP folder to move messages that could not be imported (unknown local recipient, parse error). If omitted, failed messages stay in INBOX marked `\Seen`. Either way, a copy is saved locally as `.eml` in `mail/email/failed/` for sysop review |
 | `inbound.imap.maxMessagesPerRun` | `50` | Maximum messages to import per poll cycle |
+
+> :information_source: **Server-side message lifecycle:** the inbound poller **marks every processed message `\Seen`** — both imports that succeeded and imports that failed. This is intentional: a message that cannot be matched (e.g. addressed to a deleted local user) would otherwise be re-fetched on every poll and duplicated into `mail/email/failed/` indefinitely. Marking seen breaks that loop. Messages are **never deleted** by ENiGMA½ — retention of `processedFolder` / `failedFolder` / INBOX is entirely up to you or your provider.
 
 ### Polling vs. IMAP IDLE
 
@@ -86,6 +102,13 @@ email: {
 email: {
     defaultFrom: "Sysop <sysop@yourbbs.net>"
 
+    //  Optional: send as "<UserName>" <username@yourbbs.net> instead of
+    //  always using defaultFrom. Requires your SMTP provider to allow
+    //  the authenticated account to send as other local-parts.
+    outbound: {
+        fromDomain: yourbbs.net
+    }
+
     transport: {
         host: smtp.yourdomain.com
         port: 587
@@ -109,8 +132,12 @@ email: {
             //  Check every 5 minutes (default)
             pollIntervalMs: 300000
 
-            //  Move imported messages here on the IMAP server
+            //  Move successfully imported messages here on the IMAP server
             processedFolder: "BBS-Processed"
+
+            //  Move messages that couldn't be matched to a local user here
+            //  (optional — defaults to leaving them in INBOX marked \Seen)
+            failedFolder: "BBS-Failed"
         }
     }
 }
@@ -175,9 +202,13 @@ email: {
 
 ## Failed Message Handling
 
-Messages that cannot be delivered to a local user (unknown username, parse error) are saved as raw `.eml` files in `mail/email/failed/`. The filename includes a timestamp and a short reason code (e.g. `1712345678901_no_user.eml`).
+Messages that cannot be delivered to a local user (unknown username, parse error) are:
 
-Sysops can inspect these files with any email client or text editor to diagnose routing issues.
+- Saved locally as raw `.eml` files in `mail/email/failed/`. The filename includes a timestamp and a short reason code (e.g. `1712345678901_no_user.eml`).
+- Marked `\Seen` on the IMAP server so they are not re-fetched on the next poll.
+- Moved to `inbound.imap.failedFolder` if configured, otherwise left in INBOX (read).
+
+Sysops can inspect the local `.eml` files with any email client or text editor to diagnose routing issues. Using `failedFolder` keeps the server-side INBOX tidy and makes it easy to re-run a message (e.g. after creating the missing local user) by moving it back into INBOX and clearing its `\Seen` flag.
 
 ## See Also
 


### PR DESCRIPTION
Outbound:
* New `email.outbound.fromDomain` — when set, outbound internet mail is sent as `"UserName" <sanitized@fromDomain>` derived from the sending BBS user instead of always using the static `defaultFrom`. The SMTP `Sender:` header and envelope MAIL FROM are set to `defaultFrom` so bounces stay deliverable to the authenticated mailbox and receivers display the standard "on behalf of" attribution. Sanitized local-parts are validated against `users.badUserNames` — reserved/banned names fall back to `defaultFrom`.
* New `email.outbound.usernameReplaceChar` (default `_`) for invalid local-part characters during sanitization.
* Outbound bodies are now run through the same ANSI + MCI pipe-code stripping pipeline as the NNTP export, so signatures render cleanly in external mail clients.

Inbound:
* Fix: every fetched message is now marked `\Seen` regardless of import outcome. Previously, a message that could not be matched to a local user (or failed to parse) stayed unseen in INBOX and was re-fetched + duplicated into `mail/email/failed/` on every poll cycle indefinitely.
* New `inbound.imap.failedFolder` — optional server-side folder to move failed imports into, mirroring `processedFolder` for the success path. Unset leaves failed messages in INBOX (read).

Docs:
* `docs/_docs/configuration/email.md` reworked with a top-level configuration reference table and a full internet-mail example.
* `docs/_docs/messageareas/internet-mail.md` gains outbound config reference, `failedFolder` docs, and a server-side retention callout (ENiGMA½ never deletes mail from your IMAP server).
* WHATSNEW entry under 0.4.0-beta.