### PR TITLE
Fix file/message FTS search broken by SQLITE_DQS=0 (better-sqlite3 v12)

### DIFF
--- a/core/file_area_list.js
+++ b/core/file_area_list.js
@@ -367,7 +367,11 @@ exports.getModule = class FileAreaList extends MenuModule {
         async.series(
             [
                 function fetchEntryData(callback) {
-                    if (self.fileList) {
+                    //  An empty array is truthy, so a previous load that
+                    //  errored (and left fileList=[]) would silently mask
+                    //  the error here. Only skip when the list is already
+                    //  populated.
+                    if (Array.isArray(self.fileList) && self.fileList.length > 0) {
                         return callback(null);
                     }
                     return self.loadFileIds(false, callback); //  false=do not force

--- a/core/file_entry.js
+++ b/core/file_entry.js
@@ -708,12 +708,13 @@ module.exports = class FileEntry {
             const [terms, queryType] = FileEntry._normalizeFileSearchTerms(filter.terms);
 
             if ('fts_match' === queryType) {
-                //  note the ':' in MATCH expr., see https://www.sqlite.org/cvstrac/wiki?p=FullTextIndex
+                //  Single-quoted: SQLITE_DQS=0 (better-sqlite3 v12) treats
+                //  double-quoted tokens as identifiers, breaking the MATCH.
                 appendWhereClause(
                     `f.file_id IN (
                         SELECT rowid
                         FROM file_fts
-                        WHERE file_fts MATCH ":${terms}"
+                        WHERE file_fts MATCH ':${terms}'
                     )`
                 );
             } else {

--- a/core/message.js
+++ b/core/message.js
@@ -457,12 +457,13 @@ module.exports = class Message {
         }
 
         if (filter.terms && filter.terms.length > 0) {
-            //  note the ':' in MATCH expr., see https://www.sqlite.org/cvstrac/wiki?p=FullTextIndex
+            //  Single-quoted: SQLITE_DQS=0 (better-sqlite3 v12) treats
+            //  double-quoted tokens as identifiers, breaking the MATCH.
             appendWhereClause(
                 `m.message_id IN (
                     SELECT rowid
                     FROM message_fts
-                    WHERE message_fts MATCH ":${sanitizeString(filter.terms)}"
+                    WHERE message_fts MATCH ':${sanitizeString(filter.terms)}'
                 )`
             );
         }

--- a/test/file_base_db.test.js
+++ b/test/file_base_db.test.js
@@ -88,6 +88,26 @@ function applySchema(db, done) {
             UNIQUE(file_id, user_id),
             FOREIGN KEY(file_id) REFERENCES file(file_id) ON DELETE CASCADE
         );
+
+        CREATE VIRTUAL TABLE IF NOT EXISTS file_fts USING fts4 (
+            content="file",
+            file_name,
+            desc,
+            desc_long
+        );
+
+        CREATE TRIGGER IF NOT EXISTS file_before_update BEFORE UPDATE ON file BEGIN
+            DELETE FROM file_fts WHERE docid=old.rowid;
+        END;
+        CREATE TRIGGER IF NOT EXISTS file_before_delete BEFORE DELETE ON file BEGIN
+            DELETE FROM file_fts WHERE docid=old.rowid;
+        END;
+        CREATE TRIGGER IF NOT EXISTS file_after_update AFTER UPDATE ON file BEGIN
+            INSERT INTO file_fts(docid, file_name, desc, desc_long) VALUES(new.rowid, new.file_name, new.desc, new.desc_long);
+        END;
+        CREATE TRIGGER IF NOT EXISTS file_after_insert AFTER INSERT ON file BEGIN
+            INSERT INTO file_fts(docid, file_name, desc, desc_long) VALUES(new.rowid, new.file_name, new.desc, new.desc_long);
+        END;
     `);
     return done(null);
 }
@@ -422,6 +442,148 @@ describe('FileEntry.loadBasicEntry() — relPath aliasing', function () {
                 assert.ifError(loadErr);
                 assert.equal(dest.relPath, null);
                 done();
+            });
+        });
+    });
+});
+
+// ─── findFiles: FTS terms search ──────────────────────────────────────────────
+//
+//  Regression guard for the SQLITE_DQS=0 bug: better-sqlite3 v12 ships SQLite
+//  with double-quoted strings parsed as identifiers, so any FTS MATCH operand
+//  built with double quotes ("…") fails as "no such column: …" rather than
+//  matching. These tests exercise the live SQL through findFiles() so a
+//  re-introduction of double-quoted MATCH operands fails immediately.
+
+describe('FileEntry.findFiles() — FTS terms search', function () {
+    before(done => applySchema(_testDb, done));
+
+    beforeEach(done => {
+        _testDb.exec('DELETE FROM file;');
+        done();
+    });
+
+    //  FileEntry's constructor only copies a fixed set of properties from
+    //  options (areaTag, fileName, storageTag, fileSha256, relPath, ...).
+    //  desc/descLong are populated post-construction in production via SAUCE
+    //  parsing — here we just assign them directly so persist() writes them.
+    function persistFile(overrides, cb) {
+        const ctorOpts = Object.assign(
+            { areaTag: 'pc_dos', fileName: 'sample.zip' },
+            overrides
+        );
+        const desc = overrides.desc !== undefined ? overrides.desc : 'short description';
+        const descLong =
+            overrides.descLong !== undefined
+                ? overrides.descLong
+                : 'long description body';
+
+        delete ctorOpts.desc;
+        delete ctorOpts.descLong;
+
+        const entry = makeEntry(ctorOpts);
+        entry.desc = desc;
+        entry.descLong = descLong;
+        entry.persist(err => cb(err, entry));
+    }
+
+    it('returns matching file_ids for a simple term in file_name', done => {
+        persistFile({ fileName: 'doom-shareware.zip', desc: 'a game' }, (err, e) => {
+            assert.ifError(err);
+            FileEntry.findFiles({ terms: 'doom' }, (findErr, ids) => {
+                assert.ifError(findErr);
+                assert.ok(Array.isArray(ids));
+                assert.ok(
+                    ids.includes(e.fileId),
+                    'matching fileId should appear in results'
+                );
+                done();
+            });
+        });
+    });
+
+    it('returns matching file_ids for a term in desc (short description)', done => {
+        persistFile(
+            { fileName: 'misc.zip', desc: 'an interactive fiction adventure' },
+            (err, e) => {
+                assert.ifError(err);
+                FileEntry.findFiles({ terms: 'adventure' }, (findErr, ids) => {
+                    assert.ifError(findErr);
+                    assert.ok(ids.includes(e.fileId));
+                    done();
+                });
+            }
+        );
+    });
+
+    it('returns matching file_ids for a term in desc_long', done => {
+        persistFile(
+            {
+                fileName: 'pkg.zip',
+                desc: 'short',
+                descLong: 'a sprawling treatise on assembly programming',
+            },
+            (err, e) => {
+                assert.ifError(err);
+                FileEntry.findFiles({ terms: 'treatise' }, (findErr, ids) => {
+                    assert.ifError(findErr);
+                    assert.ok(ids.includes(e.fileId));
+                    done();
+                });
+            }
+        );
+    });
+
+    it('returns an empty list when no rows match (not an error)', done => {
+        persistFile({ fileName: 'doom.zip' }, err => {
+            assert.ifError(err);
+            FileEntry.findFiles({ terms: 'unicorn-no-such-word' }, (findErr, ids) => {
+                assert.ifError(findErr);
+                assert.deepEqual(ids, []);
+                done();
+            });
+        });
+    });
+
+    it('rejects DQS=0 regression: bare-string MATCH must not error and must return results', done => {
+        //  Two records, both contain the term, in different fields. If the
+        //  underlying SQL quotes the FTS operand with " (DQS=0 regression),
+        //  the SqliteError "no such column" will surface here rather than a
+        //  result list.
+        persistFile({ fileName: 'alpha-doom.zip', desc: 'unrelated' }, (e1, a) => {
+            assert.ifError(e1);
+            persistFile(
+                { fileName: 'unrelated.zip', desc: 'doom inside desc' },
+                (e2, b) => {
+                    assert.ifError(e2);
+                    FileEntry.findFiles({ terms: 'doom' }, (findErr, ids) => {
+                        assert.ifError(findErr);
+                        assert.ok(ids.includes(a.fileId));
+                        assert.ok(ids.includes(b.fileId));
+                        done();
+                    });
+                }
+            );
+        });
+    });
+
+    it('combines FTS terms with an areaTag filter', done => {
+        persistFile({ areaTag: 'pc_dos', fileName: 'doom-pc.zip' }, (e1, pc) => {
+            assert.ifError(e1);
+            persistFile({ areaTag: 'amiga', fileName: 'doom-amiga.zip' }, (e2, am) => {
+                assert.ifError(e2);
+                FileEntry.findFiles(
+                    { terms: 'doom', areaTag: 'pc_dos' },
+                    (findErr, ids) => {
+                        assert.ifError(findErr);
+                        assert.ok(ids.includes(pc.fileId));
+                        assert.ok(
+                            !ids.includes(am.fileId),
+                            'amiga record must be filtered out by areaTag'
+                        );
+                        done();
+                    }
+                );
             });
         });
     });

--- a/test/message_db.test.js
+++ b/test/message_db.test.js
@@ -372,3 +372,109 @@ describe('Message.findMessages()', function () {
         });
     });
 });
+
+// ─── findMessages: FTS terms search ───────────────────────────────────────────
+//
+//  Regression guard for the SQLITE_DQS=0 bug: better-sqlite3 v12 ships SQLite
+//  with double-quoted strings parsed as identifiers, so any FTS MATCH operand
+//  built with double quotes ("…") fails with "no such column: …". These tests
+//  exercise the live SQL through findMessages() with a `terms` filter to
+//  catch a re-introduction of double-quoted MATCH operands.
+
+describe('Message.findMessages() — FTS terms search', function () {
+    before(done => applySchema(_testDb, done));
+
+    beforeEach(done => {
+        _testDb.exec('DELETE FROM message;');
+        done();
+    });
+
+    it('returns ids matching a term in subject', done => {
+        const msg = makeMessage({
+            areaTag: 'general',
+            subject: 'Doom shareware notes',
+            message: 'unrelated body',
+        });
+        msg.persist(err => {
+            assert.ifError(err);
+            Message.findMessages(
+                { resultType: 'id', areaTag: 'general', terms: 'doom' },
+                (findErr, ids) => {
+                    assert.ifError(findErr);
+                    assert.ok(Array.isArray(ids));
+                    assert.ok(ids.includes(msg.messageId));
+                    done();
+                }
+            );
+        });
+    });
+
+    it('returns ids matching a term in message body', done => {
+        const msg = makeMessage({
+            areaTag: 'general',
+            subject: 'unrelated subject',
+            message: 'Discussion of zmachine internals.',
+        });
+        msg.persist(err => {
+            assert.ifError(err);
+            Message.findMessages(
+                { resultType: 'id', areaTag: 'general', terms: 'zmachine' },
+                (findErr, ids) => {
+                    assert.ifError(findErr);
+                    assert.ok(ids.includes(msg.messageId));
+                    done();
+                }
+            );
+        });
+    });
+
+    it('returns empty array when no row matches (not an error)', done => {
+        const msg = makeMessage({
+            areaTag: 'general',
+            subject: 'something',
+            message: 'something',
+        });
+        msg.persist(err => {
+            assert.ifError(err);
+            Message.findMessages(
+                { resultType: 'id', areaTag: 'general', terms: 'unicorn-no-such-term' },
+                (findErr, ids) => {
+                    assert.ifError(findErr);
+                    assert.deepEqual(ids, []);
+                    done();
+                }
+            );
+        });
+    });
+
+    it('rejects DQS=0 regression: terms search must not raise SqliteError', done => {
+        //  Two records both containing the term in different fields. A DQS=0
+        //  regression in the MATCH clause would surface as "no such column: …"
+        //  rather than returning these rows.
+        const a = makeMessage({
+            areaTag: 'general',
+            subject: 'doom subject',
+            message: 'unrelated',
+        });
+        const b = makeMessage({
+            areaTag: 'general',
+            subject: 'unrelated',
+            message: 'doom in the body',
+        });
+        a.persist(e1 => {
+            assert.ifError(e1);
+            b.persist(e2 => {
+                assert.ifError(e2);
+                Message.findMessages(
+                    { resultType: 'id', areaTag: 'general', terms: 'doom' },
+                    (findErr, ids) => {
+                        assert.ifError(findErr);
+                        assert.ok(ids.includes(a.messageId));
+                        assert.ok(ids.includes(b.messageId));
+                        done();
+                    }
+                );
+            });
+        });
+    });
+});


### PR DESCRIPTION
The better-sqlite3 v12 migration in 5738ba10 converted SQL string literals from double to single quotes, but missed the FTS MATCH operands in findFiles() and findMessages(). Under SQLITE_DQS=0, the double-quoted operand `MATCH ":${terms}"` is parsed as a column identifier, raising "no such column: ':term'" instead of matching. Every file- and message- base search returned zero results.

The error never surfaced in logs because file_area_list.js fetchEntryData short-circuited on `if (self.fileList)`, which is truthy for the empty array left behind by the failed query — converting a thrown SqliteError into a clean (and silent) "no results" screen. Tightened to require a non-empty array so future load-time errors propagate.

Regression tests exercise the live SQL through findFiles() and findMessages() with `terms` filters; both batches fail without the single-quote fix and pass with it. Audit of remaining SQL sites for similar DQS=0 anti-patterns: only legitimate identifier quoting (`"${table}"`, `"${column}"` in database.js) remains.