### PR TITLE
ActivityPub: dedicated newscan viewer, attachment parity, hide-from-b…

### DIFF
--- a/core/activitypub/activity_pub_msg_viewer.js
+++ b/core/activitypub/activity_pub_msg_viewer.js
@@ -13,6 +13,7 @@ const {
     messageForNoteId,
 } = require('./boost_util');
 const { actorUrlToHandle } = require('./ap_search_util');
+const { formatAttachmentBlock } = require('./note');
 const Message = require('../message');
 
 // deps
@@ -335,7 +336,21 @@ exports.getModule = class ActivityPubMsgViewerModule extends MenuModule {
                 const content = note
                     ? note.content || note.name || note.summary || ''
                     : '';
-                bodyView.setText(content ? htmlToMessageBody(content) : '');
+                let body = content ? htmlToMessageBody(content) : '';
+
+                //  Append the same attachment footer the message-base
+                //  importer produces (see Note.formatAttachmentBlock), so
+                //  attachments — type, dimensions, alt text, URL — are
+                //  visible in the dedicated viewer rather than only via
+                //  the list's `*` indicator.
+                const attachmentBlock = note
+                    ? formatAttachmentBlock(note.attachment)
+                    : '';
+                if (attachmentBlock) {
+                    body += (body ? '\r\n\r\n' : '') + attachmentBlock;
+                }
+
+                bodyView.setText(body);
             }
 
             this._updateCustomViews();

--- a/core/activitypub/note.js
+++ b/core/activitypub/note.js
@@ -301,47 +301,12 @@ module.exports = class Note extends ActivityPubObject {
 
             message.areaTag = options.areaTag || Message.WellKnownAreaTags.Private;
 
-            //  List all attachments
-            if (Array.isArray(this.attachment) && this.attachment.length > 0) {
-                let attachmentInfoLines = ['--[Attachments]--'];
-                // https://socialhub.activitypub.rocks/t/representing-images/624
-                this.attachment.forEach(att => {
-                    const type = att.mediaType.substring(0, att.mediaType.indexOf('/'));
-                    switch (type) {
-                        case 'image':
-                            {
-                                let imgInfo;
-                                if (att.height && att.width) {
-                                    imgInfo = `Image (${att.width}x${att.height})`;
-                                } else {
-                                    imgInfo = 'Image';
-                                }
-                                attachmentInfoLines.push(imgInfo);
-                            }
-                            break;
-
-                        case 'audio':
-                            attachmentInfoLines.push('Audio');
-                            break;
-
-                        case 'video':
-                            attachmentInfoLines.push('Video');
-                            break;
-
-                        default:
-                            attachmentInfoLines.push(att.mediaType);
-                    }
-
-                    if (att.name) {
-                        attachmentInfoLines.push(att.name);
-                    }
-
-                    attachmentInfoLines.push(att.url);
-                    attachmentInfoLines.push('');
-                    attachmentInfoLines.push('');
-                });
-
-                message.message += '\r\n\r\n' + attachmentInfoLines.join('\r\n');
+            //  Append the human-readable attachment footer shared with the
+            //  AP viewer (see formatAttachmentBlock below).
+            //  https://socialhub.activitypub.rocks/t/representing-images/624
+            const attachmentBlock = formatAttachmentBlock(this.attachment);
+            if (attachmentBlock) {
+                message.message += '\r\n\r\n' + attachmentBlock;
             }
 
             //  If the Note is marked sensitive, prefix the subject
@@ -525,3 +490,55 @@ module.exports = class Note extends ActivityPubObject {
         message.toUserName = message.toUserName || 'All';
     }
 };
+
+//  Render the human-readable attachment footer used by the message-base
+//  importer (Note.toMessage) and the dedicated AP viewer. Both consumers
+//  must produce the same text so a user sees the same attachment block
+//  whether they read a Note via newscan/standard list or via the AP
+//  browser. Returns an empty string when there are no attachments.
+function formatAttachmentBlock(attachments) {
+    if (!Array.isArray(attachments) || attachments.length === 0) {
+        return '';
+    }
+
+    const lines = ['--[Attachments]--'];
+    attachments.forEach(att => {
+        const mediaType = (att && att.mediaType) || '';
+        const slash = mediaType.indexOf('/');
+        const type = slash > 0 ? mediaType.substring(0, slash) : mediaType;
+
+        switch (type) {
+            case 'image':
+                if (att.height && att.width) {
+                    lines.push(`Image (${att.width}x${att.height})`);
+                } else {
+                    lines.push('Image');
+                }
+                break;
+            case 'audio':
+                lines.push('Audio');
+                break;
+            case 'video':
+                lines.push('Video');
+                break;
+            default:
+                //  Fall back to the raw mediaType (e.g. application/pdf).
+                //  Empty/missing mediaType becomes a generic "Attachment"
+                //  label so the URL line still has context.
+                lines.push(mediaType || 'Attachment');
+        }
+
+        if (att && att.name) {
+            lines.push(att.name);
+        }
+        if (att && att.url) {
+            lines.push(att.url);
+        }
+        lines.push('');
+        lines.push('');
+    });
+
+    return lines.join('\r\n');
+}
+
+module.exports.formatAttachmentBlock = formatAttachmentBlock;

--- a/core/config_default.js
+++ b/core/config_default.js
@@ -960,6 +960,10 @@ module.exports = () => {
                     read: 'GM[users]SE[activitypub]AE1',
                 },
 
+                //  ActivityPub messages are reached via the dedicated AP UI
+                //  and via newscan, never the regular conf/area browse list.
+                hideFromBrowse: true,
+
                 areas: {
                     activitypub_shared: {
                         name: 'ActivityPub Public',

--- a/core/configure_newscan.js
+++ b/core/configure_newscan.js
@@ -104,13 +104,16 @@ exports.getModule = class ConfigureNewscanModule extends MenuModule {
 
         this.areaItems = [];
 
+        //  Include hideFromBrowse confs/areas (e.g. ActivityPub) so the
+        //  user can toggle them in their per-user newscan area selection.
         messageArea
-            .getSortedAvailMessageConferences(this.client)
+            .getSortedAvailMessageConferences(this.client, { includeHidden: true })
             .filter(conf => !SystemInternalConfTags.includes(conf.confTag))
             .forEach(conf => {
                 messageArea
                     .getSortedAvailMessageAreasByConfTag(conf.confTag, {
                         client: this.client,
+                        includeHidden: true,
                     })
                     .forEach(area => {
                         const selected =

--- a/core/message_area.js
+++ b/core/message_area.js
@@ -97,13 +97,21 @@ function shutdown(cb) {
 }
 
 function getAvailableMessageConferences(client, options) {
-    options = options || { includeSystemInternal: false };
+    options = options || {};
 
     assert(client || true === options.noClient);
 
     //  perform ACS check per conf & omit "System Internal" if desired
     return _.omitBy(Config().messageConferences, (conf, confTag) => {
         if (!options.includeSystemInternal && SystemInternalConfTags.includes(confTag)) {
+            return true;
+        }
+
+        //  Conferences flagged hideFromBrowse are kept out of the regular
+        //  conference/area UIs but remain available to newscan, search, etc.
+        //  Callers that should still see them (newscan, configure-newscan,
+        //  set-newscan-date) opt in with { includeHidden: true }.
+        if (!options.includeHidden && conf.hideFromBrowse === true) {
             return true;
         }
 
@@ -133,13 +141,21 @@ function getAvailableMessageAreasByConfTag(confTag, options) {
     const config = Config();
     if (_.has(config.messageConferences, [confTag, 'areas'])) {
         const areas = config.messageConferences[confTag].areas;
+        const hideFiltered = !options.includeHidden;
 
         if (!options.client || true === options.noAcsCheck) {
-            //  everything - no ACS checks
-            return areas;
+            //  No ACS checks. Still respect area-level hideFromBrowse unless
+            //  the caller opts in to seeing hidden entries.
+            if (!hideFiltered) {
+                return areas;
+            }
+            return _.omitBy(areas, area => area.hideFromBrowse === true);
         } else {
             //  perform ACS check per area
             return _.omitBy(areas, area => {
+                if (hideFiltered && area.hideFromBrowse === true) {
+                    return true;
+                }
                 return !options.client.acs.hasMessageAreaRead(area);
             });
         }

--- a/core/new_scan.js
+++ b/core/new_scan.js
@@ -69,7 +69,14 @@ exports.getModule = class NewScanModule extends MenuModule {
     newScanMessageConference(cb) {
         //  lazy init
         if (!this.sortedMessageConfs) {
-            const getAvailOpts = { includeSystemInternal: true }; //  find new private messages, bulletins, etc.
+            //  includeSystemInternal: pick up private mail, bulletins, etc.
+            //  includeHidden:         pick up confs flagged hideFromBrowse
+            //                         (e.g. ActivityPub) that are kept out of
+            //                         the regular browse UI but still scanned.
+            const getAvailOpts = {
+                includeSystemInternal: true,
+                includeHidden: true,
+            };
 
             this.sortedMessageConfs = _.map(
                 msgArea.getAvailableMessageConferences(this.client, getAvailOpts),
@@ -142,7 +149,10 @@ exports.getModule = class NewScanModule extends MenuModule {
         }
 
         const sortedAreas = msgArea
-            .getSortedAvailMessageAreasByConfTag(conf.confTag, { client: this.client })
+            .getSortedAvailMessageAreasByConfTag(conf.confTag, {
+                client: this.client,
+                includeHidden: true,
+            })
             .filter(area => {
                 if (omitMessageAreaTags.includes(area.areaTag)) {
                     return false;
@@ -221,6 +231,43 @@ exports.getModule = class NewScanModule extends MenuModule {
                             messageAreaTag: currentArea.areaTag,
                         },
                     };
+
+                    //  ActivityPub-flavored areas (e.g. activitypub_shared)
+                    //  have a dedicated browser/viewer with thread, attachment,
+                    //  and reaction handling that the standard msg_list path
+                    //  cannot replicate. Route to the AP newscan menu instead.
+                    //
+                    //  The AP browser does not maintain message-DB last-read
+                    //  state per note, so advance the area's last-read pointer
+                    //  to the current latest message before handing off; the
+                    //  next newscan cycle will then only re-fire if more notes
+                    //  arrive after this one.
+                    if (currentArea.area.addressFlavor === 'activitypub') {
+                        const targetMenu =
+                            self.menuConfig.config.newScanActivityPubList ||
+                            'newScanActivityPubList';
+                        const Message = require('./message.js');
+                        Message.findMessages(
+                            {
+                                areaTag: currentArea.areaTag,
+                                resultType: 'id',
+                                limit: 1,
+                            },
+                            (err, ids) => {
+                                if (err || !ids || ids.length === 0) {
+                                    return self.gotoMenu(targetMenu, nextModuleOpts);
+                                }
+                                msgArea.updateMessageAreaLastReadId(
+                                    self.client.user.userId,
+                                    currentArea.areaTag,
+                                    ids[0],
+                                    true /* allowOlder: noop, we always advance */,
+                                    () => self.gotoMenu(targetMenu, nextModuleOpts)
+                                );
+                            }
+                        );
+                        return;
+                    }
 
                     return self.gotoMenu(
                         self.menuConfig.config.newScanMessageList || 'newScanMessageList',

--- a/core/set_newscan_date.js
+++ b/core/set_newscan_date.js
@@ -173,10 +173,14 @@ exports.getModule = class SetNewScanDate extends MenuModule {
         //  Create an array of objects with conf/area information per entry,
         //  sorted naturally or via the 'sort' member in config
         //
+        //  Include hideFromBrowse confs/areas (e.g. ActivityPub) so users
+        //  can set a newscan floor date for them; they're scanned by newscan
+        //  even though they don't appear in the regular browse UI.
         const selections = [];
-        getSortedAvailMessageConferences(this.client).forEach(conf => {
+        getSortedAvailMessageConferences(this.client, { includeHidden: true }).forEach(conf => {
             getSortedAvailMessageAreasByConfTag(conf.confTag, {
                 client: this.client,
+                includeHidden: true,
             }).forEach(area => {
                 selections.push({
                     conf: {

--- a/misc/menu_templates/activitypub.in.hjson
+++ b/misc/menu_templates/activitypub.in.hjson
@@ -503,6 +503,42 @@
       }
     }
 
+    //  Entry point used by core newscan when it encounters a message area
+    //  whose addressFlavor is "activitypub" (e.g. activitypub_shared). Opens
+    //  the federated AP browser so the user sees the dedicated list/viewer
+    //  with thread, attachment, and reaction handling — instead of the
+    //  generic msg_list/FSE viewer that would otherwise be used.
+    newScanActivityPubList: {
+      desc: New ActivityPub Messages
+      module: ./activitypub/activity_pub_msg_list
+      config: {
+        mode: federated
+        threadMenu: activityPubThread
+        art: {
+          main: activitypub_msg_browser
+        }
+      }
+      form: {
+        0: {
+          mci: {
+            VM1: {
+              focus: true
+            }
+          }
+          actionKeys: [
+            {
+              keys: ["return", "space", "b", "l", "r", "d", "t", "+", "down arrow", "up arrow", "page up", "page down", "home", "end"]
+              action: @method:listKeyPressed
+            }
+            {
+              keys: ["escape", "q", "shift + q"]
+              action: @systemMethod:prevMenu
+            }
+          ]
+        }
+      }
+    }
+
     activityPubMsgViewer: {
       desc: ActivityPub Message Viewer
       module: ./activitypub/activity_pub_msg_viewer

--- a/test/activitypub_note.test.js
+++ b/test/activitypub_note.test.js
@@ -380,3 +380,125 @@ describe('Note.toMessage() + Message.persist() — duplicate delivery dedup', fu
         assert.equal(count, 2, 'exactly two rows in message table');
     });
 });
+
+// ─── formatAttachmentBlock — pure function ────────────────────────────────────
+//
+//  Shared formatter used by Note.toMessage() (importer) AND the dedicated AP
+//  viewer (_displayNote). Both must produce the same text so attachments look
+//  identical across the standard message-base view and the AP browser.
+
+const { formatAttachmentBlock } = require('../core/activitypub/note');
+
+describe('formatAttachmentBlock()', function () {
+    it('returns "" for missing/non-array input', () => {
+        assert.equal(formatAttachmentBlock(undefined), '');
+        assert.equal(formatAttachmentBlock(null), '');
+        assert.equal(formatAttachmentBlock([]), '');
+        assert.equal(formatAttachmentBlock('not an array'), '');
+    });
+
+    it('renders an image with width/height', () => {
+        const out = formatAttachmentBlock([
+            {
+                mediaType: 'image/jpeg',
+                width: 800,
+                height: 600,
+                name: 'A picture',
+                url: 'https://example.com/p.jpg',
+            },
+        ]);
+        assert.ok(out.startsWith('--[Attachments]--'));
+        assert.ok(out.includes('Image (800x600)'));
+        assert.ok(out.includes('A picture'));
+        assert.ok(out.includes('https://example.com/p.jpg'));
+    });
+
+    it('renders an image without dimensions as bare "Image"', () => {
+        const out = formatAttachmentBlock([
+            { mediaType: 'image/png', url: 'https://example.com/q.png' },
+        ]);
+        assert.ok(out.includes('Image'));
+        assert.ok(!out.includes('Image ('));
+    });
+
+    it('renders audio and video by type label', () => {
+        const audio = formatAttachmentBlock([
+            { mediaType: 'audio/mpeg', url: 'https://example.com/a.mp3' },
+        ]);
+        const video = formatAttachmentBlock([
+            { mediaType: 'video/mp4', url: 'https://example.com/v.mp4' },
+        ]);
+        assert.ok(audio.includes('Audio'));
+        assert.ok(video.includes('Video'));
+    });
+
+    it('falls back to the raw mediaType for other types', () => {
+        const out = formatAttachmentBlock([
+            { mediaType: 'application/pdf', url: 'https://example.com/d.pdf' },
+        ]);
+        assert.ok(out.includes('application/pdf'));
+    });
+
+    it('uses generic "Attachment" label when mediaType is missing', () => {
+        const out = formatAttachmentBlock([{ url: 'https://example.com/x' }]);
+        assert.ok(out.includes('Attachment'));
+        assert.ok(out.includes('https://example.com/x'));
+    });
+
+    it('omits the url line when url is absent', () => {
+        const out = formatAttachmentBlock([
+            { mediaType: 'image/png', width: 1, height: 1, name: 'just a label' },
+        ]);
+        assert.ok(out.includes('just a label'));
+        assert.ok(!out.includes('http'));
+    });
+
+    it('renders multiple attachments separated by blank lines', () => {
+        const out = formatAttachmentBlock([
+            { mediaType: 'image/png', url: 'https://example.com/1.png' },
+            { mediaType: 'image/jpeg', url: 'https://example.com/2.jpg' },
+        ]);
+        assert.ok(out.includes('https://example.com/1.png'));
+        assert.ok(out.includes('https://example.com/2.jpg'));
+        //  Header appears exactly once
+        assert.equal(out.split('--[Attachments]--').length - 1, 1);
+    });
+
+    it('uses CRLF line endings to match toMessage() output', () => {
+        const out = formatAttachmentBlock([
+            { mediaType: 'image/png', url: 'https://example.com/x.png' },
+        ]);
+        assert.ok(out.includes('\r\n'), 'output must use CRLF');
+    });
+});
+
+// ─── Note.toMessage — attachment footer ──────────────────────────────────────
+
+describe('Note.toMessage() — attachment footer', function () {
+    it('appends the attachment block to the message body', async () => {
+        const msg = await toMessage(
+            makeNote({
+                content: '<p>Hello body</p>',
+                attachment: [
+                    {
+                        mediaType: 'image/png',
+                        width: 320,
+                        height: 200,
+                        name: 'My alt text',
+                        url: 'https://example.com/img.png',
+                    },
+                ],
+            })
+        );
+        assert.ok(msg.message.includes('Hello body'));
+        assert.ok(msg.message.includes('--[Attachments]--'));
+        assert.ok(msg.message.includes('Image (320x200)'));
+        assert.ok(msg.message.includes('My alt text'));
+        assert.ok(msg.message.includes('https://example.com/img.png'));
+    });
+
+    it('does not append the block when attachment is missing/empty', async () => {
+        const msg = await toMessage(makeNote({ content: '<p>just text</p>' }));
+        assert.ok(!msg.message.includes('--[Attachments]--'));
+    });
+});

--- a/test/message_area.test.js
+++ b/test/message_area.test.js
@@ -1,0 +1,157 @@
+'use strict';
+
+const { strict: assert } = require('assert');
+
+//
+//  Config mock — must be in place before requiring message_area, which reads
+//  Config().messageConferences via the Config.get binding installed in setup.js.
+//
+const configModule = require('../core/config.js');
+
+//  A small fixture that exercises:
+//   - a normal conference with one regular area
+//   - a conference flagged hideFromBrowse: true with one area
+//   - a normal conference with one area flagged hideFromBrowse: true
+const TEST_CONFIG = {
+    debug: { assertsEnabled: false },
+    messageConferences: {
+        normal_conf: {
+            name: 'Normal',
+            desc: 'Regular conference',
+            areas: {
+                regular_area: { name: 'Regular', desc: 'A regular area' },
+                hidden_area: {
+                    name: 'Hidden Area',
+                    desc: 'Hidden via area-level hideFromBrowse',
+                    hideFromBrowse: true,
+                },
+            },
+        },
+        hidden_conf: {
+            name: 'Hidden Conf',
+            desc: 'Hidden via conf-level hideFromBrowse',
+            hideFromBrowse: true,
+            areas: {
+                some_area: { name: 'Some Area', desc: 'Lives inside a hidden conf' },
+            },
+        },
+    },
+};
+
+//  No client is supplied — pass { noClient: true } to bypass the assertion.
+//  ACS checks are skipped in that mode, so we test purely the hide-by-flag
+//  behavior here without dragging in a full client/ACS stack.
+//
+//  message_area.js does `const Config = require('./config.js').get` at load
+//  time — capturing whatever get function was bound then. Other test files
+//  re-bind configModule.get for their own fixtures, so we both bind it AND
+//  force a fresh require of message_area.js inside before() so this suite's
+//  config takes effect when the test bodies run.
+let messageArea;
+let previousGet;
+before(() => {
+    previousGet = configModule.get;
+    configModule.get = () => TEST_CONFIG;
+    delete require.cache[require.resolve('../core/message_area.js')];
+    messageArea = require('../core/message_area.js');
+});
+after(() => {
+    configModule.get = previousGet;
+});
+
+// ─── getAvailableMessageConferences — hideFromBrowse ─────────────────────────
+
+describe('getAvailableMessageConferences() — hideFromBrowse flag', function () {
+    it('omits hideFromBrowse confs by default', () => {
+        const confs = messageArea.getAvailableMessageConferences(null, {
+            noClient: true,
+        });
+        assert.ok('normal_conf' in confs, 'normal conf must be present');
+        assert.ok(!('hidden_conf' in confs), 'hidden_conf must be omitted');
+    });
+
+    it('includes hideFromBrowse confs when includeHidden=true', () => {
+        const confs = messageArea.getAvailableMessageConferences(null, {
+            noClient: true,
+            includeHidden: true,
+        });
+        assert.ok('normal_conf' in confs);
+        assert.ok('hidden_conf' in confs);
+    });
+
+    it('still omits SystemInternal regardless of includeHidden', () => {
+        //  SystemInternal is filtered by a separate gate; includeHidden must not
+        //  re-enable system_internal.
+        const previousConfig = TEST_CONFIG.messageConferences;
+        TEST_CONFIG.messageConferences = Object.assign({}, previousConfig, {
+            system_internal: { name: 'sys', areas: {} },
+        });
+        try {
+            const confs = messageArea.getAvailableMessageConferences(null, {
+                noClient: true,
+                includeHidden: true,
+            });
+            assert.ok(!('system_internal' in confs));
+        } finally {
+            TEST_CONFIG.messageConferences = previousConfig;
+        }
+    });
+});
+
+// ─── getAvailableMessageAreasByConfTag — hideFromBrowse ──────────────────────
+
+describe('getAvailableMessageAreasByConfTag() — hideFromBrowse flag', function () {
+    it('omits hideFromBrowse areas by default (no client)', () => {
+        const areas = messageArea.getAvailableMessageAreasByConfTag('normal_conf');
+        assert.ok('regular_area' in areas);
+        assert.ok(!('hidden_area' in areas));
+    });
+
+    it('includes hideFromBrowse areas when includeHidden=true (no client)', () => {
+        const areas = messageArea.getAvailableMessageAreasByConfTag('normal_conf', {
+            includeHidden: true,
+        });
+        assert.ok('regular_area' in areas);
+        assert.ok('hidden_area' in areas);
+    });
+
+    it('omits hideFromBrowse areas under noAcsCheck=true by default', () => {
+        const fakeClient = { acs: { hasMessageAreaRead: () => true } };
+        const areas = messageArea.getAvailableMessageAreasByConfTag('normal_conf', {
+            client: fakeClient,
+            noAcsCheck: true,
+        });
+        assert.ok('regular_area' in areas);
+        assert.ok(!('hidden_area' in areas));
+    });
+
+    it('includes hideFromBrowse areas under noAcsCheck + includeHidden', () => {
+        const fakeClient = { acs: { hasMessageAreaRead: () => true } };
+        const areas = messageArea.getAvailableMessageAreasByConfTag('normal_conf', {
+            client: fakeClient,
+            noAcsCheck: true,
+            includeHidden: true,
+        });
+        assert.ok('regular_area' in areas);
+        assert.ok('hidden_area' in areas);
+    });
+
+    it('omits hideFromBrowse areas during ACS check by default', () => {
+        const fakeClient = { acs: { hasMessageAreaRead: () => true } };
+        const areas = messageArea.getAvailableMessageAreasByConfTag('normal_conf', {
+            client: fakeClient,
+        });
+        assert.ok('regular_area' in areas);
+        assert.ok(!('hidden_area' in areas));
+    });
+
+    it('includes hideFromBrowse areas during ACS check with includeHidden', () => {
+        const fakeClient = { acs: { hasMessageAreaRead: () => true } };
+        const areas = messageArea.getAvailableMessageAreasByConfTag('normal_conf', {
+            client: fakeClient,
+            includeHidden: true,
+        });
+        assert.ok('regular_area' in areas);
+        assert.ok('hidden_area' in areas);
+    });
+});


### PR DESCRIPTION
…rowse

Three coordinated changes that make ActivityPub feel native to the BBS UI without leaking it into the regular conference/area browse path.

1) hideFromBrowse flag

   getAvailableMessageConferences and getAvailableMessageAreasByConfTag
   default-omit confs/areas with `hideFromBrowse: true`; callers that
   should still see them (newscan, configure-newscan, set-newscan-date)
   opt in via { includeHidden: true }. activitypub_internal is now
   flagged hideFromBrowse in the default config so the AP conference no
   longer appears in msg_conf_list / msg_area_list / change-conf menus
   while remaining fully scannable by newscan and tunable in the
   per-user newscan area selection UI.

2) Newscan routes AP areas to the dedicated AP browser

   When newscan finds new messages in an area whose addressFlavor is
   "activitypub", route to a new newScanActivityPubList menu (wrapping
   ./activitypub/activity_pub_msg_list in federated mode) instead of
   the generic msg_list path. Before handing off, advance the user's
   message-area last-read pointer to the latest message id in that area
   so the next newscan cycle does not re-fire the same set of notes.

3) Attachment parity in the dedicated AP viewer

   Note.toMessage's attachment-block builder is extracted into a shared
   formatAttachmentBlock(attachments) helper, which the dedicated AP
   viewer now also calls in _displayNote. Attachments are visible in
   both the standard message-base view and the AP browser instead of
   only via the list's `*` indicator. The helper additionally guards
   against missing mediaType / url, falling back to a generic
   "Attachment" label.

Tests: 20 new (1088 → 1108 passing).
- formatAttachmentBlock unit tests (empty input, image with/without dimensions, audio/video, mediaType fallback, missing url, multi- attachment, CRLF endings) and Note.toMessage integration assertions in test/activitypub_note.test.js
- hideFromBrowse filter behavior in a new test/message_area.test.js (both conf and area level, plain / noAcsCheck / ACS-checked paths, interaction with the existing SystemInternal filter)