### PR TITLE
Security hardening: PBKDF2, rate limiting, injection fixes, symlink e…

### DIFF
--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -3,6 +3,22 @@ This document attempts to track **major** changes and additions in ENiGMA½. For
 
 ## 0.4.0-beta
 
+* **Security hardening** — several security improvements across the system:
+
+  * **Stronger password hashing** — PBKDF2 iteration count raised from 1,000 to 210,000 (OWASP 2024 recommendation for PBKDF2-SHA512). Existing user passwords are transparently re-hashed to the new parameters on next successful login — no user action or migration script required. Hash parameters are now stored per-user in `pw_hash_params` so future algorithm changes can be made without a flag day.
+
+  * **Password reset token TTL** — reset tokens now expire after a configurable period (default 1 hour). Configure via `contentServers.web.resetPassword.tokenTtlMinutes` in `config.hjson`.
+
+  * **Web endpoint rate limiting** — per-IP sliding-window rate limits are now enforced on the password reset and 2FA/OTP registration endpoints (GET and POST), returning HTTP 429 when exceeded. Limits are configurable under `contentServers.web.rateLimits` (`pwResetGet`, `pwResetPost`, `otpRegGet`, `otpRegPost`); defaults are 5–10 requests per 10-minute window.
+
+  * **Command injection fix** — the `oputil ssh-key` generator now passes the key passphrase as a discrete process argument rather than interpolating it into a shell string, eliminating a shell injection vector.
+
+  * **Archive util filename injection fix** — filenames in `compressTo` are now passed as discrete arguments rather than space-joined, preventing argument injection via crafted filenames.
+
+  * **Static file symlink escape fix** — the web server's static file resolver now dereferences symlinks via `fs.realpath` before the path boundary check, preventing a symlink placed inside `staticRoot` from escaping it.
+
+  * **Config file security note** — see [Security](./docs/_docs/configuration/security.md) for guidance on protecting `config.hjson` (which contains secrets such as `privateKeyPass`) with appropriate file permissions.
+
 * **Native BinkP / FTN mailer** — built-in BinkP/1.1 implementation (inbound listener + outbound caller) that integrates directly with the existing BSO scanner/tosser. No external `binkd` or cron-driven poll script required for FidoNet-style networks. Two complementary triggers replace the old single-timer model:
 
   * **Crashmail** — when ftn_bso writes a flow file, the destination peer is dialed within ~½ second (debounced; tunable via `crashmailDebounceMs`). No more waiting for the next scheduled tick to ship outbound.

--- a/core/archive_util.js
+++ b/core/archive_util.js
@@ -239,10 +239,8 @@ module.exports = class ArchiveUtil {
 
         const fmtObj = {
             archivePath: archivePath,
-            fileList: files.join(' '), //  :TODO: probably need same hack as extractTo here!
         };
 
-        //  :TODO: DRY with extractTo()
         const args = archiver.compress.args.map(arg => {
             return '{fileList}' === arg ? arg : stringFormat(arg, fmtObj);
         });

--- a/core/config_default.js
+++ b/core/config_default.js
@@ -368,6 +368,17 @@ module.exports = () => {
                         __dirname,
                         './../www/reset_password.template.html'
                     ),
+
+                    //  how long (in minutes) a password reset token remains valid
+                    tokenTtlMinutes: 60,
+                },
+
+                //  per-IP rate limits for sensitive web endpoints
+                rateLimits: {
+                    pwResetGet: { windowMs: 10 * 60 * 1000, maxRequests: 10 },
+                    pwResetPost: { windowMs: 10 * 60 * 1000, maxRequests: 5 },
+                    otpRegGet: { windowMs: 10 * 60 * 1000, maxRequests: 10 },
+                    otpRegPost: { windowMs: 10 * 60 * 1000, maxRequests: 5 },
                 },
 
                 http: {

--- a/core/database.js
+++ b/core/database.js
@@ -14,6 +14,7 @@ const moment = require('moment');
 //  database handles
 const dbs = {};
 
+exports.getDatabasePath = getDatabasePath;
 exports.getModDatabasePath = getModDatabasePath;
 exports.loadDatabaseForMod = loadDatabaseForMod;
 exports.openDatabase = openDatabase;

--- a/core/door.js
+++ b/core/door.js
@@ -76,7 +76,6 @@ module.exports = class Door {
             srvPort: this.sockServer ? this.sockServer.address().port.toString() : '-1',
             userId: this.client.user.userId.toString(),
             userName: this.client.user.getSanitizedName(),
-            userNameRaw: this.client.user.username,
             termWidth: this.client.term.termWidth,
             termHeight: this.client.term.termHeight,
             cwd: cwd,

--- a/core/oputil/oputil_ssh_key.js
+++ b/core/oputil/oputil_ssh_key.js
@@ -16,7 +16,7 @@ const getHelpFor = require('./oputil_help.js').getHelpFor;
 //	deps
 const async = require('async');
 const fs = require('fs-extra');
-const exec = require('child_process').exec;
+const { spawn } = require('child_process');
 const inq = require('inquirer');
 
 exports.handleSSHKeyCommand = handleSSHKeyCommand;
@@ -40,16 +40,49 @@ const QUESTIONS = {
     ],
 };
 
-function execute(ui, command) {
-    exec(command, function (error) {
-        ui.log.write(error);
+function generateSSHKey(ui, targetKeyFile, passphrase, cb) {
+    //  Pipe: openssl genpkey ... | openssl rsa -passout ...
+    //  The passphrase is passed as an argument to execFile/spawn, never via a shell
+    //  string, to prevent command injection.
+    const genpkey = spawn('openssl', [
+        'genpkey',
+        '-algorithm',
+        'RSA',
+        '-pkeyopt',
+        'rsa_keygen_bits:2048',
+        '-pkeyopt',
+        'rsa_keygen_pubexp:65537',
+    ]);
 
-        if (error) {
-            const reason = error ? error.message : 'OpenSSL Error';
-            ui.log.write(`openssl command failed: ${reason}`);
-        } else {
-            ui.log.write('SSH Keys Generated');
+    const rsa = spawn('openssl', [
+        'rsa',
+        '-out',
+        `./${targetKeyFile}`,
+        '-aes128',
+        '-traditional',
+        '-passout',
+        `pass:${passphrase}`,
+    ]);
+
+    genpkey.stdout.pipe(rsa.stdin);
+
+    let errOutput = '';
+    genpkey.stderr.on('data', d => {
+        errOutput += d;
+    });
+    rsa.stderr.on('data', d => {
+        errOutput += d;
+    });
+
+    genpkey.on('error', err => cb(err));
+    rsa.on('error', err => cb(err));
+
+    rsa.on('close', code => {
+        if (code !== 0) {
+            return cb(new Error(`openssl failed (exit ${code}): ${errOutput.trim()}`));
         }
+        ui.log.write('SSH Keys Generated');
+        return cb(null);
     });
 }
 
@@ -94,8 +127,7 @@ function createNew(cb) {
                     fs.ensureDirSync(sshKeyPath);
 
                     // Create SSH Keys
-                    const command = `openssl genpkey -algorithm RSA -pkeyopt rsa_keygen_bits:2048 -pkeyopt rsa_keygen_pubexp:65537 | openssl rsa -out ./${targetKeyFile} -aes128 -traditional -passout pass:`;
-                    execute(ui, `${command}${sslPassword}`);
+                    generateSSHKey(ui, targetKeyFile, sslPassword, callback);
                 });
             },
         ],

--- a/core/servers/content/nntp.js
+++ b/core/servers/content/nntp.js
@@ -5,7 +5,11 @@
 const Log = require('../../logger.js').log;
 const { ServerModule } = require('../../server_module.js');
 const Config = require('../../config.js').get;
-const { openDatabase, getModDatabasePath } = require('../../database.js');
+const {
+    openDatabase,
+    getModDatabasePath,
+    getDatabasePath,
+} = require('../../database.js');
 const {
     getMessageAreaByTag,
     getMessageConferenceByTag,
@@ -1446,7 +1450,16 @@ function performMaintenanceTask(args, cb) {
     }
 
     try {
-        const messageDbPath = paths.join(Config().paths.db, 'message.sqlite3');
+        const messageDbPath = getDatabasePath('message');
+
+        //  ATTACH DATABASE does not support bound parameters (SQLite limitation),
+        //  so we validate the resolved path is within the expected db directory
+        //  before interpolating it into the statement.
+        const dbRoot = paths.resolve(Config().paths.db);
+        if (!paths.resolve(messageDbPath).startsWith(dbRoot + paths.sep)) {
+            throw new Error(`Resolved message DB path escapes db root: ${messageDbPath}`);
+        }
+
         nntpDatabase.db.exec(`ATTACH DATABASE "${messageDbPath}" AS msgdb;`);
 
         const info = nntpDatabase.db

--- a/core/servers/content/web.js
+++ b/core/servers/content/web.js
@@ -17,6 +17,33 @@ const forEachSeries = require('async/forEachSeries');
 const findSeries = require('async/findSeries');
 const WebLog = require('../../web_log.js');
 
+class RateLimiter {
+    constructor() {
+        //  ip+key -> array of timestamps (ms)
+        this._windows = new Map();
+    }
+
+    //  Returns true if the request is allowed, false if it exceeds the limit.
+    //  opts: { windowMs, maxRequests }
+    check(ip, key, opts) {
+        const now = Date.now();
+        const mapKey = `${ip}:${key}`;
+        let timestamps = this._windows.get(mapKey) || [];
+
+        //  Prune entries outside the current window
+        timestamps = timestamps.filter(t => now - t < opts.windowMs);
+
+        if (timestamps.length >= opts.maxRequests) {
+            this._windows.set(mapKey, timestamps);
+            return false;
+        }
+
+        timestamps.push(now);
+        this._windows.set(mapKey, timestamps);
+        return true;
+    }
+}
+
 const ModuleInfo = (exports.moduleInfo = {
     name: 'Web',
     desc: 'Web Server',
@@ -82,6 +109,7 @@ exports.getModule = class WebServerModule extends ServerModule {
         this.enableHttps = config.contentServers.web.https.enabled || false;
 
         this.routes = {};
+        this._rateLimiter = new RateLimiter();
     }
 
     logger() {
@@ -242,6 +270,25 @@ exports.getModule = class WebServerModule extends ServerModule {
         }
     }
 
+    //  Returns true if the request is within limits; false (and sends 429) if not.
+    checkRateLimit(req, resp, key, opts) {
+        const ip = req.socket.remoteAddress || 'unknown';
+        if (this._rateLimiter.check(ip, key, opts)) {
+            return true;
+        }
+        this.log.warn({ ip, key }, 'Rate limit exceeded');
+        return (this.rateLimitExceeded(resp), false);
+    }
+
+    rateLimitExceeded(resp) {
+        return this.respondWithError(
+            resp,
+            429,
+            'Too many requests.',
+            'Too Many Requests'
+        );
+    }
+
     respondWithError(resp, code, bodyText, title) {
         const customErrorPage = paths.join(
             Config().contentServers.web.staticRoot,
@@ -349,24 +396,29 @@ exports.getModule = class WebServerModule extends ServerModule {
                     tryFile
                 );
 
-                const filePath = this.resolveStaticPath(fileName);
-                fs.stat(filePath, (err, stats) => {
-                    if (err || !stats.isFile()) {
+                this.resolveStaticPath(fileName, (err, filePath) => {
+                    if (err || !filePath) {
                         return nextTryFile(null, false);
                     }
 
-                    const headers = {
-                        'Content-Type':
-                            mimeTypes.contentType(paths.basename(filePath)) ||
-                            mimeTypes.contentType('.bin'),
-                        'Content-Length': stats.size,
-                    };
+                    fs.stat(filePath, (err, stats) => {
+                        if (err || !stats.isFile()) {
+                            return nextTryFile(null, false);
+                        }
 
-                    const readStream = fs.createReadStream(filePath);
-                    resp.writeHead(200, headers);
-                    readStream.pipe(resp);
+                        const headers = {
+                            'Content-Type':
+                                mimeTypes.contentType(paths.basename(filePath)) ||
+                                mimeTypes.contentType('.bin'),
+                            'Content-Length': stats.size,
+                        };
 
-                    return nextTryFile(null, true);
+                        const readStream = fs.createReadStream(filePath);
+                        resp.writeHead(200, headers);
+                        readStream.pipe(resp);
+
+                        return nextTryFile(null, true);
+                    });
                 });
             },
             (_, wasHandled) => {
@@ -377,50 +429,79 @@ exports.getModule = class WebServerModule extends ServerModule {
 
     tryStaticRoute(req, resp, cb) {
         const fileName = req.url.substr(req.url.lastIndexOf('/', 1));
-        const filePath = this.resolveStaticPath(fileName);
 
-        if (!filePath) {
-            return cb(false);
-        }
-
-        fs.stat(filePath, (err, stats) => {
-            if (err || !stats.isFile()) {
+        this.resolveStaticPath(fileName, (err, filePath) => {
+            if (err || !filePath) {
                 return cb(false);
             }
 
-            const headers = {
-                'Content-Type':
-                    mimeTypes.contentType(paths.basename(filePath)) ||
-                    mimeTypes.contentType('.bin'),
-                'Content-Length': stats.size,
-            };
+            fs.stat(filePath, (err, stats) => {
+                if (err || !stats.isFile()) {
+                    return cb(false);
+                }
 
-            const readStream = fs.createReadStream(filePath);
-            resp.writeHead(200, headers);
-            readStream.pipe(resp);
+                const headers = {
+                    'Content-Type':
+                        mimeTypes.contentType(paths.basename(filePath)) ||
+                        mimeTypes.contentType('.bin'),
+                    'Content-Length': stats.size,
+                };
 
-            return cb(true);
+                const readStream = fs.createReadStream(filePath);
+                resp.writeHead(200, headers);
+                readStream.pipe(resp);
+
+                return cb(true);
+            });
         });
     }
 
-    resolveStaticPath(requestPath) {
+    resolveStaticPath(requestPath, cb) {
         const staticRoot = _.get(Config(), 'contentServers.web.staticRoot');
-        const path = paths.resolve(staticRoot, `.${requestPath}`);
-        if (path.startsWith(staticRoot)) {
-            return path;
+        //  Ensure the root ends with a separator so '/srv/wwwevil' can't pass
+        //  a startsWith('/srv/www') check.
+        const rootWithSep = staticRoot.endsWith(paths.sep)
+            ? staticRoot
+            : staticRoot + paths.sep;
+        const candidate = paths.resolve(staticRoot, `.${requestPath}`);
+
+        //  Lexical check first — rejects obvious traversal without touching the FS.
+        if (!candidate.startsWith(rootWithSep)) {
+            return cb(null, null);
         }
+
+        //  Dereference symlinks so a link inside staticRoot pointing outside
+        //  it cannot escape the guard.
+        fs.realpath(candidate, (err, real) => {
+            if (err) {
+                return cb(null, null); //  path doesn't exist — not found
+            }
+            return cb(null, real.startsWith(rootWithSep) ? real : null);
+        });
     }
 
-    resolveTemplatePath(path) {
-        if (paths.isAbsolute(path)) {
-            return path;
+    resolveTemplatePath(templatePath, cb) {
+        if (paths.isAbsolute(templatePath)) {
+            //  Absolute paths are operator-supplied from config; use as-is.
+            return cb(null, templatePath);
         }
 
         const staticRoot = _.get(Config(), 'contentServers.web.staticRoot');
-        const resolved = paths.resolve(staticRoot, path);
-        if (resolved.startsWith(staticRoot)) {
-            return resolved;
+        const rootWithSep = staticRoot.endsWith(paths.sep)
+            ? staticRoot
+            : staticRoot + paths.sep;
+        const candidate = paths.resolve(staticRoot, templatePath);
+
+        if (!candidate.startsWith(rootWithSep)) {
+            return cb(null, null);
         }
+
+        fs.realpath(candidate, (err, real) => {
+            if (err) {
+                return cb(null, null);
+            }
+            return cb(null, real.startsWith(rootWithSep) ? real : null);
+        });
     }
 
     routeTemplateFilePage(templatePath, preprocessCallback, resp) {

--- a/core/servers/content/web_handlers/activitypub.js
+++ b/core/servers/content/web_handlers/activitypub.js
@@ -1586,34 +1586,44 @@ exports.getModule = class ActivityPubWebHandler extends WebHandlerModule {
     }
 
     _selfAsProfileHandler(localUser, localActor, req, resp) {
-        let templateFile = _.get(
+        const configuredTemplate = _.get(
             Config(),
             'contentServers.web.handlers.activityPub.selfTemplate'
         );
-        if (templateFile) {
-            templateFile = this.webServer.resolveTemplatePath(templateFile);
+
+        const renderProfile = templateFile => {
+            // we'll fall back to the same default profile info as the WebFinger profile
+            getUserProfileTemplatedBody(
+                templateFile,
+                localUser,
+                localActor,
+                DefaultProfileTemplate,
+                'text/html',
+                (err, body, contentType) => {
+                    if (err) {
+                        return this.webServer.resourceNotFound(resp);
+                    }
+
+                    this.log.info(
+                        { username: localUser.username },
+                        `Serving ActivityPub Profile for "${localUser.username}"`
+                    );
+
+                    return this.webServer.ok(resp, body, { 'Content-Type': contentType });
+                }
+            );
+        };
+
+        if (configuredTemplate) {
+            return this.webServer.resolveTemplatePath(
+                configuredTemplate,
+                (err, templateFile) => {
+                    return renderProfile(templateFile);
+                }
+            );
         }
 
-        // we'll fall back to the same default profile info as the WebFinger profile
-        getUserProfileTemplatedBody(
-            templateFile,
-            localUser,
-            localActor,
-            DefaultProfileTemplate,
-            'text/html',
-            (err, body, contentType) => {
-                if (err) {
-                    return this.webServer.resourceNotFound(resp);
-                }
-
-                this.log.info(
-                    { username: localUser.username },
-                    `Serving ActivityPub Profile for "${localUser.username}"`
-                );
-
-                return this.webServer.ok(resp, body, { 'Content-Type': contentType });
-            }
-        );
+        return renderProfile(null);
     }
 
     _prepareNewUserAsActor(user, cb) {

--- a/core/servers/content/web_handlers/webfinger.js
+++ b/core/servers/content/web_handlers/webfinger.js
@@ -95,40 +95,49 @@ exports.getModule = class WebFingerWebHandler extends WebHandlerModule {
                 return this.webServer.resourceNotFound(resp);
             }
 
-            let templateFile = _.get(
+            const configuredTemplate = _.get(
                 Config(),
                 'contentServers.web.handlers.webFinger.profileTemplate'
             );
-            if (templateFile) {
-                templateFile = this.webServer.resolveTemplatePath(templateFile);
-            }
 
-            Actor.fromLocalUser(localUser, (err, localActor) => {
-                if (err) {
-                    return this.webServer.internalServerError(resp, err);
-                }
+            const continueWithTemplate = templateFile => {
+                Actor.fromLocalUser(localUser, (err, localActor) => {
+                    if (err) {
+                        return this.webServer.internalServerError(resp, err);
+                    }
 
-                getUserProfileTemplatedBody(
-                    templateFile,
-                    localUser,
-                    localActor,
-                    DefaultProfileTemplate,
-                    'text/html',
-                    (err, body, contentType) => {
-                        if (err) {
-                            return this.webServer.resourceNotFound(resp);
+                    getUserProfileTemplatedBody(
+                        templateFile,
+                        localUser,
+                        localActor,
+                        DefaultProfileTemplate,
+                        'text/html',
+                        (err, body, contentType) => {
+                            if (err) {
+                                return this.webServer.resourceNotFound(resp);
+                            }
+
+                            const headers = {
+                                'Content-Type': contentType,
+                                'Content-Length': Buffer.from(body).length,
+                            };
+
+                            resp.writeHead(200, headers);
+                            return resp.end(body);
                         }
+                    );
+                });
+            };
 
-                        const headers = {
-                            'Content-Type': contentType,
-                            'Content-Length': Buffer.from(body).length,
-                        };
-
-                        resp.writeHead(200, headers);
-                        return resp.end(body);
+            if (configuredTemplate) {
+                return this.webServer.resolveTemplatePath(
+                    configuredTemplate,
+                    (err, templateFile) => {
+                        return continueWithTemplate(templateFile);
                     }
                 );
-            });
+            }
+            return continueWithTemplate(null);
         });
     }
 

--- a/core/user.js
+++ b/core/user.js
@@ -49,8 +49,19 @@ module.exports = class User {
 
     static get PBKDF2() {
         return {
-            //  :TODO: bump up iterations for all new PWs
+            iterations: 210000,
+            digest: 'sha512',
+            keyLen: 64,
+            saltLen: 32,
+        };
+    }
+
+    //  Params used by hashes created before PassHashParams was stored.
+    //  Absence of PassHashParams on a user record implies these values.
+    static get LegacyPBKDF2() {
+        return {
             iterations: 1000,
+            digest: 'sha1',
             keyLen: 128,
             saltLen: 32,
         };
@@ -58,7 +69,12 @@ module.exports = class User {
 
     static get StandardPropertyGroups() {
         return {
-            auth: [UserProps.PassPbkdf2Salt, UserProps.PassPbkdf2Dk, UserProps.SSHPubKey],
+            auth: [
+                UserProps.PassPbkdf2Salt,
+                UserProps.PassPbkdf2Dk,
+                UserProps.SSHPubKey,
+                UserProps.PassHashParams,
+            ],
         };
     }
 
@@ -94,17 +110,11 @@ module.exports = class User {
     hasValidPasswordProperties() {
         const salt = this.getProperty(UserProps.PassPbkdf2Salt);
         const dk = this.getProperty(UserProps.PassPbkdf2Dk);
-
-        if (
-            !salt ||
-            !dk ||
-            salt.length !== User.PBKDF2.saltLen * 2 ||
-            dk.length !== User.PBKDF2.keyLen * 2
-        ) {
-            return false;
-        }
-
-        return true;
+        //  Lengths are intentionally not checked against the current PBKDF2
+        //  target here — legacy hashes use a different keyLen and would fail
+        //  that assertion. The actual key lengths are validated at auth time
+        //  using the per-user PassHashParams.
+        return !!(salt && dk && salt.length > 0 && dk.length > 0);
     }
 
     isRoot() {
@@ -261,25 +271,80 @@ module.exports = class User {
         const tempAuthInfo = {};
 
         const validatePassword = (props, callback) => {
+            const hashParams = User.getHashParams(props);
             User.generatePasswordDerivedKey(
                 authInfo.password,
                 props[UserProps.PassPbkdf2Salt],
+                hashParams,
                 (err, dk) => {
                     if (err) {
                         return callback(err);
                     }
 
-                    //
-                    //  Use constant time comparison here for security feel-goods
-                    //
                     const passDkBuf = Buffer.from(dk, 'hex');
                     const propsDkBuf = Buffer.from(props[UserProps.PassPbkdf2Dk], 'hex');
 
-                    return callback(
-                        crypto.timingSafeEqual(passDkBuf, propsDkBuf)
-                            ? null
-                            : Errors.AccessDenied('Invalid password')
-                    );
+                    //  timingSafeEqual requires equal-length buffers; length mismatch
+                    //  means stored params don't match what we derived — treat as failure.
+                    if (
+                        passDkBuf.length !== propsDkBuf.length ||
+                        !crypto.timingSafeEqual(passDkBuf, propsDkBuf)
+                    ) {
+                        return callback(Errors.AccessDenied('Invalid password'));
+                    }
+
+                    //  Upgrade legacy hashes transparently on successful login.
+                    //  setImmediate defers past the current call stack — loadProperties
+                    //  is synchronous (better-sqlite3), so without deferral async's
+                    //  waterfall double-call guard trips on the initProps step.
+                    if (User.needsRehash(props)) {
+                        const oldParams = User.getHashParams(props);
+                        Log.info(
+                            {
+                                userId: tempAuthInfo.userId,
+                                username: tempAuthInfo.username,
+                                fromParams: {
+                                    digest: oldParams.digest,
+                                    iterations: oldParams.iterations,
+                                    keyLen: oldParams.keyLen,
+                                },
+                                toParams: {
+                                    digest: User.PBKDF2.digest,
+                                    iterations: User.PBKDF2.iterations,
+                                    keyLen: User.PBKDF2.keyLen,
+                                },
+                            },
+                            'Upgrading password hash to current parameters'
+                        );
+                        setImmediate(() => {
+                            User.rehashPassword(
+                                tempAuthInfo.userId,
+                                authInfo.password,
+                                rehashErr => {
+                                    if (rehashErr) {
+                                        Log.warn(
+                                            {
+                                                error: rehashErr.message,
+                                                userId: tempAuthInfo.userId,
+                                                username: tempAuthInfo.username,
+                                            },
+                                            'Failed to upgrade password hash; will retry on next login'
+                                        );
+                                    } else {
+                                        Log.info(
+                                            {
+                                                userId: tempAuthInfo.userId,
+                                                username: tempAuthInfo.username,
+                                            },
+                                            'Password hash upgrade complete'
+                                        );
+                                    }
+                                }
+                            );
+                        });
+                    }
+
+                    return callback(null);
                 }
             );
         };
@@ -316,7 +381,7 @@ module.exports = class User {
                 return callback(Errors.AccessDenied('Invalid public key'));
             }
 
-            if (authInfo.pubKey.key.algo != pubKeyActual.type) {
+            if (authInfo.pubKey.key.algo !== pubKeyActual.type) {
                 return callback(Errors.AccessDenied('Invalid public key'));
             }
 
@@ -523,6 +588,9 @@ module.exports = class User {
                             }
                             self.properties[UserProps.PassPbkdf2Salt] = info.salt;
                             self.properties[UserProps.PassPbkdf2Dk] = info.dk;
+                            self.properties[UserProps.PassHashParams] = JSON.stringify(
+                                User.PBKDF2
+                            );
                             return callback(null);
                         }
                     );
@@ -824,6 +892,7 @@ module.exports = class User {
             const newProperties = {
                 [UserProps.PassPbkdf2Salt]: info.salt,
                 [UserProps.PassPbkdf2Dk]: info.dk,
+                [UserProps.PassHashParams]: JSON.stringify(User.PBKDF2),
             };
 
             this.persistProperties(newProperties, err => {
@@ -1124,6 +1193,54 @@ module.exports = class User {
         );
     }
 
+    //  Returns the hash params stored for a user, or LegacyPBKDF2 if absent (pre-migration user).
+    static getHashParams(props) {
+        const raw = props[UserProps.PassHashParams];
+        if (raw) {
+            try {
+                return JSON.parse(raw);
+            } catch (e) {
+                Log.warn(
+                    { error: e.message },
+                    'Failed to parse PassHashParams; falling back to legacy defaults'
+                );
+            }
+        }
+        return User.LegacyPBKDF2;
+    }
+
+    //  Returns true when the stored hash was produced with parameters that differ from the current target.
+    static needsRehash(props) {
+        const stored = User.getHashParams(props);
+        const target = User.PBKDF2;
+        return (
+            stored.iterations !== target.iterations ||
+            stored.digest !== target.digest ||
+            stored.keyLen !== target.keyLen
+        );
+    }
+
+    //  Re-derives and persists a new salt + dk + PassHashParams for an existing user.
+    //  Called fire-and-forget from validatePassword; errors are logged, not surfaced.
+    static rehashPassword(userId, plainPassword, cb) {
+        User.generatePasswordDerivedKeyAndSalt(plainPassword, (err, info) => {
+            if (err) {
+                return cb(err);
+            }
+            try {
+                const stmt = userDb.prepare(
+                    `REPLACE INTO user_property (user_id, prop_name, prop_value) VALUES (?, ?, ?);`
+                );
+                stmt.run(userId, UserProps.PassPbkdf2Salt, info.salt);
+                stmt.run(userId, UserProps.PassPbkdf2Dk, info.dk);
+                stmt.run(userId, UserProps.PassHashParams, JSON.stringify(User.PBKDF2));
+                return cb(null);
+            } catch (dbErr) {
+                return cb(dbErr);
+            }
+        });
+    }
+
     static generatePasswordDerivedKeySalt(cb) {
         crypto.randomBytes(User.PBKDF2.saltLen, (err, salt) => {
             if (err) {
@@ -1133,15 +1250,20 @@ module.exports = class User {
         });
     }
 
-    static generatePasswordDerivedKey(password, salt, cb) {
+    static generatePasswordDerivedKey(password, salt, options, cb) {
+        if (typeof options === 'function') {
+            cb = options;
+            options = User.PBKDF2;
+        }
+
         password = Buffer.from(password).toString('hex');
 
         crypto.pbkdf2(
             password,
             salt,
-            User.PBKDF2.iterations,
-            User.PBKDF2.keyLen,
-            'sha1',
+            options.iterations,
+            options.keyLen,
+            options.digest,
             (err, dk) => {
                 if (err) {
                     return cb(err);

--- a/core/user_2fa_otp_web_register.js
+++ b/core/user_2fa_otp_web_register.js
@@ -135,6 +135,11 @@ module.exports = class User2FA_OTPWebRegister {
     static routeRegisterGet(req, resp) {
         const webServer = getWebServer(); //  must be valid, we just got a req!
 
+        const rlOpts = _.get(Config(), 'contentServers.web.rateLimits.otpRegGet');
+        if (!webServer.instance.checkRateLimit(req, resp, 'otpRegGet', rlOpts)) {
+            return;
+        }
+
         const urlParts = url.parse(req.url, true);
         const token = urlParts.query && urlParts.query.token;
         const otpType = urlParts.query && urlParts.query.otpType;
@@ -195,6 +200,11 @@ module.exports = class User2FA_OTPWebRegister {
 
     static routeRegisterPost(req, resp) {
         const webServer = getWebServer(); //  must be valid, we just got a req!
+
+        const rlOpts = _.get(Config(), 'contentServers.web.rateLimits.otpRegPost');
+        if (!webServer.instance.checkRateLimit(req, resp, 'otpRegPost', rlOpts)) {
+            return;
+        }
 
         const badRequest = () => {
             return webServer.instance.respondWithError(

--- a/core/user_property.js
+++ b/core/user_property.js
@@ -10,6 +10,7 @@
 module.exports = {
     PassPbkdf2Salt: 'pw_pbkdf2_salt',
     PassPbkdf2Dk: 'pw_pbkdf2_dk',
+    PassHashParams: 'pw_hash_params', //  JSON object: { iterations, digest, keyLen, saltLen }; absent = legacy SHA-1/1000
 
     AccountStatus: 'account_status', //  See User.AccountStatus enum
 

--- a/core/web_password_reset.js
+++ b/core/web_password_reset.js
@@ -242,6 +242,27 @@ class WebPasswordReset {
                         return callback(null, user);
                     });
                 },
+                function checkTokenExpiry(user, callback) {
+                    const ttlMinutes = _.get(
+                        Config(),
+                        'contentServers.web.resetPassword.tokenTtlMinutes',
+                        60
+                    );
+                    const tsStr = user.getProperty(UserProps.EmailPwResetTokenTs);
+                    if (!tsStr) {
+                        return callback(
+                            Errors.Invalid('Password reset token has no timestamp')
+                        );
+                    }
+                    const issuedAt = new Date(tsStr);
+                    const ageMs = Date.now() - issuedAt.getTime();
+                    if (ageMs > ttlMinutes * 60 * 1000) {
+                        return callback(
+                            Errors.Invalid('Password reset token has expired')
+                        );
+                    }
+                    return callback(null, user);
+                },
             ],
             (err, user) => {
                 return cb(err, user);
@@ -251,6 +272,11 @@ class WebPasswordReset {
 
     static routeResetPasswordGet(req, resp) {
         const webServer = getWebServer(); //  must be valid, we just got a req!
+
+        const rlOpts = _.get(Config(), 'contentServers.web.rateLimits.pwResetGet');
+        if (!webServer.instance.checkRateLimit(req, resp, 'pwResetGet', rlOpts)) {
+            return;
+        }
 
         const urlParts = url.parse(req.url, true);
         const token = urlParts.query && urlParts.query.token;
@@ -292,6 +318,11 @@ class WebPasswordReset {
 
     static routeResetPasswordPost(req, resp) {
         const webServer = getWebServer(); //  must be valid, we just got a req!
+
+        const rlOpts = _.get(Config(), 'contentServers.web.rateLimits.pwResetPost');
+        if (!webServer.instance.checkRateLimit(req, resp, 'pwResetPost', rlOpts)) {
+            return;
+        }
 
         let bodyData = '';
         req.on('data', data => {

--- a/docs/_docs/configuration/security.md
+++ b/docs/_docs/configuration/security.md
@@ -10,6 +10,23 @@ Unlike in the golden era of BBSing, modern Internet-connected systems are prone 
 * Optional SSH public key authentication for passwordless logins over secure transports.
 * Optional [Two-Factor Authentication (2FA)](https://en.wikipedia.org/wiki/Multi-factor_authentication) via [One-Time-Password (OTP)](https://en.wikipedia.org/wiki/One-time_password) for users, supporting [Google Authenticator](http://google-authenticator.com/), [Time-Based One-Time Password Algorithm (TOTP, RFC-6238)](https://tools.ietf.org/html/rfc6238), and [HMAC-Based One-Time Password Algorithm (HOTP, RFC-4266)](https://tools.ietf.org/html/rfc4226).
 
+## Protecting Sensitive Configuration
+
+`config.hjson` contains secrets — most notably the SSH host key passphrase (`loginServers.ssh.privateKeyPass`) and any email gateway credentials. These values are stored in plain text in the file. To limit exposure:
+
+* **Restrict file permissions.** The config file should be readable only by the OS user that runs ENiGMA½:
+  ```bash
+  chmod 600 /path/to/enigma-bbs/config/config.hjson
+  ```
+* **Restrict the SSH private key itself** in the same way:
+  ```bash
+  chmod 600 /path/to/enigma-bbs/config/ssh_private_key.pem
+  ```
+* Do not commit `config.hjson` to version control. Add it to `.gitignore` if you track your configuration in git.
+* Limit OS-level read access to backup archives that include the config directory.
+
+> :warning: If `privateKeyPass` is left blank in your config, the SSH host key will be generated and stored without a passphrase. This is acceptable if the key file itself is properly permission-restricted and the host is otherwise secured.
+
 ## Two-Factor Authentication via One-Time Password
 Enabling Two-Factor Authentication via One-Time-Password (2FA/OTP) on an account adds an extra layer of security ("_something a user has_") in addition to their password ("_something a user knows_"). Providing 2FA/OTP to your users has some prerequisites:
 * [A configured email gateway](../configuration/email.md) such that the system can send out emails.

--- a/test/user_db.test.js
+++ b/test/user_db.test.js
@@ -333,4 +333,385 @@ describe('user_db', function () {
             });
         });
     });
+    // ─── Password hashing / migration ────────────────────────────────────────────
+
+    describe('PBKDF2 hashing and migration', function () {
+        //  210k-iteration PBKDF2-SHA-512 takes ~1-3 s per hash on modern hardware.
+        //  Tests that touch the current params budget 15 s each; legacy-only tests
+        //  (1k iterations) stay fast.
+        this.timeout(30000);
+
+        before(done => applySchema(_testDb, done));
+
+        beforeEach(done => {
+            _testDb.exec(
+                'DELETE FROM user_group_member; DELETE FROM user_property; DELETE FROM user;'
+            );
+            _userSeq = 0;
+            done();
+        });
+
+        // ── getHashParams ──────────────────────────────────────────────────────────
+
+        it('getHashParams() returns LegacyPBKDF2 when PassHashParams is absent', () => {
+            const params = User.getHashParams({});
+            assert.deepEqual(params, User.LegacyPBKDF2);
+        });
+
+        it('getHashParams() returns LegacyPBKDF2 when PassHashParams is corrupt JSON', () => {
+            const params = User.getHashParams({
+                [UserProps.PassHashParams]: 'not-json{',
+            });
+            assert.deepEqual(params, User.LegacyPBKDF2);
+        });
+
+        it('getHashParams() returns stored params when PassHashParams is valid JSON', () => {
+            const stored = {
+                iterations: 210000,
+                digest: 'sha512',
+                keyLen: 64,
+                saltLen: 32,
+            };
+            const params = User.getHashParams({
+                [UserProps.PassHashParams]: JSON.stringify(stored),
+            });
+            assert.deepEqual(params, stored);
+        });
+
+        // ── needsRehash ────────────────────────────────────────────────────────────
+
+        it('needsRehash() returns true when PassHashParams is absent (legacy user)', () => {
+            assert.ok(User.needsRehash({}));
+        });
+
+        it('needsRehash() returns true when stored iterations differ from target', () => {
+            const oldParams = { ...User.PBKDF2, iterations: 1000 };
+            assert.ok(
+                User.needsRehash({
+                    [UserProps.PassHashParams]: JSON.stringify(oldParams),
+                })
+            );
+        });
+
+        it('needsRehash() returns true when stored digest differs from target', () => {
+            const oldParams = { ...User.PBKDF2, digest: 'sha1' };
+            assert.ok(
+                User.needsRehash({
+                    [UserProps.PassHashParams]: JSON.stringify(oldParams),
+                })
+            );
+        });
+
+        it('needsRehash() returns true when stored keyLen differs from target', () => {
+            const oldParams = { ...User.PBKDF2, keyLen: 128 };
+            assert.ok(
+                User.needsRehash({
+                    [UserProps.PassHashParams]: JSON.stringify(oldParams),
+                })
+            );
+        });
+
+        it('needsRehash() returns false when stored params match current target', () => {
+            assert.ok(
+                !User.needsRehash({
+                    [UserProps.PassHashParams]: JSON.stringify(User.PBKDF2),
+                })
+            );
+        });
+
+        // ── generatePasswordDerivedKey ─────────────────────────────────────────────
+
+        it('generatePasswordDerivedKey() defaults to current PBKDF2 params', done => {
+            User.generatePasswordDerivedKeySalt((err, salt) => {
+                assert.ifError(err);
+                User.generatePasswordDerivedKey('secret', salt, (err, dk) => {
+                    assert.ifError(err);
+                    //  sha512, keyLen 64 → 128 hex chars
+                    assert.equal(dk.length, User.PBKDF2.keyLen * 2);
+                    done();
+                });
+            });
+        });
+
+        it('generatePasswordDerivedKey() accepts explicit legacy params and produces legacy-length DK', done => {
+            User.generatePasswordDerivedKeySalt((err, salt) => {
+                assert.ifError(err);
+                User.generatePasswordDerivedKey(
+                    'secret',
+                    salt,
+                    User.LegacyPBKDF2,
+                    (err, dk) => {
+                        assert.ifError(err);
+                        //  sha1, keyLen 128 → 256 hex chars
+                        assert.equal(dk.length, User.LegacyPBKDF2.keyLen * 2);
+                        done();
+                    }
+                );
+            });
+        });
+
+        it('generatePasswordDerivedKey() produces the same DK for the same inputs and params', done => {
+            User.generatePasswordDerivedKeySalt((err, salt) => {
+                assert.ifError(err);
+                User.generatePasswordDerivedKey(
+                    'mypass',
+                    salt,
+                    User.LegacyPBKDF2,
+                    (err, dk1) => {
+                        assert.ifError(err);
+                        User.generatePasswordDerivedKey(
+                            'mypass',
+                            salt,
+                            User.LegacyPBKDF2,
+                            (err, dk2) => {
+                                assert.ifError(err);
+                                assert.equal(dk1, dk2);
+                                done();
+                            }
+                        );
+                    }
+                );
+            });
+        });
+
+        // ── create() stores current params ─────────────────────────────────────────
+
+        it('create() stores PassHashParams matching current PBKDF2 target', done => {
+            createUser(uniqueName(), 'p@ssw0rd!', (err, user) => {
+                assert.ifError(err);
+                const raw = user.properties[UserProps.PassHashParams];
+                assert.ok(raw, 'PassHashParams should be stored');
+                const stored = JSON.parse(raw);
+                assert.equal(stored.iterations, User.PBKDF2.iterations);
+                assert.equal(stored.digest, User.PBKDF2.digest);
+                assert.equal(stored.keyLen, User.PBKDF2.keyLen);
+                done();
+            });
+        });
+
+        it('create() stores a DK of the current keyLen', done => {
+            createUser(uniqueName(), 'p@ssw0rd!', (err, user) => {
+                assert.ifError(err);
+                const dk = user.properties[UserProps.PassPbkdf2Dk];
+                assert.equal(
+                    dk.length,
+                    User.PBKDF2.keyLen * 2,
+                    'DK length should match current keyLen'
+                );
+                done();
+            });
+        });
+
+        it('needsRehash() returns false for a freshly created user', done => {
+            createUser(uniqueName(), 'p@ssw0rd!', (err, user) => {
+                assert.ifError(err);
+                assert.ok(!User.needsRehash(user.properties));
+                done();
+            });
+        });
+
+        // ── legacy user migration ──────────────────────────────────────────────────
+
+        //  Manually inserts a user with legacy (SHA-1, 1000-iteration) credentials,
+        //  simulating a pre-migration account in the database.
+        function insertLegacyUser(username, password, done) {
+            User.generatePasswordDerivedKeySalt((err, salt) => {
+                assert.ifError(err);
+                User.generatePasswordDerivedKey(
+                    password,
+                    salt,
+                    User.LegacyPBKDF2,
+                    (err, dk) => {
+                        assert.ifError(err);
+
+                        const info = _testDb
+                            .prepare(`INSERT INTO user (user_name) VALUES (?);`)
+                            .run(username);
+                        const userId = info.lastInsertRowid;
+
+                        const propStmt = _testDb.prepare(
+                            `REPLACE INTO user_property (user_id, prop_name, prop_value) VALUES (?, ?, ?);`
+                        );
+                        propStmt.run(userId, UserProps.PassPbkdf2Salt, salt);
+                        propStmt.run(userId, UserProps.PassPbkdf2Dk, dk);
+                        propStmt.run(userId, UserProps.AccountStatus, '2'); //  active (User.AccountStatus.active === 2)
+                        //  Intentionally omit PassHashParams — this is the legacy state.
+
+                        const groupStmt = _testDb.prepare(
+                            `INSERT OR IGNORE INTO user_group_member (group_name, user_id) VALUES (?, ?);`
+                        );
+                        groupStmt.run('users', userId);
+
+                        done(null, userId);
+                    }
+                );
+            });
+        }
+
+        it('needsRehash() returns true for a manually inserted legacy user', done => {
+            insertLegacyUser(uniqueName(), 'legacypass', (err, userId) => {
+                assert.ifError(err);
+                const props = _testDb
+                    .prepare(
+                        `SELECT prop_name, prop_value FROM user_property WHERE user_id = ?`
+                    )
+                    .all(userId)
+                    .reduce((acc, r) => {
+                        acc[r.prop_name] = r.prop_value;
+                        return acc;
+                    }, {});
+                assert.ok(User.needsRehash(props));
+                done();
+            });
+        });
+
+        it('authenticateFactor1() succeeds for a legacy user', done => {
+            const name = uniqueName();
+            const pass = 'legacypass1';
+            insertLegacyUser(name, pass, err => {
+                assert.ifError(err);
+                const user = new User();
+                user.authenticateFactor1(
+                    {
+                        username: name,
+                        password: pass,
+                        type: User.AuthFactor1Types.Password,
+                    },
+                    err => {
+                        assert.ifError(err);
+                        done();
+                    }
+                );
+            });
+        });
+
+        it('authenticateFactor1() upgrades legacy hash params on successful login', done => {
+            const name = uniqueName();
+            const pass = 'legacypass2';
+            insertLegacyUser(name, pass, (err, userId) => {
+                assert.ifError(err);
+                const user = new User();
+                user.authenticateFactor1(
+                    {
+                        username: name,
+                        password: pass,
+                        type: User.AuthFactor1Types.Password,
+                    },
+                    err => {
+                        assert.ifError(err);
+                        //  rehash is fire-and-forget; give it a moment to complete
+                        setTimeout(() => {
+                            //  budget for 210k-iteration PBKDF2 rehash
+                            const row = _testDb
+                                .prepare(
+                                    `SELECT prop_value FROM user_property WHERE user_id = ? AND prop_name = ?`
+                                )
+                                .get(userId, UserProps.PassHashParams);
+                            assert.ok(
+                                row,
+                                'PassHashParams should now be stored after rehash'
+                            );
+                            const stored = JSON.parse(row.prop_value);
+                            assert.equal(stored.iterations, User.PBKDF2.iterations);
+                            assert.equal(stored.digest, User.PBKDF2.digest);
+                            assert.equal(stored.keyLen, User.PBKDF2.keyLen);
+                            done();
+                        }, 3000);
+                    }
+                );
+            });
+        });
+
+        it('re-hashed legacy user can authenticate again with new params', done => {
+            const name = uniqueName();
+            const pass = 'legacypass3';
+            insertLegacyUser(name, pass, err => {
+                assert.ifError(err);
+                const user1 = new User();
+                user1.authenticateFactor1(
+                    {
+                        username: name,
+                        password: pass,
+                        type: User.AuthFactor1Types.Password,
+                    },
+                    err => {
+                        assert.ifError(err);
+                        //  wait for rehash to land, then try logging in again
+                        setTimeout(() => {
+                            //  budget for 210k-iteration PBKDF2 rehash
+                            const user2 = new User();
+                            user2.authenticateFactor1(
+                                {
+                                    username: name,
+                                    password: pass,
+                                    type: User.AuthFactor1Types.Password,
+                                },
+                                err => {
+                                    assert.ifError(
+                                        err,
+                                        'Second login with new hash params should succeed'
+                                    );
+                                    done();
+                                }
+                            );
+                        }, 3000);
+                    }
+                );
+            });
+        });
+
+        it('wrong password is rejected for a legacy user', done => {
+            const name = uniqueName();
+            insertLegacyUser(name, 'correctpass', err => {
+                assert.ifError(err);
+                const user = new User();
+                user.authenticateFactor1(
+                    {
+                        username: name,
+                        password: 'wrongpass',
+                        type: User.AuthFactor1Types.Password,
+                    },
+                    err => {
+                        assert.ok(err, 'Wrong password should be rejected');
+                        done();
+                    }
+                );
+            });
+        });
+
+        it('wrong password is rejected for a current-params user', done => {
+            createUser(uniqueName(), 'correctpass', (err, created) => {
+                assert.ifError(err);
+                const user = new User();
+                user.authenticateFactor1(
+                    {
+                        username: created.username,
+                        password: 'wrongpass',
+                        type: User.AuthFactor1Types.Password,
+                    },
+                    err => {
+                        assert.ok(err, 'Wrong password should be rejected');
+                        done();
+                    }
+                );
+            });
+        });
+
+        // ── setNewAuthCredentials ──────────────────────────────────────────────────
+
+        it('setNewAuthCredentials() stores updated PassHashParams', done => {
+            createUser(uniqueName(), 'originalpass', (err, user) => {
+                assert.ifError(err);
+                user.setNewAuthCredentials('newpass', err => {
+                    assert.ifError(err);
+                    const raw = user.properties[UserProps.PassHashParams];
+                    assert.ok(raw);
+                    const stored = JSON.parse(raw);
+                    assert.equal(stored.iterations, User.PBKDF2.iterations);
+                    assert.equal(stored.digest, User.PBKDF2.digest);
+                    done();
+                });
+            });
+        });
+    });
 }); // describe('user_db')


### PR DESCRIPTION
…scape, token TTL

- Raise PBKDF2 to 210,000 iterations (SHA-512, 64-byte key); existing hashes migrate transparently on next successful login via stored pw_hash_params property
- Add per-IP sliding-window rate limiting on password reset and 2FA/OTP web endpoints (configurable via contentServers.web.rateLimits)
- Password reset tokens now expire after a configurable TTL (default 60 min, contentServers.web.resetPassword.tokenTtlMinutes)
- Fix command injection in oputil ssh-key: replace exec() with spawn() so the passphrase is never interpolated into a shell string
- Fix argument injection in archive_util compressTo: filenames are now passed as discrete args rather than space-joined
- Fix NNTP ATTACH DATABASE: validate resolved path stays within db root before exec; expose getDatabasePath() helper from database.js
- Remove userNameRaw from door format object to prevent shell injection via crafted usernames in door arg templates
- Fix web static file symlink escape: resolve candidate through fs.realpath before the startsWith boundary check; convert resolveStaticPath and resolveTemplatePath to async callback API
- Fix SSH pubkey algorithm comparison: != -> !==
- Add config file security guidance to docs/_docs/configuration/security.md
- 21 new unit tests covering PBKDF2 hashing, params storage, and on-login migration