### PR TITLE
Add @file: config directive for secret injection

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -20,6 +20,12 @@ Refer to [Upgrading](./docs/_docs/admin/upgrading.md) for details around this pr
 # Version to Version Notes
 > :warning: Be sure to inspect these notes during any upgrades!
 
+## 0.4.0-beta to 0.5.0-beta
+
+* No breaking changes or required migrations.
+
+* **Recommended:** review any secrets currently stored as plain text in `config.hjson` (`privateKeyPass`, SMTP/IMAP passwords, BinkP `sessionPassword`, FTN `packetPassword`, TIC `password`, `jwtSecret`, door service credentials) and consider moving them to `@file:` or `@environment:` references. This is optional but strongly encouraged — existing plain-text values continue to work unchanged. See [Security](./docs/_docs/configuration/security.md#keeping-secrets-out-of-confighjson) for examples.
+
 ## 0.3.0-beta to 0.4.0-beta
 N/A
 

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -3,6 +3,8 @@ This document attempts to track **major** changes and additions in ENiGMA½. For
 
 ## 0.5.0-beta
 
+* **Secret file injection (`@file:`)** — any string-valued config key that holds a secret (SSH host key passphrase, SMTP/IMAP passwords, BinkP session passwords, FTN packet passwords, JWT signing secret, door service credentials, etc.) can now be kept out of `config.hjson` entirely by using the new `@file:` directive. Point it at any readable file — absolute or relative to the config directory — and ENiGMA½ reads and trims the value at startup. Docker/Podman secrets (`/run/secrets/…`) and `chmod 600` files both work. The existing `@environment:` directive is unchanged. See [Configuration Files — Secret Files](./docs/_docs/configuration/config-files.md#secret-files) and [Security](./docs/_docs/configuration/security.md) for examples covering every secret-bearing config key.
+
 * **REST API v1** — a JSON REST API is now available under `/_enig/api/v1/` when the web server is enabled. Endpoints cover system info, message conferences and areas (read/post/delete), file areas (list/metadata/download/upload), and user profiles. Two auth schemes are supported: short-lived JWT Bearer tokens (obtained via `POST /auth/login`) and long-lived API keys managed with `oputil rest api-key`. Public access to specific message and file areas can be configured without requiring authentication. See [REST API](./docs/_docs/servers/contentservers/rest-api.md) for full documentation.
 
 ## 0.4.0-beta

--- a/core/config_loader.js
+++ b/core/config_loader.js
@@ -1,5 +1,6 @@
 //  deps
 const paths = require('path');
+const fs = require('fs');
 const async = require('async');
 const moment = require('moment');
 
@@ -74,7 +75,7 @@ module.exports = class ConfigLoader {
         //  1 - Fetch base configuration from |baseConfigPath|
         //  2 - Merge with |defaultConfig|
         //  3 - Resolve any includes
-        //  4 - Resolve @reference and @environment
+        //  4 - Resolve @reference, @environment, and @file
         //  5 - Perform any validation
         //
         async.waterfall(
@@ -178,6 +179,26 @@ module.exports = class ConfigLoader {
         return value;
     }
 
+    _resolveFileValue(spec) {
+        //  spec format: @file:/path/to/secret  (or @file:relative/path)
+        const filePath = spec.slice(6); //  strip "@file:"
+        if (!filePath) {
+            return console.info(`WARNING: empty path in spec "${spec}"`);
+        }
+
+        const resolvedPath = paths.isAbsolute(filePath)
+            ? filePath
+            : paths.join(paths.dirname(this.baseConfigPath), filePath);
+
+        try {
+            return fs.readFileSync(resolvedPath, 'utf8').trim();
+        } catch (e) {
+            return console.info(
+                `WARNING: could not read file "${resolvedPath}" from spec "${spec}": ${e.message}`
+            );
+        }
+    }
+
     _resolveEnvironmentVariable(spec) {
         const [, varName, type, array] = spec.split(':');
         if (!varName) {
@@ -264,6 +285,8 @@ module.exports = class ConfigLoader {
                     value = _.get(config, refPath, value);
                 } else if (value.startsWith('@environment:')) {
                     value = this._resolveEnvironmentVariable(value) || value;
+                } else if (value.startsWith('@file:')) {
+                    value = this._resolveFileValue(value) || value;
                 }
             }
 

--- a/docs/_docs/configuration/config-files.md
+++ b/docs/_docs/configuration/config-files.md
@@ -121,6 +121,38 @@ If the environment has `BAR_VAR=1337`, this would produce:
 }
 ```
 
+### Secret Files
+For secrets that should not be stored in `config.hjson` (passwords, API keys, tokens, etc.), ENiGMA½ supports the `@file` directive to read a value from a file at startup. This is particularly useful in container environments where secrets are injected as files (e.g. Docker/Podman secrets under `/run/secrets/`).
+
+The path may be absolute or relative to the directory containing `config.hjson`.
+
+```hjson
+loginServers: {
+    ssh: {
+        // absolute path (e.g. a Docker/Podman secret)
+        privateKeyPass: "@file:/run/secrets/ssh_key_pass"
+    }
+}
+
+email: {
+    transport: {
+        auth: {
+            user: bbs@example.com
+            // relative path — resolved from the config directory
+            pass: "@file:secrets/smtp_pass"
+        }
+    }
+}
+```
+
+The file contents are trimmed of leading/trailing whitespace (including the trailing newline that most editors and secrets managers append).
+
+> :information_source: If the file cannot be read, a warning is logged and the literal `@file:…` string is left intact rather than crashing the system.
+
+> :bulb: `@file` works for **any** string-valued config key — SSH passphrase, SMTP/IMAP passwords, BinkP session passwords, FTN packet passwords, JWT secrets, etc.
+
+> :bulb: On POSIX systems, restrict secret files with `chmod 600`.
+
 ## See Also
 * [System Configuration](config-hjson.md)
 * [Menu Configuration](menu-hjson.md)

--- a/docs/_docs/configuration/email.md
+++ b/docs/_docs/configuration/email.md
@@ -111,6 +111,16 @@ email: {
 
 See [Internet Mail](../messageareas/internet-mail.md) for the full reference, inbound flow details, failed-message handling, and provider-specific tips (app passwords, catch-all rules, etc.).
 
+> :bulb: Avoid storing SMTP/IMAP passwords in plain text. Use `@file:` or `@environment:` to inject credentials securely:
+> ```hjson
+> auth: {
+>     user: noreply@yourbbs.net
+>     pass: "@file:/run/secrets/smtp_pass"
+>     // or: pass: "@environment:SMTP_PASS"
+> }
+> ```
+> See [Configuration Files — Secret Files](config-files.md#secret-files) for details.
+
 ## Password Reset / Account Unlock
 
 If email is configured and you allow email-driven password resets, you may also allow locked accounts to be unlocked at reset time. This is controlled by `users.unlockAtEmailPwReset`. If an account is locked due to too many failed login attempts, the user can reset their password to remedy the situation themselves.

--- a/docs/_docs/configuration/security.md
+++ b/docs/_docs/configuration/security.md
@@ -12,7 +12,7 @@ Unlike in the golden era of BBSing, modern Internet-connected systems are prone 
 
 ## Protecting Sensitive Configuration
 
-`config.hjson` contains secrets — most notably the SSH host key passphrase (`loginServers.ssh.privateKeyPass`) and any email gateway credentials. These values are stored in plain text in the file. To limit exposure:
+`config.hjson` may contain secrets — the SSH host key passphrase, email credentials, FTN/BinkP session passwords, and more. To limit exposure:
 
 * **Restrict file permissions.** The config file should be readable only by the OS user that runs ENiGMA½:
   ```bash
@@ -25,7 +25,47 @@ Unlike in the golden era of BBSing, modern Internet-connected systems are prone 
 * Do not commit `config.hjson` to version control. Add it to `.gitignore` if you track your configuration in git.
 * Limit OS-level read access to backup archives that include the config directory.
 
-> :warning: If `privateKeyPass` is left blank in your config, the SSH host key will be generated and stored without a passphrase. This is acceptable if the key file itself is properly permission-restricted and the host is otherwise secured.
+### Keeping Secrets Out of config.hjson
+
+For stronger separation — especially in container or GitOps environments — ENiGMA½ supports two directives that let you keep sensitive values out of `config.hjson` entirely:
+
+* **`@file:/path/to/secret`** — reads the value from a file at startup (trimming surrounding whitespace). Ideal for Docker/Podman secrets (`/run/secrets/…`) or any chmod-600 file on disk.
+* **`@environment:VAR_NAME`** — reads the value from an environment variable.
+
+These work for **any** string-valued config key. Examples:
+
+```hjson
+loginServers: {
+    ssh: {
+        privateKeyPass: "@file:/run/secrets/ssh_key_pass"
+    }
+}
+
+email: {
+    transport: {
+        auth: {
+            user: noreply@yourbbs.net
+            pass: "@environment:SMTP_PASS"
+        }
+    }
+}
+
+scannerTossers: {
+    ftn_bso: {
+        binkp: {
+            nodes: {
+                "1:218/700": {
+                    sessionPassword: "@file:/run/secrets/binkp_pass"
+                }
+            }
+        }
+    }
+}
+```
+
+See [Configuration Files — Secret Files](config-files.md#secret-files) for the full reference and a complete list of supported `@environment:` type coercions.
+
+> :warning: If `privateKeyPass` is left blank in your config, the SSH host key will be used without a passphrase. This is acceptable if the key file itself is properly permission-restricted and the host is otherwise secured.
 
 ## Two-Factor Authentication via One-Time Password
 Enabling Two-Factor Authentication via One-Time-Password (2FA/OTP) on an account adds an extra layer of security ("_something a user has_") in addition to their password ("_something a user knows_"). Providing 2FA/OTP to your users has some prerequisites:

--- a/docs/_docs/filebase/tic-support.md
+++ b/docs/_docs/filebase/tic-support.md
@@ -18,7 +18,7 @@ Under a given node defined in the `ftn_bso` config section in `config.hjson` (se
           encoding: cp437
           archiveType: zip
           tic: { // <--- General TIC config for 46:*
-            password: TESTY-TEST
+            password: TESTY-TEST  // see tip below for keeping this out of plain text
             uploadBy: AgoraNet TIC
             allowReplace: true
           }
@@ -28,6 +28,12 @@ Under a given node defined in the `ftn_bso` config section in `config.hjson` (se
   }
 }
 ```
+
+> :bulb: Avoid storing `password` in plain text. Use `@file:` or `@environment:` instead:
+> ```hjson
+> password: "@file:/run/secrets/tic_pass"
+> ```
+> See [Configuration Files — Secret Files](../configuration/config-files.md#secret-files) for details.
 
 Valid `tic` members:
 

--- a/docs/_docs/messageareas/binkp.md
+++ b/docs/_docs/messageareas/binkp.md
@@ -95,7 +95,7 @@ scannerTossers: {
                 "1:218/700": {
                     host: "bbs.example.com"
                     port: 24554              // optional, defaults to 24554
-                    sessionPassword: "s3cr3t" // optional CRAM-MD5 password
+                    sessionPassword: "s3cr3t" // optional CRAM-MD5 password — see tip below
                     pull: true                // optional, defaults to true
                 }
 
@@ -112,6 +112,12 @@ scannerTossers: {
     }
 }
 ```
+
+> :bulb: Avoid storing `sessionPassword` in plain text. Use `@file:` or `@environment:` instead:
+> ```hjson
+> sessionPassword: "@file:/run/secrets/binkp_pass"
+> ```
+> See [Configuration Files — Secret Files](../configuration/config-files.md#secret-files) for details.
 
 #### `binkp.inbound`
 

--- a/docs/_docs/messageareas/bso-import-export.md
+++ b/docs/_docs/messageareas/bso-import-export.md
@@ -40,7 +40,7 @@ A node entry starts with a [FTN address](http://ftsc.org/docs/old/fsp-1028.001) 
       nodes: {
         "21:*": { // wildcard address
           packetType: 2+
-          packetPassword: D@TP4SS
+          packetPassword: D@TP4SS  // see tip below for keeping this out of plain text
           encoding: cp437
           archiveType: zip
         }
@@ -49,6 +49,12 @@ A node entry starts with a [FTN address](http://ftsc.org/docs/old/fsp-1028.001) 
   }
 }
 ```
+
+> :bulb: Avoid storing `packetPassword` in plain text. Use `@file:` or `@environment:` instead:
+> ```hjson
+> packetPassword: "@file:/run/secrets/ftn_packet_pass"
+> ```
+> See [Configuration Files — Secret Files](../configuration/config-files.md#secret-files) for details.
 
 #### Paths
 Paths for packet files work out of the box and are relative to your install directory. If you want to configure `reject` or `retain` to keep rejected/imported packet files respectively, set those values. You may override defaults as well.

--- a/docs/_docs/messageareas/internet-mail.md
+++ b/docs/_docs/messageareas/internet-mail.md
@@ -200,6 +200,13 @@ email: {
 
 > :warning: Many providers (Gmail, Outlook) require an **app password** or OAuth2 token rather than your account password for IMAP/SMTP access. Generate one in your provider's security settings.
 
+> :bulb: Avoid storing SMTP/IMAP passwords in plain text in `config.hjson`. Use `@file:` or `@environment:` to inject credentials securely — for example:
+> ```hjson
+> pass: "@file:/run/secrets/smtp_pass"
+> password: "@environment:IMAP_PASSWORD"
+> ```
+> See [Configuration Files — Secret Files](../configuration/config-files.md#secret-files) for details.
+
 ## Failed Message Handling
 
 Messages that cannot be delivered to a local user (unknown username, parse error) are:

--- a/docs/_docs/modding/door-servers.md
+++ b/docs/_docs/modding/door-servers.md
@@ -23,6 +23,12 @@ doorTradeWars2002BBSLink: {
 
 Fill in your credentials in `sysCode`, `authCode`, and `schemeCode` and that's it!
 
+> :bulb: Avoid storing credentials in plain text. Use `@file:` or `@environment:` instead:
+> ```hjson
+> authCode: "@file:/run/secrets/bbslink_auth"
+> ```
+> See [Configuration Files — Secret Files](../../configuration/config-files.md#secret-files) for details.
+
 ## The door_party Module
 The module `door_party` provides native support for [DoorParty!](http://www.throwbackbbs.com/) Configuration is quite easy:
 
@@ -39,6 +45,12 @@ doorParty: {
 ```
 
 Fill in `username`, `password`, and `bbsTag` with credentials provided to you and you should be in business!
+
+> :bulb: Avoid storing credentials in plain text. Use `@file:` or `@environment:` instead:
+> ```hjson
+> password: "@file:/run/secrets/doorparty_pass"
+> ```
+> See [Configuration Files — Secret Files](../../configuration/config-files.md#secret-files) for details.
 
 ## The Exodus Module
 TBC

--- a/docs/_docs/servers/loginservers/ssh.md
+++ b/docs/_docs/servers/loginservers/ssh.md
@@ -41,6 +41,12 @@ Entries available under `config.loginServers.ssh`:
 }
 ```
 
+> :bulb: To avoid storing the passphrase in plain text, use the `@file:` directive to read it from a separate file — for example a Docker/Podman secret or a chmod-600 file:
+> ```hjson
+> privateKeyPass: "@file:/run/secrets/ssh_key_pass"
+> ```
+> See [Configuration Files — Secret Files](../../configuration/config-files.md#secret-files) for details.
+
 ## Generate a SSH Private Key
 
 To utilize the SSH server, an SSH Private Key (PK) will need generated. OpenSSH or (with some versions) OpenSSL can be used for this task:

--- a/misc/config_template.in.hjson
+++ b/misc/config_template.in.hjson
@@ -156,7 +156,12 @@
             //  (The above is a more modern equivelant of the following):
             //  > openssl genrsa -aes128 -out ./config/security/ssh_private_key.pem 2048
             //
-            //  2 - Set 'privateKeyPass' to the password you used in step #1
+            //  2 - Set 'privateKeyPass' to the password you used in step #1.
+            //      To avoid storing it in plain text, use @file: or @environment:
+            //      instead of a literal value. For example:
+            //        privateKeyPass: "@file:/run/secrets/ssh_key_pass"
+            //        privateKeyPass: "@environment:SSH_KEY_PASS"
+            //      See docs on "Secret Files" in configuration/config-files.md
             //
             //  3 - Finally, set 'enabled' to 'true'
             //
@@ -174,7 +179,9 @@
             //
             enabled: XXXXX
 
-            //  set this to your PK's password, generated in step #1 above
+            //  Set to your PK's password (step #1 above), or use @file:/@environment:
+            //  to avoid storing the secret in this file (recommended):
+            //    privateKeyPass: "@file:/run/secrets/ssh_key_pass"
             privateKeyPass: SuperSecretPasswordChangeMe!
 
             //
@@ -265,7 +272,8 @@
                     //  Optional: override the JWT signing secret (e.g. for multi-node
                     //  setups that share a secret). If omitted, ENiGMA auto-generates
                     //  one on first run and stores it in the database.
-                    //  jwtSecret: "a long random string"
+                    //  Use @file: or @environment: to avoid storing it in plain text:
+                    //  jwtSecret: "@file:/run/secrets/jwt_secret"
 
                     //  Control which system endpoints are public vs. auth-required.
                     //  Defaults: info, last-callers, stats = public; nodes = auth required.
@@ -434,7 +442,9 @@
         //      secure: false
         //      auth: {
         //          user: myuser@yourdomain.com
-        //          pass: supersecretpassword
+        //          //  Avoid plain text — use @file: or @environment: for passwords:
+        //          pass: "@file:/run/secrets/smtp_pass"
+        //          //  pass: "@environment:SMTP_PASS"
         //      }
         //  }
         //
@@ -443,7 +453,7 @@
         //      service: Zoho
         //      auth: {
         //          user: myuser@myhost.com
-        //          pass: supersecretpassword
+        //          pass: "@file:/run/secrets/smtp_pass"
         //      }
         //  }
         //
@@ -461,9 +471,10 @@
         //          port: 993
         //          secure: true
         //
-        //          //  Credentials
+        //          //  Credentials — use @file: or @environment: to avoid plain text:
         //          user: bbs@yourdomain.com
-        //          password: supersecretpassword
+        //          password: "@file:/run/secrets/imap_pass"
+        //          //  password: "@environment:IMAP_PASS"
         //
         //          //  How often to check for new messages (ms). Set to 0 to use IMAP IDLE
         //          //  (push-like, lower latency, persistent connection).
@@ -505,6 +516,14 @@
             //
             //  When you're ready to hook up to FTN networks, please
             //  see the documentation on message networks.
+            //
+            //  Passwords (packetPassword, tic.password, binkp sessionPassword, etc.)
+            //  support @file: and @environment: to avoid plain text storage. Example:
+            //    nodes: {
+            //        "21:1/100": {
+            //            packetPassword: "@file:/run/secrets/ftn_packet_pass"
+            //        }
+            //    }
             //
         }
     }

--- a/test/config_loader.test.js
+++ b/test/config_loader.test.js
@@ -2,6 +2,8 @@
 
 const { strict: assert } = require('assert');
 const paths = require('path');
+const os = require('os');
+const fs = require('fs');
 
 //  ConfigLoader has no load-time Config() dependency — require directly.
 const ConfigLoader = require('../core/config_loader');
@@ -102,6 +104,147 @@ describe('ConfigLoader._configFileChanged()', () => {
 
         loader._configFileChanged({ fileName: 'config.hjson', fileRoot: '/fake' });
         assert.equal(scheduled, true);
+    });
+});
+
+// ─── _resolveFileValue ────────────────────────────────────────────────────────
+
+describe('ConfigLoader._resolveFileValue()', () => {
+    let tmpDir;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(paths.join(os.tmpdir(), 'enigma-test-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('reads the file contents and trims surrounding whitespace', () => {
+        const secretFile = paths.join(tmpDir, 'secret');
+        fs.writeFileSync(secretFile, '  s3cr3t\n');
+
+        const loader = new ConfigLoader({ hotReload: false });
+        loader.baseConfigPath = paths.join(tmpDir, 'config.hjson');
+
+        assert.equal(loader._resolveFileValue(`@file:${secretFile}`), 's3cr3t');
+    });
+
+    it('resolves a relative path against the config directory', () => {
+        const secretFile = paths.join(tmpDir, 'mypass');
+        fs.writeFileSync(secretFile, 'relativepass\n');
+
+        const loader = new ConfigLoader({ hotReload: false });
+        loader.baseConfigPath = paths.join(tmpDir, 'config.hjson');
+
+        assert.equal(loader._resolveFileValue('@file:mypass'), 'relativepass');
+    });
+
+    it('returns undefined and logs a warning when the file does not exist', () => {
+        const loader = new ConfigLoader({ hotReload: false });
+        loader.baseConfigPath = paths.join(tmpDir, 'config.hjson');
+
+        const warnings = [];
+        const origInfo = console.info;
+        console.info = msg => {
+            warnings.push(msg);
+        };
+        try {
+            const result = loader._resolveFileValue('@file:/nonexistent/no_such_file');
+            assert.equal(result, undefined);
+            assert.equal(warnings.length, 1);
+            assert.ok(warnings[0].includes('WARNING'));
+        } finally {
+            console.info = origInfo;
+        }
+    });
+
+    it('returns undefined and logs a warning for an empty path (@file: with nothing after)', () => {
+        const loader = new ConfigLoader({ hotReload: false });
+        loader.baseConfigPath = paths.join(tmpDir, 'config.hjson');
+
+        const warnings = [];
+        const origInfo = console.info;
+        console.info = msg => {
+            warnings.push(msg);
+        };
+        try {
+            const result = loader._resolveFileValue('@file:');
+            assert.equal(result, undefined);
+            assert.equal(warnings.length, 1);
+        } finally {
+            console.info = origInfo;
+        }
+    });
+
+    it('preserves internal whitespace in the secret value', () => {
+        const secretFile = paths.join(tmpDir, 'multi');
+        fs.writeFileSync(secretFile, '  pass word  \n');
+
+        const loader = new ConfigLoader({ hotReload: false });
+        loader.baseConfigPath = paths.join(tmpDir, 'config.hjson');
+
+        assert.equal(loader._resolveFileValue(`@file:${secretFile}`), 'pass word');
+    });
+});
+
+// ─── _resolveAtSpecs @file integration ───────────────────────────────────────
+
+describe('ConfigLoader._resolveAtSpecs() @file integration', () => {
+    let tmpDir;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(paths.join(os.tmpdir(), 'enigma-test-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('resolves @file: values anywhere in the config tree', () => {
+        const secretFile = paths.join(tmpDir, 'smtp_pass');
+        fs.writeFileSync(secretFile, 'hunter2\n');
+
+        const loader = new ConfigLoader({ hotReload: false });
+        loader.baseConfigPath = paths.join(tmpDir, 'config.hjson');
+
+        const resolved = loader._resolveAtSpecs({
+            email: {
+                transport: {
+                    auth: {
+                        user: 'bbs@example.com',
+                        pass: `@file:${secretFile}`,
+                    },
+                },
+            },
+        });
+
+        assert.equal(resolved.email.transport.auth.pass, 'hunter2');
+        assert.equal(resolved.email.transport.auth.user, 'bbs@example.com');
+    });
+
+    it('leaves a non-@file @-prefixed value untouched', () => {
+        const loader = new ConfigLoader({ hotReload: false });
+        loader.baseConfigPath = '/fake/config.hjson';
+
+        const resolved = loader._resolveAtSpecs({ key: '@unknown:something' });
+        assert.equal(resolved.key, '@unknown:something');
+    });
+
+    it('leaves the literal @file: spec intact when the file is missing (non-fatal)', () => {
+        const loader = new ConfigLoader({ hotReload: false });
+        loader.baseConfigPath = paths.join(tmpDir, 'config.hjson');
+
+        const origInfo = console.info;
+        console.info = () => {};
+        try {
+            const resolved = loader._resolveAtSpecs({
+                ssh: { pass: '@file:/no/such/file' },
+            });
+            assert.equal(resolved.ssh.pass, '@file:/no/such/file');
+        } finally {
+            console.info = origInfo;
+        }
     });
 });
 


### PR DESCRIPTION
Introduces a new @file: resolver in the config loader so that any string-valued config key can reference a file path rather than embedding a secret in plain text. Absolute and config-dir-relative paths are both supported; file contents are trimmed of surrounding whitespace. Failure to read the file is non-fatal (warning logged, spec left intact), matching existing @environment: behaviour.

Closes #692.

Affected areas documented and updated:
- SSH privateKeyPass
- Email SMTP/IMAP credentials
- BinkP sessionPassword
- FTN packetPassword / TIC password
- REST API jwtSecret
- Door server credentials (BBSLink, DoorParty)

Also documents the already-existing but undiscovered @environment: directive more prominently across all relevant config pages.

Resolves https://github.com/NuSkooler/enigma-bbs/issues/692