### PR TITLE
Add OSC 8 clickable hyperlink support

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -24,6 +24,17 @@ Refer to [Upgrading](./docs/_docs/admin/upgrading.md) for details around this pr
 
 * No breaking changes or required migrations.
 
+* **Optional: enable OSC 8 hyperlinks in message viewers** — clickable URL support is now available for `%MT` views in `preview` or `read-only` mode. The default menu templates already include `hyperlinks: true` on the appropriate views. If you maintain a custom menu config, add `hyperlinks: true` to any message-body or NFO viewer `%MT` view where you want URL detection:
+
+  ```hjson
+  MT1: {
+      mode: preview
+      hyperlinks: true
+  }
+  ```
+
+  No effect on terminals that do not support OSC 8 — it degrades silently to plain text.
+
 * **Optional: expose the new `user_status_config` module** — a new module lets users toggle their own availability and visibility. To add it to your menus, wire up a command or menu entry pointing to `@menu:userStatusConfig`. A minimal menu block is required in your menu config:
 
   ```hjson

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -3,6 +3,8 @@ This document attempts to track **major** changes and additions in ENiGMA½. For
 
 ## 0.5.0-beta
 
+* **OSC 8 clickable hyperlinks** — URLs in message bodies, file NFO/readme viewers, and file download listings are now rendered as clickable hyperlinks on terminals that support the OSC 8 standard: IcyTerm, SyncTERM, VTX, and modern *nix terminals (foot, Alacritty, GNOME Terminal, kitty, WezTerm, Windows Terminal, and others). Sysops enable hyperlinks per-view by adding `hyperlinks: true` to any `%MT` view in preview or read-only mode. The default menu templates and ActivityPub viewer have this enabled out of the box. See [Multi Line Edit Text View](./docs/_docs/art/views/multi_line_edit_text_view.md) for details.
+
 * **User status config module** — users can now toggle their own availability and visibility via the new `user_status_config` module (command `STATUS` from the main menu in the default template). Availability controls whether the user can be paged/messaged; visibility controls whether they appear in who's-online and last-callers lists. Sysops expose the module by wiring `@menu:userStatusConfig` into their menu config. The module supports `enabledIndicator`/`disabledIndicator` config overrides and `TL10`/`TL11` custom-format views (`{availableIndicator}`, `{visibleIndicator}`) for full theme control.
 
 * **Pre-auth feedback to sysop** — visitors can now send a private message to the sysop directly from the login matrix, before logging in. The sender types a free-text name (not resolved to any user account) and composes a message using the full FSE editor. Replies to these ghost-sender messages are blocked at the inbox with a clear notice rather than failing silently. See the Sysop Chat & Contact doc for configuration details.

--- a/core/ansi_term.js
+++ b/core/ansi_term.js
@@ -23,8 +23,8 @@
 //  VT100
 //      * http://www.noah.org/python/pexpect/ANSI-X3.64.htm
 //
-//  VTX
-//      * https://github.com/codewar65/VTX_ClientServer/blob/master/vtx.txt
+//  OSC 8 Hyperlinks
+//      * https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
 //
 //  General
 //      * http://en.wikipedia.org/wiki/ANSI_escape_code
@@ -62,7 +62,7 @@ exports.setSyncTermFont = setSyncTermFont;
 exports.getSyncTermFontFromAlias = getSyncTermFontFromAlias;
 exports.setSyncTermFontWithAlias = setSyncTermFontWithAlias;
 exports.setCursorStyle = setCursorStyle;
-exports.vtxHyperlink = vtxHyperlink;
+exports.osc8Hyperlink = osc8Hyperlink;
 
 //
 //  See also
@@ -489,16 +489,9 @@ function disableVT100LineWrapping() {
     return `${ESC_CSI}?7l`;
 }
 
-function vtxHyperlink(client, url, len) {
-    if (!client.terminalSupports('vtx_hyperlink')) {
-        return '';
-    }
-
-    len = len || url.length;
-
-    const codes = new Array(url.length);
-    for (let i = 0; i < url.length; i++) {
-        codes[i] = url.charCodeAt(i);
-    }
-    return `${ESC_CSI}1;${len};1;1;${codes.join(';')}\\`;
+//  OSC 8 hyperlink: wraps |text| with a clickable OSC 8 sequence pointing to |url|.
+//  Both the open and close sequences are zero display-width.
+//  Spec: https://gist.github.com/egmontkob/eb114294efbcd5adb1944c9f3cb5feda
+function osc8Hyperlink(url, text) {
+    return `\x1b]8;;${url}\x1b\\${text}\x1b]8;;\x1b\\`;
 }

--- a/core/client.js
+++ b/core/client.js
@@ -58,6 +58,10 @@ exports.Client = Client;
 /* eslint-disable no-control-regex */
 const RE_DSR_RESPONSE_ANYWHERE = /(?:\u001b\[)([0-9;]+)(R)/;
 const RE_DEV_ATTR_RESPONSE_ANYWHERE = /(?:\u001b\[)[=?]([0-9a-zA-Z;]+)(c)/;
+//  CTerm capability query response: ESC [ = <id> ; <value> n
+//  e.g. \x1b[=6;1n  → capability 6 (OSC 8 hyperlinks) supported
+//  See https://syncterm.bbsdev.net/cterm.html
+const RE_CTERM_CAP_RESPONSE_ANYWHERE = /\u001b\[=([0-9]+);([0-9]+)n/;
 const RE_META_KEYCODE_ANYWHERE = /(?:\u001b)([a-zA-Z0-9])/;
 const RE_META_KEYCODE = new RegExp('^' + RE_META_KEYCODE_ANYWHERE.source + '$');
 const RE_FUNCTION_KEYCODE_ANYWHERE = new RegExp(
@@ -78,6 +82,7 @@ const RE_ESC_CODE_ANYWHERE = new RegExp(
         RE_META_KEYCODE_ANYWHERE.source,
         RE_DSR_RESPONSE_ANYWHERE.source,
         RE_DEV_ATTR_RESPONSE_ANYWHERE.source,
+        RE_CTERM_CAP_RESPONSE_ANYWHERE.source,
         /\u001b./.source, //  eslint-disable-line no-control-regex
     ].join('|')
 );
@@ -166,6 +171,12 @@ function Client(/*input, output*/) {
                 //  * SyncTERM
                 //
                 termClient = 'cterm';
+            } else if (deviceAttr.startsWith('73;99;121;84;101;114;109')) {
+                //
+                //  DA prefix decodes to "IcyTerm"; remaining bytes are version info.
+                //  See https://github.com/mkrueger/icy_tools
+                //
+                termClient = 'icy_term';
             }
         }
 
@@ -338,6 +349,11 @@ function Client(/*input, output*/) {
                 if (termClient) {
                     self.term.termClient = termClient;
                 }
+            } else if ((parts = RE_CTERM_CAP_RESPONSE_ANYWHERE.exec(s))) {
+                self.emit('cterm capability response', {
+                    id: parseInt(parts[1], 10),
+                    value: parseInt(parts[2], 10),
+                });
             } else if ('\r' === s) {
                 key.name = 'return';
             } else if ('\n' === s) {
@@ -630,8 +646,16 @@ Client.prototype.terminalSupports = function (query) {
             //  https://github.com/codewar65/VTX_ClientServer/blob/master/vtx.txt
             return 'vtx' === termClient;
 
-        case 'vtx_hyperlink':
-            return 'vtx' === termClient;
+        case 'osc8_hyperlink':
+            //  OSC 8 clickable hyperlink support
+            //  cterm/SyncTERM: confirmed via active capability query (CSI = 6 n)
+            //  IcyTerm: confirmed via DA response + feature documentation
+            //  VTX: uses xterm.js which supports OSC 8
+            //  *nix xterm-class: broad support
+            if (this.term.termCapabilities.osc8) return true;
+            if ('icy_term' === termClient) return true;
+            if ('vtx' === termClient) return true;
+            return this.term.isNixTerm();
 
         default:
             return false;

--- a/core/client_term.js
+++ b/core/client_term.js
@@ -21,6 +21,7 @@ function ClientTerminal(output) {
     this.convertLF = true;
 
     this.syncTermFontsEnabled = false;
+    this.termCapabilities = {};
 
     //
     //  Some terminal we handle specially

--- a/core/connect.js
+++ b/core/connect.js
@@ -236,6 +236,38 @@ const ansiQuerySyncTermFontSupport = (client, cb) => {
     );
 };
 
+const CTERM_CAP_OSC8 = 6; //  capability ID for OSC 8 hyperlink support
+
+const ansiQueryCtermOsc8Support = (client, cb) => {
+    if (client.term.termClient !== 'cterm') {
+        return cb(null);
+    }
+
+    let giveUpTimer;
+
+    const done = () => {
+        client.removeListener('cterm capability response', capListener);
+        clearTimeout(giveUpTimer);
+        return cb(null);
+    };
+
+    const capListener = ({ id, value }) => {
+        if (id === CTERM_CAP_OSC8) {
+            if (value === 1) {
+                client.log.info(`CTerm OSC 8 hyperlink support enabled on node ${client.node}`);
+                client.term.termCapabilities.osc8 = true;
+            }
+            return done();
+        }
+    };
+
+    client.on('cterm capability response', capListener);
+    giveUpTimer = setTimeout(done, 2000);
+
+    //  Query: CSI = 6 n
+    client.term.rawWrite('[=6n');
+};
+
 function ansiQueryTermSizeIfNeeded(client, cb) {
     if (client.term.termHeight > 0 || client.term.termWidth > 0) {
         return cb(null);
@@ -351,6 +383,9 @@ function connectEntry(client, nextMenu) {
             },
             function querySyncTERMFontSupport(callback) {
                 return ansiQuerySyncTermFontSupport(client, callback);
+            },
+            function queryCtermOsc8Support(callback) {
+                return ansiQueryCtermOsc8Support(client, callback);
             },
         ],
         () => {

--- a/core/file_area_list.js
+++ b/core/file_area_list.js
@@ -330,8 +330,9 @@ exports.getModule = class FileAreaList extends MenuModule {
                         config.webDlExpireTimeFormat ||
                         this.client.currentTheme.helpers.getDateTimeFormat('short');
 
-                    entryInfo.webDlLink =
-                        ansi.vtxHyperlink(this.client, serveItem.url) + serveItem.url;
+                    entryInfo.webDlLink = this.client.terminalSupports('osc8_hyperlink')
+                        ? ansi.osc8Hyperlink(serveItem.url, serveItem.url)
+                        : serveItem.url;
                     entryInfo.webDlExpire = moment(serveItem.expireTimestamp).format(
                         webDlExpireTimeFormat
                     );
@@ -610,7 +611,9 @@ exports.getModule = class FileAreaList extends MenuModule {
                                 'YYYY-MMM-DD @ h:mm';
 
                             self.currentFileEntry.entryInfo.webDlLink =
-                                ansi.vtxHyperlink(self.client, url) + url;
+                                self.client.terminalSupports('osc8_hyperlink')
+                                    ? ansi.osc8Hyperlink(url, url)
+                                    : url;
                             self.currentFileEntry.entryInfo.webDlExpire =
                                 expireTime.format(webDlExpireTimeFormat);
 

--- a/core/file_base_download_manager.js
+++ b/core/file_base_download_manager.js
@@ -145,8 +145,9 @@ exports.getModule = class FileBaseDownloadQueueManager extends MenuModule {
                         this.menuConfig.config.webDlExpireTimeFormat ||
                         'YYYY-MMM-DD @ h:mm';
 
-                    fileEntry.webDlLink =
-                        ansi.vtxHyperlink(this.client, serveItem.url) + serveItem.url;
+                    fileEntry.webDlLink = this.client.terminalSupports('osc8_hyperlink')
+                        ? ansi.osc8Hyperlink(serveItem.url, serveItem.url)
+                        : serveItem.url;
                     fileEntry.webDlExpire = moment(serveItem.expireTimestamp).format(
                         webDlExpireTimeFormat
                     );

--- a/core/file_base_web_download_manager.js
+++ b/core/file_base_web_download_manager.js
@@ -161,8 +161,9 @@ exports.getModule = class FileBaseWebDownloadQueueManager extends MenuModule {
                     this.menuConfig.config.webDlExpireTimeFormat || 'YYYY-MMM-DD @ h:mm';
 
                 const formatObj = {
-                    webBatchDlLink:
-                        ansi.vtxHyperlink(this.client, webBatchDlLink) + webBatchDlLink,
+                    webBatchDlLink: this.client.terminalSupports('osc8_hyperlink')
+                        ? ansi.osc8Hyperlink(webBatchDlLink, webBatchDlLink)
+                        : webBatchDlLink,
                     webBatchDlExpire: expireTime.format(webDlExpireTimeFormat),
                 };
 
@@ -232,8 +233,9 @@ exports.getModule = class FileBaseWebDownloadQueueManager extends MenuModule {
 
                                                 fileEntry.webDlLinkRaw = url;
                                                 fileEntry.webDlLink =
-                                                    ansi.vtxHyperlink(self.client, url) +
-                                                    url;
+                                                    self.client.terminalSupports('osc8_hyperlink')
+                                                        ? ansi.osc8Hyperlink(url, url)
+                                                        : url;
                                                 fileEntry.webDlExpire =
                                                     expireTime.format(
                                                         webDlExpireTimeFormat
@@ -245,10 +247,9 @@ exports.getModule = class FileBaseWebDownloadQueueManager extends MenuModule {
                                     } else {
                                         fileEntry.webDlLinkRaw = serveItem.url;
                                         fileEntry.webDlLink =
-                                            ansi.vtxHyperlink(
-                                                self.client,
-                                                serveItem.url
-                                            ) + serveItem.url;
+                                            self.client.terminalSupports('osc8_hyperlink')
+                                                ? ansi.osc8Hyperlink(serveItem.url, serveItem.url)
+                                                : serveItem.url;
                                         fileEntry.webDlExpire = moment(
                                             serveItem.expireTimestamp
                                         ).format(webDlExpireTimeFormat);

--- a/core/multi_line_edit_text_view.js
+++ b/core/multi_line_edit_text_view.js
@@ -187,6 +187,9 @@ class MultiLineEditTextView extends View {
         this._pipeCodeExpanded = false;
         this._pipeCodeDebounceTimer = null;
         this._pipeCodeNearIndex = -1; //  buffer index of the one code being shown
+
+        //  OSC 8 hyperlink rendering (view mode only; ignored in edit mode)
+        this.hyperlinks = options.hyperlinks || false;
     }
 
     isEditMode() {
@@ -215,6 +218,57 @@ class MultiLineEditTextView extends View {
     //  sequence (bare | or |d).  Used to decide whether to enter expanded mode.
     _hasPipeCodesOrPartial(chars) {
         return /\|[0-9]{2}/.test(chars) || /\|[0-9]?$/.test(chars);
+    }
+
+    //  Wraps detected URLs in |rawText| with OSC 8 hyperlink sequences (zero display-width).
+    //  To handle URLs split by soft word-wrap, reconstructs the full paragraph text,
+    //  runs URL detection, then maps overlapping URL spans back to this visual line.
+    //  Each visual line emits balanced open/close sequences so links don't bleed across
+    //  lines that are rendered independently with explicit cursor-goto positioning.
+    _wrapUrlsInLine(rawText, lineIndex) {
+        if (!this.client.terminalSupports('osc8_hyperlink')) {
+            return rawText;
+        }
+
+        //  Walk back to the start of the paragraph (first line after a hard EOL).
+        let paraStart = lineIndex;
+        while (paraStart > 0 && this.buffer.lines[paraStart - 1] && !this.buffer.lines[paraStart - 1].eol) {
+            paraStart--;
+        }
+
+        //  Build the full paragraph text and track the char offset of each visual line.
+        let paraText = '';
+        const lineStartOffsets = [];
+        for (let i = paraStart; i <= lineIndex; i++) {
+            lineStartOffsets.push(paraText.length);
+            paraText += (this.buffer.lines[i]?.chars || '').replace(/\t/g, ' ');
+        }
+
+        const lineStart = lineStartOffsets[lineIndex - paraStart];
+        const lineEnd = lineStart + rawText.length;
+
+        const urls = strUtil.extractUrls(paraText);
+        const overlapping = urls.filter(u => u.start < lineEnd && u.end > lineStart);
+        if (overlapping.length === 0) {
+            return rawText;
+        }
+
+        //  Build annotated output — each URL span gets balanced OSC 8 open/close per
+        //  visual line so that independent goto-positioned rendering stays correct.
+        let result = '';
+        let cursor = 0; // position within rawText
+
+        for (const { start, end, url } of overlapping) {
+            const localStart = Math.max(start, lineStart) - lineStart;
+            const localEnd   = Math.min(end,   lineEnd)  - lineStart;
+
+            result += rawText.slice(cursor, localStart);
+            const fragment = rawText.slice(localStart, localEnd);
+            result += `\x1b]8;;${url}\x1b\\${fragment}\x1b]8;;\x1b\\`;
+            cursor = localEnd;
+        }
+
+        return result + rawText.slice(cursor);
     }
 
     //  Renders |## numeric pipe color codes in chars to ANSI SGR sequences for
@@ -707,7 +761,10 @@ class MultiLineEditTextView extends View {
 
         //  Default path — plain text or ANSI-baked preview mode.
         const remain = this.dimens.width - strUtil.renderStringLength(rawText);
-        return remain > 0 ? rawText + ' '.repeat(remain) : rawText;
+        const text = (this.hyperlinks && !_.isUndefined(index))
+            ? this._wrapUrlsInLine(rawText, index)
+            : rawText;
+        return remain > 0 ? text + ' '.repeat(remain) : text;
     }
 
     //  Compatibility shim — returns raw buffer lines (shape: { chars, attrs, eol })
@@ -1972,6 +2029,12 @@ class MultiLineEditTextView extends View {
 
             case 'findCurrentMatchStyle':
                 this._findCurrentMatchStyle = value;
+                break;
+
+            case 'hyperlinks':
+                if (_.isBoolean(value)) {
+                    this.hyperlinks = value;
+                }
                 break;
         }
 

--- a/core/string_util.js
+++ b/core/string_util.js
@@ -36,6 +36,7 @@ exports.isAnsiLine = isAnsiLine;
 exports.isFormattedLine = isFormattedLine;
 exports.splitTextAtTerms = splitTextAtTerms;
 exports.wildcardMatch = wildcardMatch;
+exports.extractUrls = extractUrls;
 
 //  :TODO: create Unicode version of this
 const VOWELS = ['a', 'e', 'i', 'o', 'u', 'A', 'E', 'I', 'O', 'U'];
@@ -630,4 +631,22 @@ function wildcardMatch(input, rule) {
         _wildcardCache.set(rule, re);
     }
     return re.test(input);
+}
+
+//  Matches URLs with common schemes.  Terminates at whitespace or shell-style
+//  punctuation that is unlikely to be part of a URL.
+//  mailto: uses a bare colon (no //); all others use ://
+const URL_RE = /(?:(?:https?|ftps?|gopher|ssh|telnet):\/\/[^\s\x00-\x1f"'<>()[\],;]+|mailto:[^\s\x00-\x1f"'<>()[\],;]+)/g;
+
+//  extractUrls(str) → [{ start, end, url }, ...]
+//  Indices refer to positions in |str|.  Zero-allocation fast path when no
+//  URLs are present (the regex is reset via lastIndex before each call).
+function extractUrls(str) {
+    const results = [];
+    URL_RE.lastIndex = 0;
+    let m;
+    while ((m = URL_RE.exec(str)) !== null) {
+        results.push({ start: m.index, end: m.index + m[0].length, url: m[0] });
+    }
+    return results;
 }

--- a/docs/_docs/art/views/multi_line_edit_text_view.md
+++ b/docs/_docs/art/views/multi_line_edit_text_view.md
@@ -20,6 +20,7 @@ A text display / editor designed to edit or display a message.
 | `height` | Sets the height of a view to display vertically |
 | `argName` | Sets the argument name for the form |
 | `mode` | One of edit, preview, or read-only. See **Mode** below |
+| `hyperlinks` | When `true`, URLs in the displayed text are rendered as clickable OSC 8 hyperlinks on supported terminals (IcyTerm, SyncTERM, VTX, and modern *nix terminals). Only active in `preview` or `read-only` mode; ignored in `edit` mode. Defaults to `false`. |
 
 ### Mode
 
@@ -47,6 +48,15 @@ ML1: {
   width: 79
   argName: message
   mode: edit
+}
+```
+
+Viewer with clickable hyperlinks:
+```
+MT1: {
+  width: 79
+  mode: preview
+  hyperlinks: true
 }
 ```
 </div>

--- a/misc/menu_templates/activitypub.in.hjson
+++ b/misc/menu_templates/activitypub.in.hjson
@@ -168,6 +168,7 @@
               mode: preview
               acceptsFocus: false
               acceptsInput: false
+              hyperlinks: true
             }
           }
           submit: {}
@@ -535,6 +536,7 @@
               mode: preview
               acceptsFocus: false
               acceptsInput: false
+              hyperlinks: true
             }
           }
         }

--- a/misc/menu_templates/file_base.in.hjson
+++ b/misc/menu_templates/file_base.in.hjson
@@ -190,6 +190,7 @@
                     mci: {
                         MT1: {
                             mode: preview
+                            hyperlinks: true
                         }
                     }
                 }

--- a/misc/menu_templates/login.in.hjson
+++ b/misc/menu_templates/login.in.hjson
@@ -529,6 +529,7 @@
                     mci: {
                         MT1: {
                             mode: preview
+                            hyperlinks: true
                         }
                     }
                 }

--- a/misc/menu_templates/message_base.in.hjson
+++ b/misc/menu_templates/message_base.in.hjson
@@ -624,6 +624,7 @@
                         MT1: {
                             width: 79
                             mode: preview
+                            hyperlinks: true
                         }
                     }
                     submit: {


### PR DESCRIPTION
Replaces the old VTX-only vtxHyperlink() with the standard OSC 8 escape sequence, supported by SyncTERM (via CTerm cap query), VTX, IcyTerm, and modern *nix terminals.

- Auto-detect URLs (https/http/ftp/ftps/gopher/ssh/telnet/mailto) in MLTEV preview/read-only mode via new `hyperlinks: true` property
- Handles word-wrapped URLs by reconstructing the full paragraph from LineBuffer soft-wrapped lines before URL detection
- Detects SyncTERM OSC 8 support via CTerm capability query (cap 6)
- Detects IcyTerm via DA response prefix ("IcyTerm" in ASCII)
- Enables hyperlinks in message, AP, file base, and login NFO viewers (menu templates + dev menus)
- Updates file area download managers to use osc8Hyperlink()