### PR TITLE
fix(activitypub): deliver outgoing notes to followers (getFollowerSharedInboxes wrong column)

### DIFF
--- a/core/activitypub/collection.js
+++ b/core/activitypub/collection.js
@@ -323,10 +323,10 @@ module.exports = class Collection extends ActivityPubObject {
                         ON  a.collection_id = ?
                         AND a.name          = ?
                         AND a.object_id     = f.object_id
-                    WHERE f.name = ?
+                    WHERE f.collection_id = ? AND f.name = ?
                       AND json_extract(a.object_json, '$.endpoints.sharedInbox') IS NOT NULL`
                 )
-                .all(ActorCollectionId, Collections.Actors, followersEndpoint);
+                .all(ActorCollectionId, Collections.Actors, followersEndpoint, Collections.Followers);
 
             return cb(
                 null,


### PR DESCRIPTION
## What

`getFollowerSharedInboxes()` in `core/activitypub/collection.js` filtered the followers rows with `WHERE f.name = ?` bound to the followers **endpoint URL**. In the `collection` table, `name` holds the collection *type* (`'followers'`) while the endpoint URL lives in `collection_id` (per the schema comments and every other query in the file). So the JOIN matched zero rows → no shared inboxes collected → outgoing public notes were written to the outbox but **never delivered** to followers. The tosser still logged `"Note Activity published successfully"`, masking the failure.

## Fix

```diff
- WHERE f.name = ?
+ WHERE f.collection_id = ? AND f.name = ?
  ...
- .all(ActorCollectionId, Collections.Actors, followersEndpoint);
+ .all(ActorCollectionId, Collections.Actors, followersEndpoint, Collections.Followers);
```

## Verification

Confirmed at the SQL level on a live install: the original `WHERE f.name = <url>` returns 0 rows; the corrected `WHERE f.collection_id = <url> AND f.name = 'followers'` returns the follower's `endpoints.sharedInbox`. After the patch, posting a public note logs `"Message delivered to Inbox" inbox=https://<remote>/inbox` and the note appears in the follower's Mastodon timeline.

Likely a regression from the SQL refactor that replaced the previous per-actor `Actor.fromId()` fan-out loop.

Fixes #701