### PR TITLE
fix(fse): redraw editor footer after init so static hints aren't lost

### DIFF
--- a/core/fse.js
+++ b/core/fse.js
@@ -1071,6 +1071,18 @@ exports.FullScreenEditorModule =
                         this.client.log.warn({ error: err.message }, 'FSE init error');
                     } else {
                         this.isReady = true;
+                        //  The body render during mciReady paints over the initial
+                        //  footer, wiping any static command hints in the editor
+                        //  footer art. Re-render the footer once on top (same path
+                        //  used when the find prompt closes) so the hints are
+                        //  visible from the start. Only needed in edit mode;
+                        //  view-mode footers use redrawn views (HM) that survive.
+                        if (this.isEditMode()) {
+                            return this.switchFooter(() => {
+                                this._returnFocusToBody();
+                                this.finishedLoading();
+                            });
+                        }
                         this.finishedLoading();
                     }
                 }


### PR DESCRIPTION
## Summary

Fixes #705 — the FSE editor footer (`MSGEFTR`) static text is overwritten by the body on initial entry and only reappears after a later footer redraw.

During FSE init the footer art is displayed, then `mciReady` → `createInitialViews` renders the body `MultiLineEditTextView` over the footer row (`_footerStartRow === header.height + body.height`, the body's last row). The footer is never redrawn afterward during init, so its static art text (e.g. the `ESC : menu` hint next to `%SB1` in the bundled `luciano_blocktronics` theme) is painted over. Footer *views* like `%SB1` survive because their view controller repaints them; static text does not.

## Fix

After init completes, in edit mode re-render the footer once — reusing the exact path already used when the find prompt closes (`_closeFindPrompt` → `switchFooter` → `_returnFocusToBody`):

```js
if (this.isEditMode()) {
    return this.switchFooter(() => {
        this._returnFocusToBody();
        this.finishedLoading();
    });
}
this.finishedLoading();
```

View-mode footers are unaffected (they use redrawn views such as `%HM`).

## Testing

- Before: opening a new post / reply showed no static footer hint; it appeared only after pressing `Ctrl-F` and closing the find prompt.
- After: the editor footer (with static hints) renders correctly from the moment the editor opens. Verified on the message post and reply editors; focus/cursor remain in the body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
