### PR TITLE
fix(ssh): ignore hardcoded terminal size from stock cryptlib clients

### DIFF
--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -3,6 +3,8 @@ This document attempts to track **major** changes and additions in ENiGMA½. For
 
 ## 0.5.0-beta
 
+* **NetRunner over SSH sizing fix** — NetRunner connects via stock cryptlib, which hardcodes the terminal size it reports as 80x48, throwing art positioning off by a row on an 80x25 screen. That reported size is now skipped; ENiGMA½ queries the terminal instead, which NetRunner answers correctly. SyncTERM is unaffected — Synchronet's cryptlib fork reports a real size and identifies itself distinctly. Controlled by `loginServers.ssh.untrustedTermSizeClients`.
+
 * **v86 multi-node shared disk** — concurrent door sessions for the same disk image now share a single in-memory buffer (SharedArrayBuffer), giving all nodes a live view of the same disk — exactly as they would on a real BBS with a shared drive. Games that rely on file/record locking (e.g. TradeWars 2002) work correctly when `SHARE.COM` is loaded from `runBatch`. Single-player doors are unchanged; use `nodeMax: 1` as before. The buffer is flushed back to the image file after each session exits, serialized so concurrent exits never race at the OS level.
 
 * **OSC 8 clickable hyperlinks** — URLs in message bodies, file NFO/readme viewers, and file download listings are now rendered as clickable hyperlinks on terminals that support the OSC 8 standard: IcyTerm, SyncTERM, VTX, and modern *nix terminals (foot, Alacritty, GNOME Terminal, kitty, WezTerm, Windows Terminal, and others). Sysops enable hyperlinks per-view by adding `hyperlinks: true` to any `%MT` view in preview or read-only mode. The default menu templates and ActivityPub viewer have this enabled out of the box. See [Multi Line Edit Text View](./docs/_docs/art/views/multi_line_edit_text_view.md) for details.

--- a/core/config_default.js
+++ b/core/config_default.js
@@ -238,6 +238,24 @@ module.exports = () => {
                 firstMenuNewUser: 'sshConnectedNewUser',
 
                 //
+                //  SSH clients whose reported terminal size cannot be believed, matched
+                //  against the full client identification string, case-insensitively.
+                //
+                //  Stock cryptlib hardcodes the pty-req as "xterm" 80x48 with no way for
+                //  the application to override it (upstream 3.4.9.3, session/ssh2_msgcli.c),
+                //  so NetRunner reports 80x48 whatever its real window is. Skipping it lets
+                //  the ANSI CPR query (which these clients answer correctly) find the
+                //  actual size, and failing that the usual 80x25 assumption applies.
+                //
+                //  Match exactly, never as a substring: Synchronet's cryptlib fork patches
+                //  the terminal attributes in and was measured reporting the actual size, but
+                //  it identifies as "SSH-2.0-cryptlib(SBBS)" (SyncTERM 1.9rc4) or
+                //  "SSH-2.0-SyncTERM_<version>" (newer). A substring match on "cryptlib"
+                //  would sweep every SyncTERM user in with NetRunner.
+                //
+                untrustedTermSizeClients: ['SSH-2.0-cryptlib'],
+
+                //
                 //  SSH details that can affect security. Stronger ciphers are better for example,
                 //  but terminals such as SyncTERM require KEX diffie-hellman-group14-sha1,
                 //  cipher 3des-cbc, etc.

--- a/core/servers/login/ssh.js
+++ b/core/servers/login/ssh.js
@@ -29,7 +29,26 @@ const ModuleInfo = (exports.moduleInfo = {
     packageName: 'codes.l33t.enigma.ssh.server',
 });
 
-function SSHClient(clientConn) {
+//
+//  Some clients report a terminal size that has nothing to do with their window;
+//  see the 'untrustedTermSizeClients' config for details.
+//
+function isUntrustedTermSizeClient(clientIdent) {
+    const untrusted = _.get(Config(), 'loginServers.ssh.untrustedTermSizeClients', []);
+
+    //
+    //  Exact match, not substring: SyncTERM reports the actual size but identifies as
+    //  "SSH-2.0-cryptlib(SBBS)" on 1.9rc4 and "SSH-2.0-SyncTERM_<version>" on
+    //  newer builds, so matching "cryptlib" loosely would sweep it in alongside
+    //  stock "SSH-2.0-cryptlib".
+    //
+    const ident = clientIdent.toLowerCase();
+    return untrusted.some(name => name.toLowerCase() === ident);
+}
+
+exports.isUntrustedTermSizeClient = isUntrustedTermSizeClient;
+
+function SSHClient(clientConn, connInfo) {
     baseClient.Client.apply(this, arguments);
 
     //
@@ -38,6 +57,8 @@ function SSHClient(clientConn) {
     //
 
     const self = this;
+
+    self.sshClientIdent = _.get(connInfo, 'header.identRaw');
 
     clientConn.on('authentication', function authAttempt(ctx) {
         const username = ctx.username || '';
@@ -266,6 +287,22 @@ function SSHClient(clientConn) {
         assert(_.isObject(self.term));
 
         //
+        //  Leaving the size at 0 hands the job to connect.js, which asks the
+        //  terminal directly via CPR (the only trustworthy answer from these
+        //  clients) and otherwise assumes 80x25. See #414. There is nothing
+        //  worth keeping from the reported size: it is a constant compiled into
+        //  the client's SSH library, so it says nothing about the real window.
+        //
+        if (isUntrustedTermSizeClient(self.sshClientIdent)) {
+            self.log.debug(
+                { clientIdent: self.sshClientIdent, termHeight, termWidth },
+                'Ignoring terminal size reported by untrusted SSH client'
+            );
+            termHeight = 0;
+            termWidth = 0;
+        }
+
+        //
         //  Note that if we fail here, connect.js attempts some non-standard
         //  queries/etc., and ultimately will default to 80x24 if all else fails
         //
@@ -413,7 +450,7 @@ exports.getModule = class SSHServerModule extends LoginServerModule {
         this.server = new ssh2.Server(serverConf);
         this.server.on('connection', (conn, info) => {
             Log.info(info, 'New SSH connection');
-            this.handleNewClient(new SSHClient(conn), conn._sock, ModuleInfo);
+            this.handleNewClient(new SSHClient(conn, info), conn._sock, ModuleInfo);
         });
 
         return cb(null);

--- a/docs/_docs/servers/loginservers/ssh.md
+++ b/docs/_docs/servers/loginservers/ssh.md
@@ -23,6 +23,7 @@ Entries available under `config.loginServers.ssh`:
 | `address` | :-1: | Sets an explicit bind address. |
 | `algorithms` | :-1: | Configuration block for SSH algorithms. Includes keys of `kex`, `cipher`, `hmac`, and `compress`. See the algorithms section in the [ssh2-streams](https://github.com/mscdex/ssh2-streams#ssh2stream-methods) documentation for details. For defaults set by ENiGMA½, see `core/config_default.js`.
 | `traceConnections` | :-1: | Set to `true` to enable full trace-level information on SSH connections.
+| `untrustedTermSizeClients` | :-1: | List of SSH client identification strings whose reported terminal size should be skipped, compared in full and case-insensitively. Defaults to `[ "SSH-2.0-cryptlib" ]`, which covers NetRunner: stock cryptlib hardcodes the terminal size as 80x48 and gives the application no way to change it. The size is established by querying the terminal instead, falling back to the usual 80x25 assumption if that query fails. Matching is deliberately exact rather than by substring: SyncTERM reports the actual size but identifies as `SSH-2.0-cryptlib(SBBS)` on 1.9rc4 and `SSH-2.0-SyncTERM_<version>` on newer builds, so a loose match on `cryptlib` would wrongly catch it. Remove an entry if a client's size reporting is fixed upstream.
 
 * *IMPORTANT* With the `privateKeyPass` option set, make sure that you verify that the config file is not readable by other users!
 

--- a/test/ssh_untrusted_term_size.test.js
+++ b/test/ssh_untrusted_term_size.test.js
@@ -1,0 +1,50 @@
+/* jslint node: true */
+'use strict';
+
+const assert = require('assert');
+const configModule = require('../core/config.js');
+const defaultConfig = require('../core/config_default.js')();
+
+//  ssh.js binds Config at require time, so the mock goes in first and comes
+//  straight back out. ssh.js keeps the getter it captured, so no other test
+//  file ends up loading under our config.
+const previousConfig = configModule._pushTestConfig(defaultConfig);
+const { isUntrustedTermSizeClient } = require('../core/servers/login/ssh.js');
+configModule._popTestConfig(previousConfig);
+
+describe('SSH untrusted terminal size clients', () => {
+    it('ships stock cryptlib in the default list', () => {
+        assert.ok(
+            defaultConfig.loginServers.ssh.untrustedTermSizeClients.includes(
+                'SSH-2.0-cryptlib'
+            )
+        );
+    });
+
+    it('flags NetRunner, which identifies as stock cryptlib', () => {
+        assert.strictEqual(isUntrustedTermSizeClient('SSH-2.0-cryptlib'), true);
+    });
+
+    it('ignores case', () => {
+        assert.strictEqual(isUntrustedTermSizeClient('ssh-2.0-CRYPTLIB'), true);
+    });
+
+    //  Clients on Synchronet's cryptlib fork send the actual terminal size, so
+    //  they must not be caught by the entry for stock cryptlib. Both idents were
+    //  captured from live SyncTERM sessions: released 1.9rc4 sends the fork's
+    //  compiled-in default, while 1.10a from master names itself.
+    it('leaves cryptlib-derived clients that report honestly alone', () => {
+        assert.strictEqual(isUntrustedTermSizeClient('SSH-2.0-cryptlib(SBBS)'), false);
+        assert.strictEqual(isUntrustedTermSizeClient('SSH-2.0-SyncTERM_1.10a'), false);
+    });
+
+    //  Representative idents, not captured ones; any non-matching string
+    //  exercises the same path.
+    it('leaves other clients alone', () => {
+        assert.strictEqual(isUntrustedTermSizeClient('SSH-2.0-OpenSSH_9.6'), false);
+        assert.strictEqual(
+            isUntrustedTermSizeClient('SSH-2.0-PuTTY_Release_0.80'),
+            false
+        );
+    });
+});


### PR DESCRIPTION
Fixes #414 

I walked through some manual/visual testing with Claude and then vibe-coded a fix. But I hope it helps. If nothing else, hopefully you can pinch some useful code from it, or it helps with debugging later.