### PR TITLE
fix(bso): unify outbound directory resolution between ftn_bso and Bin…

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -20,6 +20,28 @@ Refer to [Upgrading](./docs/_docs/admin/upgrading.md) for details around this pr
 # Version to Version Notes
 > :warning: Be sure to inspect these notes during any upgrades!
 
+## 0.5.0-beta to 0.5.1-beta
+
+* **Multi-network BSO outbound directories are now consistent between `ftn_bso` and the native BinkP mailer** ([#719](https://github.com/NuSkooler/enigma-bbs/issues/719)). The scanner/tosser and the mailer each used their own rule for deciding which FTN network owns the bare `outbound/` directory, and the two disagreed whenever more than one network was configured. Both now use the documented rule: `scannerTossers.ftn_bso.defaultNetwork` when set, otherwise the first network listed in `messageNetworks.ftn.networks`.
+
+  **If you have two or more FTN networks configured and have _not_ set `defaultNetwork`**, the first-listed network's outbound now lands in `mail/ftn_out/outbound/` rather than `mail/ftn_out/<networkName>/`.
+
+  * **Built-in BinkP mailer — no action required.** Mail already queued under the previous layout is still found and sent; once that directory drains you may delete it. A startup log entry appears while this applies.
+  * **External mailer (Binkd, Mystic, etc.) — action required.** Either update the mailer's outbound path for that network to `outbound/`, or keep the previous layout by explicitly declaring that there is no default network:
+
+    ```hjson
+    scannerTossers: {
+      ftn_bso: {
+        //  no default network; every network uses its own subdirectory
+        defaultNetwork: null
+      }
+    }
+    ```
+
+  Either way, explicitly setting `defaultNetwork` to a network name is recommended for multi-network systems: it pins the layout so that adding or reordering entries in `messageNetworks.ftn.networks` can never relocate a spool directory. See [BSO Import / Export](./docs/_docs/messageareas/bso-import-export.md).
+
+* **Network names are now matched case-insensitively when resolving outbound directories.** Systems using a mixed-case key in `messageNetworks.ftn.networks` (e.g. `fsxNet`) on a case-sensitive filesystem could have outbound mail written to a directory the mailer never scanned. No action required.
+
 ## 0.4.0-beta to 0.5.0-beta
 
 * No breaking changes or required migrations.

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -1,6 +1,10 @@
 # Whats New
 This document attempts to track **major** changes and additions in ENiGMA½. For details, see GitHub.
 
+## 0.5.1-beta
+
+* **Multi-network BSO outbound fix** — `ftn_bso` (the scanner/tosser) and the native BinkP mailer used two independent rules to decide which FTN network owns the bare `outbound/` spool directory. With two or more networks configured and no explicit `scannerTossers.ftn_bso.defaultNetwork`, the two disagreed: outbound NetMail and EchoMail for the first-listed network was written to `mail/ftn_out/<network>/` but looked for in `mail/ftn_out/outbound/`, so it was never sent — and never logged an error. Both sides now share a single resolver (`defaultNetwork` when set, otherwise the first listed network), network names are matched case-insensitively, and mail already queued under the previous layout is picked up and sent automatically. See [UPGRADE.md](UPGRADE.md) for details.
+
 ## 0.5.0-beta
 
 * **NetRunner over SSH sizing fix** — NetRunner connects via stock cryptlib, which hardcodes the terminal size it reports as 80x48, throwing art positioning off by a row on an 80x25 screen. That reported size is now skipped; ENiGMA½ queries the terminal instead, which NetRunner answers correctly. SyncTERM is unaffected — Synchronet's cryptlib fork reports a real size and identifies itself distinctly. Controlled by `loginServers.ssh.untrustedTermSizeClients`.

--- a/core/binkp/bso_spool.js
+++ b/core/binkp/bso_spool.js
@@ -6,6 +6,13 @@ const path = require('path');
 const Address = require('../ftn_address');
 const { moveFileWithCollisionHandling } = require('../file_util');
 const Log = require('../logger').log;
+const {
+    resolveDefaultNetworkName,
+    resolveNetworkDefaultZone,
+    outboundDirName,
+    legacyOutboundDirName,
+    DEFAULT_NETWORK_DIR_NAME,
+} = require('../bso_util');
 
 // In priority order (highest first)
 const FLOW_EXTS = ['ilo', 'clo', 'dlo', 'flo', 'hlo'];
@@ -32,11 +39,17 @@ const DEFAULT_STALE_LOCK_MAX_AGE_MS = 30 * 60 * 1000;
 //    paths.inbound    : unsecured inbound dir
 //    paths.secInbound : password-protected inbound dir
 //    networks         : messageNetworks.ftn.networks  (for zone/dir resolution)
+//    defaultNetwork   : scannerTossers.ftn_bso.defaultNetwork  (which network
+//                       owns the bare outbound/ dir; see core/bso_util.js)
 //
 class BsoSpool {
     constructor(config) {
         this._paths = config.paths || {};
         this._networks = config.networks || {};
+        this._defaultNetwork = config.defaultNetwork;
+        //  Networks we've already complained about; _allOutboundDirs() runs on
+        //  every poll and the complaint is about static config.
+        this._warnedNetworks = new Set();
         this._staleLockMaxAgeMs =
             typeof config.staleLockMaxAgeMs === 'number'
                 ? config.staleLockMaxAgeMs
@@ -136,49 +149,57 @@ class BsoSpool {
     // Each entry: { name, path, size, timestamp, disposition, disposeFn }
     // Call disposeFn() after the remote acknowledges receipt (file-sent event).
     async getOutboundFilesForNode(addr) {
-        const dir = this._outboundDir(addr);
         const base = nodeBaseName(addr);
         const results = [];
 
-        for (const ext of DIRECT_EXTS) {
-            const filePath = path.join(dir, `${base}.${ext}`);
-            try {
-                const stat = await fsp.stat(filePath);
-                // Zero-byte .ilo = poll trigger, not actual mail
-                if (stat.size === 0) continue;
-                results.push({
-                    name: path.basename(filePath),
-                    path: filePath,
-                    size: stat.size,
-                    timestamp: Math.floor(stat.mtimeMs / 1000),
-                    disposition: 'delete',
-                    //  Direct-attach has no flow file to annotate, and the
-                    //  session layer (BinkpSession._applyDisposition) already
-                    //  unlinks/truncates per the queued disposition. Nothing
-                    //  for the spool layer to do post-send.
-                    disposeFn: null,
-                });
-            } catch (err) {
-                if (err.code !== 'ENOENT') {
-                    Log.warn(
-                        { path: filePath, error: err.message },
-                        '[BinkP/BSO] Error stat-ing direct-attach file'
-                    );
-                }
-            }
+        //  A 2D address (no zone) matches no zone-tagged directory; fall back
+        //  to the canonical one rather than reporting nothing pending.
+        let dirs = await this._candidateDirsForZone(addr.zone);
+        if (0 === dirs.length) {
+            dirs = [this._outboundDir(addr)];
         }
 
-        for (const ext of FLOW_EXTS) {
-            const flowPath = path.join(dir, `${base}.${ext}`);
-            try {
-                const entries = await this._parseFlowFile(flowPath);
-                results.push(...entries);
-            } catch (err) {
-                if (err.code !== 'ENOENT') {
-                    Log.warn(
-                        { path: flowPath, error: err.message },
-                        '[BinkP/BSO] Error reading flow file'
-                    );
+        for (const dir of dirs) {
+            for (const ext of DIRECT_EXTS) {
+                const filePath = path.join(dir, `${base}.${ext}`);
+                try {
+                    const stat = await fsp.stat(filePath);
+                    // Zero-byte .ilo = poll trigger, not actual mail
+                    if (stat.size === 0) continue;
+                    results.push({
+                        name: path.basename(filePath),
+                        path: filePath,
+                        size: stat.size,
+                        timestamp: Math.floor(stat.mtimeMs / 1000),
+                        disposition: 'delete',
+                        //  Direct-attach has no flow file to annotate, and the
+                        //  session layer (BinkpSession._applyDisposition) already
+                        //  unlinks/truncates per the queued disposition. Nothing
+                        //  for the spool layer to do post-send.
+                        disposeFn: null,
+                    });
+                } catch (err) {
+                    if (err.code !== 'ENOENT') {
+                        Log.warn(
+                            { path: filePath, error: err.message },
+                            '[BinkP/BSO] Error stat-ing direct-attach file'
+                        );
+                    }
+                }
+            }
+
+            for (const ext of FLOW_EXTS) {
+                const flowPath = path.join(dir, `${base}.${ext}`);
+                try {
+                    const entries = await this._parseFlowFile(flowPath);
+                    results.push(...entries);
+                } catch (err) {
+                    if (err.code !== 'ENOENT') {
+                        Log.warn(
+                            { path: flowPath, error: err.message },
+                            '[BinkP/BSO] Error reading flow file'
+                        );
+                    }
                 }
             }
         }
@@ -258,19 +279,19 @@ class BsoSpool {
 
     // ── Private ──────────────────────────────────────────────────────────────
 
+    //  Which network owns the bare outbound/ dir. Shared with ftn_bso via
+    //  core/bso_util.js so the writer and this reader cannot drift.
     _defaultNetworkName() {
-        const names = Object.keys(this._networks);
-        return names.length > 0 ? names[0] : null;
+        return resolveDefaultNetworkName(this._networks, this._defaultNetwork);
     }
 
     _defaultZone(networkName) {
-        const net = this._networks[networkName];
-        if (!net) return 1;
-        if (typeof net.defaultZone === 'number') return net.defaultZone;
-        const addr = Address.fromString(net.localAddress || '');
-        return addr && addr.zone ? addr.zone : 1;
+        return resolveNetworkDefaultZone(this._networks, networkName);
     }
 
+    //  Best-effort network for |addr|, by zone. Only used to pick the single
+    //  canonical directory the per-node .bsy lock lives in -- file lookup goes
+    //  through _candidateDirsForZone() instead, which doesn't have to guess.
     _networkNameForAddr(addr) {
         for (const [name] of Object.entries(this._networks)) {
             if (addr.zone === this._defaultZone(name)) return name;
@@ -278,20 +299,33 @@ class BsoSpool {
         return this._defaultNetworkName();
     }
 
+    //  Canonical directory for |addr|. Deterministic -- the .bsy lock must
+    //  resolve to exactly one path for a given node.
     _outboundDir(addr) {
-        const netName = this._networkNameForAddr(addr);
-        const defaultNet = this._defaultNetworkName();
-        const defaultZone = this._defaultZone(netName);
+        //  An address belonging to no configured network still needs somewhere
+        //  to put its lock; fall back to the first network, then to outbound/.
+        const netName = this._networkNameForAddr(addr) || Object.keys(this._networks)[0];
 
-        const zoneExt =
-            addr.zone !== undefined && addr.zone !== defaultZone
-                ? '.' + `000${addr.zone.toString(16)}`.slice(-3)
-                : '';
-
-        const dirName =
-            netName === defaultNet ? `outbound${zoneExt}` : `${netName}${zoneExt}`;
+        const dirName = netName
+            ? outboundDirName(this._networks, this._defaultNetwork, netName, addr.zone)
+            : DEFAULT_NETWORK_DIR_NAME;
 
         return path.join(this._paths.outbound, dirName);
+    }
+
+    //  Every directory that could hold mail for a node in |zone|.
+    //
+    //  More than one is normal: a legacy pre-0.5.1-beta directory may still be
+    //  draining, and nothing stops two configured networks from sharing a zone.
+    //  Scanning all of them beats guessing one and silently missing mail.
+    async _candidateDirsForZone(zone) {
+        const seen = new Set();
+        for (const { dir, zone: dirZone } of await this._allOutboundDirs()) {
+            if (dirZone === zone) {
+                seen.add(dir);
+            }
+        }
+        return Array.from(seen);
     }
 
     _bsyPath(addr) {
@@ -389,39 +423,71 @@ class BsoSpool {
 
     async _allOutboundDirs() {
         const dirs = [];
-        const defaultNet = this._defaultNetworkName();
+        const seen = new Set();
+        const push = (dirName, zone) => {
+            const dir = path.join(this._paths.outbound, dirName);
+            const key = `${dir}\0${zone}`;
+            if (seen.has(key)) return;
+            seen.add(key);
+            dirs.push({ dir, zone });
+        };
 
-        for (const [netName] of Object.entries(this._networks)) {
+        let rootEntries = [];
+        try {
+            rootEntries = await fsp.readdir(this._paths.outbound);
+        } catch {
+            // outbound root does not exist yet — fine
+        }
+
+        for (const netName of Object.keys(this._networks)) {
             const defaultZone = this._defaultZone(netName);
-            const isDefault = netName === defaultNet;
-            const baseName = isDefault ? 'outbound' : netName;
-
-            dirs.push({
-                dir: path.join(this._paths.outbound, baseName),
-                zone: defaultZone,
-            });
-
-            // Also pick up zone-specific subdirs (outbound.001, outbound.002, …)
-            try {
-                const re = new RegExp(`^${baseName}\\.([0-9a-f]{3})$`, 'i');
-                const entries = await fsp.readdir(this._paths.outbound);
-                for (const entry of entries) {
-                    const m = re.exec(entry);
-                    if (m) {
-                        dirs.push({
-                            dir: path.join(this._paths.outbound, entry),
-                            zone: parseInt(m[1], 16),
-                        });
-                    }
+            if (typeof defaultZone !== 'number') {
+                if (!this._warnedNetworks.has(netName)) {
+                    this._warnedNetworks.add(netName);
+                    Log.warn(
+                        { network: netName },
+                        '[BinkP/BSO] Network has no resolvable default zone; skipping its outbound directories'
+                    );
                 }
-            } catch {
-                // outbound root does not exist yet — fine
+                continue;
+            }
+
+            //  The canonical directory, plus the pre-0.5.1-beta one when the
+            //  layout changed under this network (see core/bso_util.js) so
+            //  anything still queued there gets sent.
+            const baseNames = [
+                outboundDirName(
+                    this._networks,
+                    this._defaultNetwork,
+                    netName,
+                    defaultZone
+                ),
+                legacyOutboundDirName(
+                    this._networks,
+                    this._defaultNetwork,
+                    netName,
+                    defaultZone
+                ),
+            ].filter(Boolean);
+
+            for (const baseName of baseNames) {
+                push(baseName, defaultZone);
+
+                // Also pick up zone-specific subdirs (outbound.001, outbound.002, …)
+                const prefix = `${baseName}.`;
+                for (const entry of rootEntries) {
+                    const lower = entry.toLowerCase();
+                    if (!lower.startsWith(prefix)) continue;
+                    const suffix = lower.slice(prefix.length);
+                    if (!/^[0-9a-f]{3}$/.test(suffix)) continue;
+                    push(entry, parseInt(suffix, 16));
+                }
             }
         }
 
         // Fallback when no networks are configured
         if (dirs.length === 0) {
-            dirs.push({ dir: path.join(this._paths.outbound, 'outbound'), zone: 1 });
+            push(DEFAULT_NETWORK_DIR_NAME, 1);
         }
 
         return dirs;

--- a/core/binkp/bso_spool.js
+++ b/core/binkp/bso_spool.js
@@ -24,6 +24,11 @@ const DIRECT_EXTS = ['iut', 'cut', 'dut', 'out', 'hut'];
 // via scannerTossers.ftn_bso.binkp.staleLockMaxAgeMs.
 const DEFAULT_STALE_LOCK_MAX_AGE_MS = 30 * 60 * 1000;
 
+// Networks we've already complained about. Module scope rather than per
+// instance: a spool is rebuilt for every poll and every inbound session, but
+// the complaint is about static configuration — once per process is plenty.
+const warnedNetworks = new Set();
+
 //
 //  BsoSpool — filesystem adapter between BinkP sessions and the BSO outbound/
 //  inbound spool that ftn_bso manages.
@@ -47,9 +52,6 @@ class BsoSpool {
         this._paths = config.paths || {};
         this._networks = config.networks || {};
         this._defaultNetwork = config.defaultNetwork;
-        //  Networks we've already complained about; _allOutboundDirs() runs on
-        //  every poll and the complaint is about static config.
-        this._warnedNetworks = new Set();
         this._staleLockMaxAgeMs =
             typeof config.staleLockMaxAgeMs === 'number'
                 ? config.staleLockMaxAgeMs
@@ -442,8 +444,8 @@ class BsoSpool {
         for (const netName of Object.keys(this._networks)) {
             const defaultZone = this._defaultZone(netName);
             if (typeof defaultZone !== 'number') {
-                if (!this._warnedNetworks.has(netName)) {
-                    this._warnedNetworks.add(netName);
+                if (!warnedNetworks.has(netName)) {
+                    warnedNetworks.add(netName);
                     Log.warn(
                         { network: netName },
                         '[BinkP/BSO] Network has no resolvable default zone; skipping its outbound directories'

--- a/core/binkp/caller.js
+++ b/core/binkp/caller.js
@@ -25,6 +25,7 @@ function buildSpool() {
     return new BsoSpool({
         paths: _.get(config, 'scannerTossers.ftn_bso.paths'),
         networks: _.get(config, 'messageNetworks.ftn.networks', {}),
+        defaultNetwork: _.get(config, 'scannerTossers.ftn_bso.defaultNetwork'),
         staleLockMaxAgeMs: _.get(
             config,
             'scannerTossers.ftn_bso.binkp.staleLockMaxAgeMs'

--- a/core/bso_util.js
+++ b/core/bso_util.js
@@ -1,0 +1,217 @@
+/* jslint node: true */
+'use strict';
+
+const Address = require('./ftn_address.js');
+
+//
+//  Shared BSO (Binkley Style Outbound) spool path resolution.
+//
+//  Two subsystems read and write the same outbound spool:
+//
+//    * core/scanner_tossers/ftn_bso.js — the writer; scans message areas and
+//      drops .pkt/bundle files plus flow file references into the spool.
+//    * core/binkp/bso_spool.js         — the reader; the native BinkP mailer's
+//      filesystem adapter, which finds those files and ships them.
+//
+//  They must agree, byte for byte, on the directory a given (network, zone)
+//  pair maps to. They previously each carried their own implementation and
+//  drifted apart (see issue #719): with two or more networks configured and no
+//  explicit |defaultNetwork|, the writer treated *every* network as non-default
+//  while the reader always treated the first-listed one as default. Outbound
+//  mail for that network was written to one directory and looked for in
+//  another, so it silently never shipped.
+//
+//  Everything here is pure and takes its configuration by argument so both
+//  callers - and tests - can drive it without a live Config(). Nothing in this
+//  module logs; see validateOutboundConfig() for the diagnostics surface.
+//
+
+//
+//  BSO outbound directory naming, for reference:
+//
+//    <paths.outbound>/outbound/          default network, its default zone
+//    <paths.outbound>/outbound.<zzz>/    default network, other zone <zzz> (3 hex)
+//    <paths.outbound>/<network>/         non-default network, its default zone
+//    <paths.outbound>/<network>.<zzz>/   non-default network, other zone
+//
+//  Directory components are always lowercased: the network name is a config
+//  key chosen by the sysop and may be mixed case (e.g. "fsxNet"), but the
+//  on-disk name must be stable across both subsystems on case-sensitive
+//  filesystems.
+//
+const DEFAULT_NETWORK_DIR_NAME = 'outbound';
+
+function networkNames(networks) {
+    return networks && 'object' === typeof networks ? Object.keys(networks) : [];
+}
+
+//
+//  Canonical (as-configured) key for |networkName| within |networks|, matched
+//  case-insensitively. Returns undefined when there is no such network.
+//
+function canonicalNetworkName(networks, networkName) {
+    if (!networkName) {
+        return undefined;
+    }
+    const wanted = String(networkName).toLowerCase();
+    return networkNames(networks).find(k => k.toLowerCase() === wanted);
+}
+
+//
+//  Which network owns the bare "outbound" directory?
+//
+//    |defaultNetwork| unset (undefined)   -> the first network listed
+//    |defaultNetwork| a network name      -> that network (case-insensitive)
+//    |defaultNetwork| null / false / ''   -> none; every network gets its own
+//                                            subdirectory
+//
+//  A |defaultNetwork| naming a network that isn't configured falls back to the
+//  documented default (first listed) rather than quietly leaving the system
+//  with no default at all; validateOutboundConfig() reports the typo.
+//
+//  Returns the canonical config key, or undefined when there is no default
+//  network (explicitly disabled, or no networks configured).
+//
+function resolveDefaultNetworkName(networks, defaultNetwork) {
+    const names = networkNames(networks);
+    if (0 === names.length) {
+        return undefined;
+    }
+
+    if (undefined === defaultNetwork) {
+        return names[0];
+    }
+
+    //  explicitly disabled
+    if (!defaultNetwork) {
+        return undefined;
+    }
+
+    return canonicalNetworkName(networks, defaultNetwork) || names[0];
+}
+
+//
+//  Default zone for |networkName|: an explicit |defaultZone|, else the zone of
+//  the network's |localAddress|. Returns undefined when neither is usable --
+//  callers must not assume a zone in that case.
+//
+function resolveNetworkDefaultZone(networks, networkName) {
+    const key = canonicalNetworkName(networks, networkName);
+    if (undefined === key) {
+        return undefined;
+    }
+
+    const networkConfig = networks[key] || {};
+    if ('number' === typeof networkConfig.defaultZone) {
+        return networkConfig.defaultZone;
+    }
+
+    if (networkConfig.localAddress) {
+        const addr = Address.fromString(networkConfig.localAddress);
+        if (addr && 'number' === typeof addr.zone) {
+            return addr.zone;
+        }
+    }
+
+    return undefined;
+}
+
+//
+//  ".<zzz>" suffix for |zone| within |networkName|, or "" when |zone| is that
+//  network's default zone. A network whose default zone can't be resolved is
+//  treated as matching nothing, so every zone gets an explicit suffix.
+//
+function zoneSuffix(networks, networkName, zone) {
+    if ('number' !== typeof zone) {
+        return '';
+    }
+    if (zone === resolveNetworkDefaultZone(networks, networkName)) {
+        return '';
+    }
+    return '.' + `000${zone.toString(16)}`.slice(-3);
+}
+
+//
+//  Outbound directory name (not a full path) for |networkName| / |zone|.
+//
+function outboundDirName(networks, defaultNetwork, networkName, zone) {
+    const name = String(networkName || '').toLowerCase();
+    const defaultName = resolveDefaultNetworkName(networks, defaultNetwork);
+    const isDefault = undefined !== defaultName && defaultName.toLowerCase() === name;
+
+    return `${
+        isDefault ? DEFAULT_NETWORK_DIR_NAME : name
+    }${zoneSuffix(networks, networkName, zone)}`;
+}
+
+//
+//  Pre-0.5.1-beta outbound directory name for |networkName| / |zone|, or null
+//  when there isn't a distinct one.
+//
+//  Before the writer and reader were unified, a system with two or more
+//  networks and no explicit |defaultNetwork| had *no* default network on the
+//  writing side, so what is now "outbound/" was written as "<network>/". Mail
+//  queued under the old layout still needs to ship after an upgrade, so the
+//  reader checks here as well. The directory drains itself as those files are
+//  sent (flow entries carry the '^' truncate-and-delete directive), after
+//  which the sysop can remove it.
+//
+//  Only the default network has a legacy name -- for every other network the
+//  name never changed.
+//
+function legacyOutboundDirName(networks, defaultNetwork, networkName, zone) {
+    const name = String(networkName || '').toLowerCase();
+    const defaultName = resolveDefaultNetworkName(networks, defaultNetwork);
+    if (undefined === defaultName || defaultName.toLowerCase() !== name) {
+        return null;
+    }
+
+    return `${name}${zoneSuffix(networks, networkName, zone)}`;
+}
+
+//
+//  Configuration problems that make outbound spool paths ambiguous or
+//  unresolvable. Returns an array of { code, ... } objects, empty when all is
+//  well. Intended to be called once at startup and logged; the resolvers above
+//  stay silent since they run per message.
+//
+function validateOutboundConfig(networks, defaultNetwork) {
+    const issues = [];
+    const names = networkNames(networks);
+
+    if (
+        defaultNetwork &&
+        undefined === canonicalNetworkName(networks, defaultNetwork) &&
+        names.length > 0
+    ) {
+        issues.push({
+            code: 'unknownDefaultNetwork',
+            defaultNetwork,
+            using: names[0],
+        });
+    }
+
+    names.forEach(name => {
+        if (undefined === resolveNetworkDefaultZone(networks, name)) {
+            issues.push({ code: 'unresolvableZone', network: name });
+        }
+
+        //  A network literally named "outbound" collides with the default
+        //  network's directory.
+        if (DEFAULT_NETWORK_DIR_NAME === name.toLowerCase()) {
+            issues.push({ code: 'reservedNetworkName', network: name });
+        }
+    });
+
+    return issues;
+}
+
+module.exports = {
+    DEFAULT_NETWORK_DIR_NAME,
+    canonicalNetworkName,
+    resolveDefaultNetworkName,
+    resolveNetworkDefaultZone,
+    outboundDirName,
+    legacyOutboundDirName,
+    validateOutboundConfig,
+};

--- a/core/scanner_tossers/binkp.js
+++ b/core/scanner_tossers/binkp.js
@@ -158,6 +158,7 @@ exports.getModule = class BinkpModule extends MessageScanTossModule {
         const spool = new BsoSpool({
             paths: ftnBsoCfg.paths,
             networks: _.get(Config(), 'messageNetworks.ftn.networks', {}),
+            defaultNetwork: ftnBsoCfg.defaultNetwork,
             staleLockMaxAgeMs: binkpCfg.staleLockMaxAgeMs,
         });
         spool
@@ -214,6 +215,7 @@ exports.getModule = class BinkpModule extends MessageScanTossModule {
         const spool = new BsoSpool({
             paths: ftnBsoCfg.paths,
             networks: _.get(Config(), 'messageNetworks.ftn.networks', {}),
+            defaultNetwork: ftnBsoCfg.defaultNetwork,
             staleLockMaxAgeMs: binkpCfg.staleLockMaxAgeMs,
         });
 

--- a/core/scanner_tossers/ftn_bso.js
+++ b/core/scanner_tossers/ftn_bso.js
@@ -25,6 +25,13 @@ const isValidStorageTag = require('../file_base_area.js').isValidStorageTag;
 const User = require('../user.js');
 const StatLog = require('../stat_log.js');
 const SysProps = require('../system_property.js');
+const {
+    resolveDefaultNetworkName,
+    resolveNetworkDefaultZone,
+    outboundDirName,
+    legacyOutboundDirName,
+    validateOutboundConfig,
+} = require('../bso_util.js');
 
 //  deps
 const moment = require('moment');
@@ -77,31 +84,28 @@ function FTNMessageScanTossModule() {
         return key ? networks[key] : undefined;
     };
 
-    this.getDefaultNetworkName = function () {
-        if (this.moduleConfig.defaultNetwork) {
-            return this.moduleConfig.defaultNetwork;
-        }
+    //
+    //  Outbound spool path resolution is shared with the native BinkP mailer
+    //  (core/binkp/bso_spool.js) via core/bso_util.js. Both sides must agree on
+    //  which network owns the bare "outbound" directory; see that module.
+    //
+    this.getNetworks = function () {
+        return _.get(Config(), 'messageNetworks.ftn.networks', {});
+    };
 
-        const networkNames = Object.keys(config.messageNetworks.ftn.networks);
-        if (1 === networkNames.length) {
-            return networkNames[0];
-        }
+    this.getConfiguredDefaultNetwork = function () {
+        return _.get(this.moduleConfig, 'defaultNetwork');
+    };
+
+    this.getDefaultNetworkName = function () {
+        return resolveDefaultNetworkName(
+            this.getNetworks(),
+            this.getConfiguredDefaultNetwork()
+        );
     };
 
     this.getDefaultZone = function (networkName) {
-        const networkConfig = this.getNetworkConfig(networkName);
-        if (!networkConfig) {
-            return;
-        }
-        if (_.isNumber(networkConfig.defaultZone)) {
-            return networkConfig.defaultZone;
-        }
-
-        //  non-explicit: default to local address zone
-        if (networkConfig.localAddress) {
-            const addr = Address.fromString(networkConfig.localAddress);
-            return addr.zone;
-        }
+        return resolveNetworkDefaultZone(this.getNetworks(), networkName);
     };
 
     /*
@@ -173,27 +177,15 @@ function FTNMessageScanTossModule() {
     */
 
     this.getOutgoingEchoMailPacketDir = function (networkName, destAddress) {
-        networkName = networkName.toLowerCase();
-
-        let dir = this.moduleConfig.paths.outbound;
-
-        const defaultNetworkName = this.getDefaultNetworkName();
-        const defaultZone = this.getDefaultZone(networkName);
-
-        let zoneExt;
-        if (defaultZone !== destAddress.zone) {
-            zoneExt = '.' + `000${destAddress.zone.toString(16)}`.substr(-3);
-        } else {
-            zoneExt = '';
-        }
-
-        if (defaultNetworkName === networkName) {
-            dir = paths.join(dir, `outbound${zoneExt}`);
-        } else {
-            dir = paths.join(dir, `${networkName}${zoneExt}`);
-        }
-
-        return dir;
+        return paths.join(
+            this.moduleConfig.paths.outbound,
+            outboundDirName(
+                this.getNetworks(),
+                this.getConfiguredDefaultNetwork(),
+                networkName,
+                destAddress.zone
+            )
+        );
     };
 
     this.getOutgoingPacketFileName = function (basePath, messageId, isTemp, fileCase) {
@@ -2881,10 +2873,104 @@ FTNMessageScanTossModule.prototype.processTicFilesInDirectory = function (import
     );
 };
 
+//
+//  Report configuration that makes outbound spool directories ambiguous or
+//  unresolvable, plus any leftovers from the pre-0.5.1-beta layout. Advisory
+//  only -- nothing here fails startup.
+//
+FTNMessageScanTossModule.prototype.logOutboundSpoolDiagnostics = function () {
+    const networks = this.getNetworks();
+    const defaultNetwork = this.getConfiguredDefaultNetwork();
+
+    validateOutboundConfig(networks, defaultNetwork).forEach(issue => {
+        switch (issue.code) {
+            case 'unknownDefaultNetwork':
+                Log.warn(
+                    { defaultNetwork: issue.defaultNetwork, using: issue.using },
+                    'scannerTossers.ftn_bso.defaultNetwork does not name a configured FTN network; falling back to the first configured network'
+                );
+                break;
+
+            case 'unresolvableZone':
+                Log.warn(
+                    { network: issue.network },
+                    'FTN network has neither a defaultZone nor a parsable localAddress; its outbound zone directories cannot be resolved'
+                );
+                break;
+
+            case 'reservedNetworkName':
+                Log.warn(
+                    { network: issue.network },
+                    'FTN network name collides with the default outbound directory name; please rename the network'
+                );
+                break;
+        }
+    });
+
+    //
+    //  Before the writer and the native BinkP reader were unified (issue #719)
+    //  a multi-network system with no explicit |defaultNetwork| had no default
+    //  network at all on the writing side, so what is now "outbound/" was
+    //  written as "<network>/". BsoSpool still scans the old directory so
+    //  anything queued there ships, but let the sysop know it exists.
+    //
+    const outboundPath = _.get(this.moduleConfig, 'paths.outbound');
+    const defaultNetworkName = resolveDefaultNetworkName(networks, defaultNetwork);
+    if (!_.isString(outboundPath) || !defaultNetworkName) {
+        return;
+    }
+
+    const legacyBase = legacyOutboundDirName(
+        networks,
+        defaultNetwork,
+        defaultNetworkName
+    );
+    const currentBase = outboundDirName(networks, defaultNetwork, defaultNetworkName);
+    if (!legacyBase || legacyBase === currentBase) {
+        return;
+    }
+
+    const zoneSuffixed = `${legacyBase}.`;
+    fs.readdir(outboundPath, (err, entries) => {
+        if (err) {
+            return;
+        }
+
+        entries
+            .filter(entry => {
+                const lower = entry.toLowerCase();
+                return (
+                    lower === legacyBase ||
+                    (lower.startsWith(zoneSuffixed) &&
+                        /^[0-9a-f]{3}$/.test(lower.slice(zoneSuffixed.length)))
+                );
+            })
+            .forEach(entry => {
+                const legacyDir = paths.join(outboundPath, entry);
+                fs.readdir(legacyDir, (readErr, files) => {
+                    if (readErr || 0 === files.length) {
+                        return;
+                    }
+
+                    Log.warn(
+                        {
+                            network: defaultNetworkName,
+                            legacyDir,
+                            currentDir: paths.join(outboundPath, currentBase),
+                            fileCount: files.length,
+                        },
+                        'Outbound mail found in the pre-0.5.1-beta directory for the default network; it will still be sent, and the directory may be removed once empty. See UPGRADE.md'
+                    );
+                });
+            });
+    });
+};
+
 FTNMessageScanTossModule.prototype.startup = function (cb) {
     Log.info(`${exports.moduleInfo.name} Scanner/Tosser starting up`);
 
     this.hasValidConfiguration({ shouldLog: true }); //  just check and log
+    this.logOutboundSpoolDiagnostics();
 
     //  Refresh cached top-level module config when config.hjson is hot-reloaded
     this._onConfigChanged = () => {

--- a/core/scanner_tossers/ftn_bso.js
+++ b/core/scanner_tossers/ftn_bso.js
@@ -2978,6 +2978,11 @@ FTNMessageScanTossModule.prototype.startup = function (cb) {
         if (_.has(config, 'scannerTossers.ftn_bso')) {
             this.moduleConfig = config.scannerTossers.ftn_bso;
         }
+
+        //  ...and re-check what the new config says about the outbound spool:
+        //  a reload can introduce a bad defaultNetwork, or move the default
+        //  network and leave mail behind in the previous directory.
+        this.logOutboundSpoolDiagnostics();
     };
     Events.on(Events.getSystemEvents().ConfigChanged, this._onConfigChanged);
 

--- a/docs/_docs/messageareas/binkp.md
+++ b/docs/_docs/messageareas/binkp.md
@@ -248,6 +248,10 @@ With this setup, every new nodelist that arrives via TIC is immediately FREQ-ser
 
 The two modules share the same BSO spool directories (`paths.outbound`, `paths.inbound`, `paths.secInbound`):
 
+Both resolve outbound subdirectories — which network owns the bare `outbound/` directory, and how zones are suffixed — through the same shared logic, so they cannot disagree about where a given node's mail lives. See [Outbound Directory Layout](bso-import-export.md#outbound-directory-layout).
+
+> :information_source: Systems upgraded from before 0.5.1-beta may still have mail queued under the previous layout, in which a multi-network system with no explicit `defaultNetwork` wrote the first-listed network's mail to `<networkName>/` rather than `outbound/`. BinkP scans that directory as well, so anything left there is still sent; once it is empty it can be removed. See [UPGRADE.md](https://github.com/NuSkooler/enigma-bbs/blob/master/UPGRADE.md).
+
 **Outbound flow:**
 1. `ftn_bso` scans message areas → writes `.pkt` files and flow file references into the outbound spool
 2. `ftn_bso` emits a `NewOutboundBSO` event with the destination address

--- a/docs/_docs/messageareas/bso-import-export.md
+++ b/docs/_docs/messageareas/bso-import-export.md
@@ -14,7 +14,7 @@ Let's look at some of the basic configuration:
 |-------------|----------|----------------------------------------------------------|
 | `schedule`  | :+1: | Sets `import` and `export` schedules. [Later style text parsing](https://bunkat.github.io/later/parsers.html#text) supported. `import` also can utilize a `@watch:<path/to/file>` syntax while `export` additionally supports `@immediate`. |
 | `packetMsgEncoding` | :-1: | Override default `utf8` encoding.
-| `defaultNetwork` | :-1: | Explicitly set default network (by tag found within `messageNetworks.ftn.networks`). If not set, the first found is used. |
+| `defaultNetwork` | :-1: | Explicitly set default network (by tag found within `messageNetworks.ftn.networks`, matched case-insensitively). If not set, the first found is used. Set to `null` for *no* default network. See **Outbound Directory Layout** below. |
 | `nodes` | :+1: | Per-node settings. Entries (keys) here support wildcards for a portion of the FTN-style address (e.g.: `21:1/*`). See **Nodes** below.
 | `paths` | :-1: | An optional configuration block that can set a additional paths or override defaults. See **Paths** below. |
 | `packetTargetByteSize`  | :-1: | Overrides the system *target* packet (.pkt) size of 512000 bytes (512k) |
@@ -66,6 +66,32 @@ Paths for packet files work out of the box and are relative to your install dire
 | `secInbound` | *Base* path to write **secure** inbound packet files and bundles. | `enigma-bbs/mail/ftn_secin/` |
 | `reject` | Path in which to write rejected packet files. | No default |
 | `retain` | Path in which to write imported packet files. Useful for debugging or if you wish to archive the raw .pkt files. | No default |
+
+#### Outbound Directory Layout
+Within `paths.outbound`, mail is placed in a subdirectory determined by the network it belongs to and the destination zone:
+
+| Directory | Contents |
+|-----------|----------|
+| `outbound/` | The **default network**, at that network's default zone |
+| `outbound.<zzz>/` | The default network, at some other zone `<zzz>` (three lowercase hex digits, e.g. `outbound.00f` for zone 15) |
+| `<networkName>/` | A non-default network, at that network's default zone |
+| `<networkName>.<zzz>/` | A non-default network, at some other zone |
+
+A network's default zone is its `defaultZone` if set, else the zone of its `localAddress`. Directory names are always lowercase.
+
+The **default network** is `defaultNetwork` when set, otherwise the first network listed in `messageNetworks.ftn.networks`. Explicitly setting `defaultNetwork` is recommended whenever you have more than one network configured: it pins the layout so that adding or reordering entries in `messageNetworks.ftn.networks` cannot relocate a spool directory out from under your mailer.
+
+To have *no* default network — every network in its own subdirectory, nothing in `outbound/` — set `defaultNetwork` to `null`:
+
+```hjson
+scannerTossers: {
+  ftn_bso: {
+    defaultNetwork: null
+  }
+}
+```
+
+> :information_source: The [native BinkP mailer](binkp.md) resolves these directories through the same logic, so the two always agree. If you use an external mailer such as Binkd, its per-domain outbound paths must match the table above — see the Binkd example at the end of this document.
 
 ### Scheduling
 Schedules can be defined for importing and exporting via `import` and `export` under `schedule`. Each entry is allowed a "free form" text and/or special indicators for immediate export or watch file triggers.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "enigma-bbs",
-    "version": "0.5.0-beta",
+    "version": "0.5.1-beta",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "enigma-bbs",
-            "version": "0.5.0-beta",
+            "version": "0.5.1-beta",
             "license": "BSD-2-Clause",
             "dependencies": {
                 "@breejs/later": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "enigma-bbs",
-    "version": "0.5.0-beta",
+    "version": "0.5.1-beta",
     "description": "ENiGMA½ Bulletin Board System",
     "author": "Bryan Ashby <bryan@l33t.codes>",
     "license": "BSD-2-Clause",

--- a/test/binkp_ftn_bso_integration.test.js
+++ b/test/binkp_ftn_bso_integration.test.js
@@ -297,6 +297,325 @@ describe('ftn_bso ↔ BinkP integration', function () {
         });
     });
 
+    // ── multi-network agreement (issue #719) ─────────────────────────────────────
+    //
+    //  ftn_bso (writer) and BsoSpool (reader) must resolve the same outbound
+    //  directory for a given network/zone. They once carried separate
+    //  implementations that only agreed when exactly one network was
+    //  configured — which is all the two tests above exercise — so outbound
+    //  mail for a multi-network system was written to one directory and looked
+    //  for in another. These cases drive both sides through the layouts that
+    //  used to diverge.
+
+    describe('ftn_bso ↔ BsoSpool multi-network agreement', () => {
+        const Address = require('../core/ftn_address.js');
+
+        const THREE_NETWORKS = {
+            fidonet: { localAddress: '1:103/705' },
+            fsxnet: { localAddress: '21:1/121' },
+            spooknet: { localAddress: '700:100/28' },
+        };
+
+        //  One uplink per network, in config order
+        const UPLINKS = [
+            { network: 'fidonet', addr: { zone: 1, net: 103, node: 705 } },
+            { network: 'fsxnet', addr: { zone: 21, net: 1, node: 100 } },
+            { network: 'spooknet', addr: { zone: 700, net: 100, node: 1 } },
+        ];
+
+        const ALL_PENDING = ['1:103/705', '21:1/100', '700:100/1'];
+
+        let caseSeq = 0;
+
+        const FTN_BSO_PATH = require.resolve('../core/scanner_tossers/ftn_bso.js');
+
+        //  ftn_bso captures `Config` (the getter function itself) at require
+        //  time, so a _pushTestConfig() after the module is cached has no
+        //  effect on it — every case here needs a different config, so drop it
+        //  from the require cache and let it re-capture.
+        function requireFtnBso() {
+            delete require.cache[FTN_BSO_PATH];
+            return require('../core/scanner_tossers/ftn_bso.js');
+        }
+
+        //  ...and leave the cache empty so the next suite re-captures under
+        //  its own config rather than the last one pushed here.
+        after(() => {
+            delete require.cache[FTN_BSO_PATH];
+        });
+
+        //  Each case gets its own outbound root so layouts can't bleed together.
+        async function makeCase(networks, defaultNetwork) {
+            const outbound = path.join(tmpDir, `multinet_${caseSeq++}`);
+            await fsp.mkdir(outbound, { recursive: true });
+
+            const paths_ = {
+                outbound,
+                inbound: path.join(tmpDir, 'ftn_in'),
+                secInbound: path.join(tmpDir, 'ftn_secin'),
+            };
+
+            const prev = configModule._pushTestConfig({
+                debug: { assertsEnabled: false },
+                scannerTossers: { ftn_bso: { paths: paths_, defaultNetwork } },
+                messageNetworks: { ftn: { networks } },
+            });
+
+            const { getModule } = requireFtnBso();
+            const { BsoSpool } = require('../core/binkp/bso_spool.js');
+
+            return {
+                outbound,
+                mod: new getModule(),
+                spool: new BsoSpool({ paths: paths_, networks, defaultNetwork }),
+                restore: () => configModule._popTestConfig(prev),
+            };
+        }
+
+        function flowBaseName(addr) {
+            const net = `0000${addr.net.toString(16)}`.slice(-4);
+            const node = `0000${addr.node.toString(16)}`.slice(-4);
+            return `${net}${node}`;
+        }
+
+        //  Drop a .pkt plus a flow file referencing it into |dir|, exactly as
+        //  ftn_bso's export path does.
+        async function writeFlowInto(dir, addr, pktName) {
+            await fsp.mkdir(dir, { recursive: true });
+            const pkt = path.join(dir, pktName);
+            await fsp.writeFile(pkt, 'PKT');
+            await fsp.writeFile(path.join(dir, `${flowBaseName(addr)}.flo`), `^${pkt}\n`);
+            return dir;
+        }
+
+        //  Export every uplink through the writer, then read it all back
+        //  through the spool. Returns the writer's directory choice per
+        //  network plus what the reader found.
+        async function roundTrip(ctx, uplinks) {
+            const writerDirs = {};
+            for (const uplink of uplinks) {
+                writerDirs[uplink.network] = path.basename(
+                    await writeFlowInto(
+                        ctx.mod.getOutgoingEchoMailPacketDir(uplink.network, uplink.addr),
+                        uplink.addr,
+                        `${uplink.network}.pkt`
+                    )
+                );
+            }
+
+            const pending = (await ctx.spool.getNodesWithPendingMail())
+                .map(a => `${a.zone}:${a.net}/${a.node}`)
+                .sort();
+
+            const fileCounts = {};
+            for (const uplink of uplinks) {
+                fileCounts[uplink.network] = (
+                    await ctx.spool.getOutboundFilesForNode(new Address(uplink.addr))
+                ).length;
+            }
+
+            return { writerDirs, pending, fileCounts };
+        }
+
+        it('finds mail for every network when defaultNetwork is unset', async () => {
+            const ctx = await makeCase(THREE_NETWORKS, undefined);
+            try {
+                const { writerDirs, pending, fileCounts } = await roundTrip(ctx, UPLINKS);
+
+                assert.deepEqual(writerDirs, {
+                    fidonet: 'outbound',
+                    fsxnet: 'fsxnet',
+                    spooknet: 'spooknet',
+                });
+                assert.deepEqual(
+                    pending,
+                    ALL_PENDING,
+                    'first-listed network must not go missing'
+                );
+                assert.deepEqual(fileCounts, {
+                    fidonet: 1,
+                    fsxnet: 1,
+                    spooknet: 1,
+                });
+            } finally {
+                ctx.restore();
+            }
+        });
+
+        it('does not mis-attribute zones when defaultNetwork is not first-listed', async () => {
+            const ctx = await makeCase(THREE_NETWORKS, 'fsxnet');
+            try {
+                const { writerDirs, pending, fileCounts } = await roundTrip(ctx, UPLINKS);
+
+                assert.deepEqual(writerDirs, {
+                    fidonet: 'fidonet',
+                    fsxnet: 'outbound',
+                    spooknet: 'spooknet',
+                });
+                //  The reader used to read fsxnet's outbound/ with fidonet's
+                //  zone, reporting a node that does not exist (1:1/100).
+                assert.deepEqual(pending, ALL_PENDING);
+                assert.deepEqual(fileCounts, {
+                    fidonet: 1,
+                    fsxnet: 1,
+                    spooknet: 1,
+                });
+            } finally {
+                ctx.restore();
+            }
+        });
+
+        it('keeps working when defaultNetwork names the first-listed network', async () => {
+            const ctx = await makeCase(THREE_NETWORKS, 'fidonet');
+            try {
+                const { writerDirs, pending } = await roundTrip(ctx, UPLINKS);
+                assert.equal(writerDirs.fidonet, 'outbound');
+                assert.deepEqual(pending, ALL_PENDING);
+            } finally {
+                ctx.restore();
+            }
+        });
+
+        it('falls back to the first-listed network when defaultNetwork is unknown', async () => {
+            const ctx = await makeCase(THREE_NETWORKS, 'nosuchnet');
+            try {
+                const { writerDirs, pending } = await roundTrip(ctx, UPLINKS);
+                assert.equal(writerDirs.fidonet, 'outbound');
+                assert.deepEqual(pending, ALL_PENDING);
+            } finally {
+                ctx.restore();
+            }
+        });
+
+        it('gives every network its own subdir when defaultNetwork is disabled', async () => {
+            const ctx = await makeCase(THREE_NETWORKS, null);
+            try {
+                const { writerDirs, pending, fileCounts } = await roundTrip(ctx, UPLINKS);
+
+                assert.deepEqual(writerDirs, {
+                    fidonet: 'fidonet',
+                    fsxnet: 'fsxnet',
+                    spooknet: 'spooknet',
+                });
+                assert.deepEqual(pending, ALL_PENDING);
+                assert.deepEqual(fileCounts, {
+                    fidonet: 1,
+                    fsxnet: 1,
+                    spooknet: 1,
+                });
+            } finally {
+                ctx.restore();
+            }
+        });
+
+        it('agrees on a mixed-case network key', async () => {
+            const ctx = await makeCase(
+                { fsxNet: { localAddress: '21:1/121' } },
+                undefined
+            );
+            try {
+                const uplink = {
+                    network: 'fsxNet',
+                    addr: { zone: 21, net: 1, node: 100 },
+                };
+                const { writerDirs, pending, fileCounts } = await roundTrip(ctx, [
+                    uplink,
+                ]);
+
+                assert.equal(writerDirs.fsxNet, 'outbound');
+                assert.deepEqual(pending, ['21:1/100']);
+                assert.equal(fileCounts.fsxNet, 1);
+            } finally {
+                ctx.restore();
+            }
+        });
+
+        it('agrees on zone-suffixed subdirs across networks', async () => {
+            const ctx = await makeCase(THREE_NETWORKS, undefined);
+            try {
+                const uplinks = [
+                    //  zone 15 is not fidonet's (default network) default zone
+                    { network: 'fidonet', addr: { zone: 15, net: 2, node: 3 } },
+                    //  ...nor fsxnet's
+                    { network: 'fsxnet', addr: { zone: 15, net: 4, node: 5 } },
+                ];
+                const { writerDirs, pending, fileCounts } = await roundTrip(ctx, uplinks);
+
+                assert.deepEqual(writerDirs, {
+                    fidonet: 'outbound.00f',
+                    fsxnet: 'fsxnet.00f',
+                });
+                assert.deepEqual(pending, ['15:2/3', '15:4/5'].sort());
+                assert.deepEqual(fileCounts, { fidonet: 1, fsxnet: 1 });
+            } finally {
+                ctx.restore();
+            }
+        });
+
+        it('still ships mail queued under the pre-0.5.1-beta layout', async () => {
+            const ctx = await makeCase(THREE_NETWORKS, undefined);
+            try {
+                const uplink = UPLINKS[0]; //  fidonet — the default network
+
+                //  What the old writer produced: the default network's mail in
+                //  a directory named after the network rather than outbound/.
+                const legacyDir = path.join(ctx.outbound, 'fidonet');
+                await writeFlowInto(legacyDir, uplink.addr, 'legacy.pkt');
+
+                assert.equal(
+                    ctx.mod.getOutgoingEchoMailPacketDir(uplink.network, uplink.addr),
+                    path.join(ctx.outbound, 'outbound'),
+                    'new mail belongs in outbound/'
+                );
+
+                const pending = (await ctx.spool.getNodesWithPendingMail()).map(
+                    a => `${a.zone}:${a.net}/${a.node}`
+                );
+                assert.deepEqual(pending, ['1:103/705']);
+
+                const files = await ctx.spool.getOutboundFilesForNode(
+                    new Address(uplink.addr)
+                );
+                assert.equal(files.length, 1);
+                assert.equal(path.basename(files[0].path), 'legacy.pkt');
+            } finally {
+                ctx.restore();
+            }
+        });
+
+        it('reports a node once when both the current and legacy layouts hold mail', async () => {
+            const ctx = await makeCase(THREE_NETWORKS, undefined);
+            try {
+                const uplink = UPLINKS[0];
+
+                await writeFlowInto(
+                    path.join(ctx.outbound, 'fidonet'),
+                    uplink.addr,
+                    'legacy.pkt'
+                );
+                await writeFlowInto(
+                    ctx.mod.getOutgoingEchoMailPacketDir(uplink.network, uplink.addr),
+                    uplink.addr,
+                    'current.pkt'
+                );
+
+                const pending = await ctx.spool.getNodesWithPendingMail();
+                assert.equal(pending.length, 1, 'node must not be reported twice');
+
+                //  ...but both files still ship
+                const files = await ctx.spool.getOutboundFilesForNode(
+                    new Address(uplink.addr)
+                );
+                assert.deepEqual(files.map(f => path.basename(f.path)).sort(), [
+                    'current.pkt',
+                    'legacy.pkt',
+                ]);
+            } finally {
+                ctx.restore();
+            }
+        });
+    });
+
     // ── ftn_bso ↔ NewOutboundBSO event ───────────────────────────────────────────
     //
     //  ftn_bso emits NewOutboundBSO each time flowFileAppendRefs successfully

--- a/test/bso_util.test.js
+++ b/test/bso_util.test.js
@@ -1,0 +1,242 @@
+'use strict';
+
+const { strict: assert } = require('assert');
+
+const {
+    DEFAULT_NETWORK_DIR_NAME,
+    canonicalNetworkName,
+    resolveDefaultNetworkName,
+    resolveNetworkDefaultZone,
+    outboundDirName,
+    legacyOutboundDirName,
+    validateOutboundConfig,
+} = require('../core/bso_util.js');
+
+// ── fixtures ──────────────────────────────────────────────────────────────────
+
+//  Three networks, in config order. Matches the layout from issue #719.
+const THREE_NETWORKS = {
+    fidonet: { localAddress: '1:103/705' },
+    fsxnet: { localAddress: '21:1/121' },
+    spooknet: { localAddress: '700:100/28' },
+};
+
+const ONE_NETWORK = { fsxnet: { localAddress: '21:1/121' } };
+
+const MIXED_CASE_NETWORK = { fsxNet: { localAddress: '21:1/121' } };
+
+describe('bso_util — outbound spool path resolution', () => {
+    describe('resolveDefaultNetworkName', () => {
+        it('returns the first configured network when defaultNetwork is unset', () => {
+            assert.equal(resolveDefaultNetworkName(THREE_NETWORKS, undefined), 'fidonet');
+        });
+
+        it('returns the single configured network when defaultNetwork is unset', () => {
+            assert.equal(resolveDefaultNetworkName(ONE_NETWORK, undefined), 'fsxnet');
+        });
+
+        it('honors an explicit defaultNetwork that is not first-listed', () => {
+            assert.equal(
+                resolveDefaultNetworkName(THREE_NETWORKS, 'spooknet'),
+                'spooknet'
+            );
+        });
+
+        it('matches defaultNetwork case-insensitively and returns the canonical key', () => {
+            assert.equal(
+                resolveDefaultNetworkName(MIXED_CASE_NETWORK, 'fsxnet'),
+                'fsxNet'
+            );
+            assert.equal(resolveDefaultNetworkName(THREE_NETWORKS, 'FsxNet'), 'fsxnet');
+        });
+
+        it('falls back to the first network when defaultNetwork names an unconfigured network', () => {
+            assert.equal(
+                resolveDefaultNetworkName(THREE_NETWORKS, 'nosuchnet'),
+                'fidonet'
+            );
+        });
+
+        it('returns undefined when defaultNetwork is explicitly disabled', () => {
+            for (const disabled of [null, false, '']) {
+                assert.equal(
+                    resolveDefaultNetworkName(THREE_NETWORKS, disabled),
+                    undefined,
+                    `defaultNetwork: ${JSON.stringify(disabled)} should mean "no default"`
+                );
+            }
+        });
+
+        it('returns undefined when no networks are configured', () => {
+            assert.equal(resolveDefaultNetworkName({}, undefined), undefined);
+            assert.equal(resolveDefaultNetworkName(undefined, undefined), undefined);
+        });
+    });
+
+    describe('resolveNetworkDefaultZone', () => {
+        it('prefers an explicit defaultZone', () => {
+            const networks = { n: { localAddress: '1:2/3', defaultZone: 42 } };
+            assert.equal(resolveNetworkDefaultZone(networks, 'n'), 42);
+        });
+
+        it('falls back to the localAddress zone', () => {
+            assert.equal(resolveNetworkDefaultZone(THREE_NETWORKS, 'fsxnet'), 21);
+        });
+
+        it('resolves the network name case-insensitively', () => {
+            assert.equal(resolveNetworkDefaultZone(MIXED_CASE_NETWORK, 'fsxnet'), 21);
+        });
+
+        it('returns undefined rather than guessing when neither is usable', () => {
+            assert.equal(resolveNetworkDefaultZone({ n: {} }, 'n'), undefined);
+            assert.equal(
+                resolveNetworkDefaultZone({ n: { localAddress: 'nonsense' } }, 'n'),
+                undefined
+            );
+            assert.equal(resolveNetworkDefaultZone(THREE_NETWORKS, 'nope'), undefined);
+        });
+    });
+
+    describe('canonicalNetworkName', () => {
+        it('maps any casing to the configured key', () => {
+            assert.equal(canonicalNetworkName(MIXED_CASE_NETWORK, 'FSXNET'), 'fsxNet');
+        });
+
+        it('returns undefined for unknown or empty names', () => {
+            assert.equal(canonicalNetworkName(THREE_NETWORKS, 'nope'), undefined);
+            assert.equal(canonicalNetworkName(THREE_NETWORKS, ''), undefined);
+            assert.equal(canonicalNetworkName(THREE_NETWORKS, undefined), undefined);
+        });
+    });
+
+    describe('outboundDirName', () => {
+        it('gives the default network the bare outbound dir', () => {
+            assert.equal(
+                outboundDirName(THREE_NETWORKS, undefined, 'fidonet', 1),
+                DEFAULT_NETWORK_DIR_NAME
+            );
+        });
+
+        it('gives every other network its own dir', () => {
+            assert.equal(
+                outboundDirName(THREE_NETWORKS, undefined, 'fsxnet', 21),
+                'fsxnet'
+            );
+            assert.equal(
+                outboundDirName(THREE_NETWORKS, undefined, 'spooknet', 700),
+                'spooknet'
+            );
+        });
+
+        it('follows an explicit defaultNetwork', () => {
+            assert.equal(
+                outboundDirName(THREE_NETWORKS, 'fsxnet', 'fsxnet', 21),
+                DEFAULT_NETWORK_DIR_NAME
+            );
+            assert.equal(
+                outboundDirName(THREE_NETWORKS, 'fsxnet', 'fidonet', 1),
+                'fidonet'
+            );
+        });
+
+        it('gives no network the bare outbound dir when the default is disabled', () => {
+            assert.equal(outboundDirName(THREE_NETWORKS, null, 'fidonet', 1), 'fidonet');
+            assert.equal(outboundDirName(THREE_NETWORKS, null, 'fsxnet', 21), 'fsxnet');
+        });
+
+        it('lowercases the directory component regardless of the config key casing', () => {
+            assert.equal(
+                outboundDirName(MIXED_CASE_NETWORK, null, 'fsxNet', 21),
+                'fsxnet'
+            );
+            //  ...and still recognizes it as the default network
+            assert.equal(
+                outboundDirName(MIXED_CASE_NETWORK, undefined, 'fsxNet', 21),
+                DEFAULT_NETWORK_DIR_NAME
+            );
+        });
+
+        it('appends a 3-hex zone suffix for non-default zones', () => {
+            assert.equal(
+                outboundDirName(THREE_NETWORKS, undefined, 'fidonet', 15),
+                'outbound.00f'
+            );
+            assert.equal(
+                outboundDirName(THREE_NETWORKS, undefined, 'fsxnet', 2),
+                'fsxnet.002'
+            );
+            assert.equal(
+                outboundDirName(THREE_NETWORKS, undefined, 'spooknet', 700),
+                'spooknet'
+            );
+        });
+
+        it('omits the zone suffix when no zone is supplied', () => {
+            assert.equal(
+                outboundDirName(THREE_NETWORKS, undefined, 'fsxnet', undefined),
+                'fsxnet'
+            );
+        });
+    });
+
+    describe('legacyOutboundDirName', () => {
+        it('gives the pre-0.5.1-beta name for the default network', () => {
+            assert.equal(
+                legacyOutboundDirName(THREE_NETWORKS, undefined, 'fidonet', 1),
+                'fidonet'
+            );
+            assert.equal(
+                legacyOutboundDirName(THREE_NETWORKS, undefined, 'fidonet', 15),
+                'fidonet.00f'
+            );
+        });
+
+        it('returns null for non-default networks, whose name never changed', () => {
+            assert.equal(
+                legacyOutboundDirName(THREE_NETWORKS, undefined, 'fsxnet', 21),
+                null
+            );
+        });
+
+        it('returns null when there is no default network', () => {
+            assert.equal(legacyOutboundDirName(THREE_NETWORKS, null, 'fidonet', 1), null);
+        });
+    });
+
+    describe('validateOutboundConfig', () => {
+        it('reports nothing for a healthy config', () => {
+            assert.deepEqual(validateOutboundConfig(THREE_NETWORKS, 'fsxnet'), []);
+        });
+
+        it('reports a defaultNetwork that names no configured network', () => {
+            const issues = validateOutboundConfig(THREE_NETWORKS, 'nosuchnet');
+            assert.equal(issues.length, 1);
+            assert.equal(issues[0].code, 'unknownDefaultNetwork');
+            assert.equal(issues[0].using, 'fidonet');
+        });
+
+        it('does not report an explicitly disabled defaultNetwork as unknown', () => {
+            assert.deepEqual(validateOutboundConfig(THREE_NETWORKS, null), []);
+        });
+
+        it('reports a network whose zone cannot be resolved', () => {
+            const issues = validateOutboundConfig({ broken: {} }, undefined);
+            assert.equal(issues.length, 1);
+            assert.equal(issues[0].code, 'unresolvableZone');
+            assert.equal(issues[0].network, 'broken');
+        });
+
+        it('reports a network name that collides with the default outbound dir', () => {
+            const issues = validateOutboundConfig(
+                {
+                    fidonet: { localAddress: '1:103/705' },
+                    Outbound: { localAddress: '21:1/121' },
+                },
+                undefined
+            );
+            assert.equal(issues.length, 1);
+            assert.equal(issues[0].code, 'reservedNetworkName');
+            assert.equal(issues[0].network, 'Outbound');
+        });
+    });
+});


### PR DESCRIPTION
…kP (#719)

ftn_bso (the writer) and BsoSpool (the native BinkP mailer's reader) each carried their own rule for deciding which FTN network owns the bare outbound/ directory, and the two disagreed whenever more than one network was configured:

  writer: defaultNetwork, else the sole network, else *no* default
  reader: always the first-listed network, ignoring defaultNetwork entirely

With 2+ networks and no explicit defaultNetwork, outbound mail for the first-listed network was written to mail/ftn_out/<network>/ but looked for in mail/ftn_out/outbound/. It was never sent, never polled, and never logged an error. Setting defaultNetwork to a network that was not first-listed was worse than silence: the reader read that network's mail out of outbound/ and tagged it with the first-listed network's zone, producing addresses that do not exist.

Both sides now resolve through core/bso_util.js:

  * default network is defaultNetwork when set, else the first listed -- the behavior the docs have always described. Set defaultNetwork to null for no default network at all (every network in its own subdirectory).
  * network names are matched case-insensitively and directory components are always lowercased. A mixed-case key such as "fsxNet" previously broke the writer/reader agreement even with a single network configured.
  * a defaultNetwork naming an unconfigured network falls back to the first listed and is reported at startup rather than quietly leaving the system with no default.
  * zones resolve to defaultZone, else the localAddress zone, else undefined -- the reader no longer assumes zone 1 and fabricates addresses for networks it cannot place.

Upgrades are transparent: BsoSpool also scans the pre-0.5.1-beta directory for the default network, so mail already queued there still ships and the directory drains itself. ftn_bso logs a pointer to UPGRADE.md while it is non-empty. Sysops running an external mailer must repoint it at outbound/ or set defaultNetwork: null -- see UPGRADE.md.

Also in BsoSpool, since it no longer has to guess:

  * getOutboundFilesForNode() scans every candidate directory for the address's zone instead of one guessed directory, which additionally fixes two networks sharing a zone
  * _allOutboundDirs() reads the outbound root once rather than once per network, and matches zone subdirectories by prefix instead of an unescaped RegExp built from the network name

The two existing writer/reader path-compatibility tests only configured a single network, which is the one case where the old implementations agreed. Adds multi-network coverage for every layout that used to diverge, plus unit tests for the shared resolver.