### PR TITLE
fix(binkp): apply config.hjson reloads without a restart

### DIFF
--- a/core/binkp/caller.js
+++ b/core/binkp/caller.js
@@ -11,27 +11,19 @@ const Events = require('../events.js');
 const configModule = require('../config.js');
 const Address = require('../ftn_address.js');
 const { BinkpSession } = require('./session.js');
-const { BsoSpool, attachSpoolToSession } = require('./bso_spool.js');
-const { localAddresses, addressKey, findBestNodeMatch } = require('./util.js');
+const { attachSpoolToSession } = require('./bso_spool.js');
+const {
+    localAddresses,
+    addressKey,
+    findBestNodeMatch,
+    buildSpool,
+} = require('./util.js');
 
 const Config = () => configModule.get();
 
 const CONNECT_TIMEOUT_MS = 30_000;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
-
-function buildSpool() {
-    const config = Config();
-    return new BsoSpool({
-        paths: _.get(config, 'scannerTossers.ftn_bso.paths'),
-        networks: _.get(config, 'messageNetworks.ftn.networks', {}),
-        defaultNetwork: _.get(config, 'scannerTossers.ftn_bso.defaultNetwork'),
-        staleLockMaxAgeMs: _.get(
-            config,
-            'scannerTossers.ftn_bso.binkp.staleLockMaxAgeMs'
-        ),
-    });
-}
 
 // Returns the most-specific node config entry whose pattern matches |addr|.
 // Specificity is by Address#getMatchScore — concrete-and-matching parts beat
@@ -142,7 +134,7 @@ async function pollNodes(forceAddrs, cb) {
         return cb(null);
     }
 
-    const spool = buildSpool();
+    const spool = buildSpool(config);
 
     let pendingAddrs;
     try {

--- a/core/binkp/util.js
+++ b/core/binkp/util.js
@@ -2,6 +2,7 @@
 
 const _ = require('lodash');
 const Address = require('../ftn_address.js');
+const { BsoSpool } = require('./bso_spool.js');
 
 //  Helpers shared across the BinkP module surface (caller, scanner_tosser).
 //  Anything reaching for `messageNetworks.ftn.networks` or the in-memory
@@ -66,4 +67,24 @@ function findBestNodeMatch(nodes, addr) {
     return bestConf;
 }
 
-module.exports = { localAddresses, addressKey, findBestNodeMatch };
+//
+//  A BsoSpool for the current configuration.
+//
+//  Build one at the point of use and throw it away -- never cache it in a
+//  closure. config.hjson is hot-reloadable, so a poll or an inbound session
+//  starting after a reload has to honour the new paths and networks. Holding
+//  a spool built at startup silently pins the process to boot-time config.
+//
+//  |config| is the full Config() object, as with localAddresses() above.
+//
+function buildSpool(config) {
+    const ftnBsoCfg = _.get(config, 'scannerTossers.ftn_bso', {});
+    return new BsoSpool({
+        paths: ftnBsoCfg.paths,
+        networks: _.get(config, 'messageNetworks.ftn.networks', {}),
+        defaultNetwork: ftnBsoCfg.defaultNetwork,
+        staleLockMaxAgeMs: _.get(ftnBsoCfg, 'binkp.staleLockMaxAgeMs'),
+    });
+}
+
+module.exports = { localAddresses, addressKey, findBestNodeMatch, buildSpool };

--- a/core/scanner_tossers/binkp.js
+++ b/core/scanner_tossers/binkp.js
@@ -15,9 +15,14 @@ const configModule = require('../config.js');
 const Address = require('../ftn_address.js');
 const { MessageScanTossModule } = require('../msg_scan_toss_module.js');
 const { BinkpSession } = require('../binkp/session.js');
-const { BsoSpool, attachSpoolToSession } = require('../binkp/bso_spool.js');
+const { attachSpoolToSession } = require('../binkp/bso_spool.js');
 const { pollNodes } = require('../binkp/caller.js');
-const { localAddresses, addressKey, findBestNodeMatch } = require('../binkp/util.js');
+const {
+    localAddresses,
+    addressKey,
+    findBestNodeMatch,
+    buildSpool,
+} = require('../binkp/util.js');
 const { FreqResolver, attachFreqToSession } = require('../binkp/freq.js');
 
 const Config = () => configModule.get();
@@ -27,6 +32,20 @@ const Config = () => configModule.get();
 //  node coalesce into a single session. Tunable via
 //  scannerTossers.ftn_bso.binkp.crashmailDebounceMs.
 const DEFAULT_CRASHMAIL_DEBOUNCE_MS = 500;
+
+//  Settings baked into a socket at listen() time. Unlike everything else in
+//  the binkp block, these cannot be picked up by re-reading config: applying
+//  them means tearing down and rebinding a listener, potentially under live
+//  sessions. A reload that touches them is reported instead.
+const LISTENER_BOUND_KEYS = [
+    'inbound.enabled',
+    'inbound.port',
+    'inbound.address',
+    'inbound.tls.enabled',
+    'inbound.tls.port',
+    'inbound.tls.certFile',
+    'inbound.tls.keyFile',
+];
 
 //  Inbound temp file (binkp_in_*.dt) startup-sweep age threshold. Anything
 //  older than this in tempDir at startup is treated as a leaked partial from
@@ -85,6 +104,9 @@ exports.getModule = class BinkpModule extends MessageScanTossModule {
         this._crashmailTimer = null;
         this._crashmailPending = new Map(); // zone:net/node -> Address
         this._crashmailListener = null;
+        this._configChangedListener = null;
+        this._listenerConfig = null; // boot-time LISTENER_BOUND_KEYS snapshot
+        this._pullSchedule = null;
     }
 
     startup(cb) {
@@ -97,11 +119,12 @@ exports.getModule = class BinkpModule extends MessageScanTossModule {
 
         async.series(
             [
-                callback => this._reapStaleLocks(binkpCfg, ftnBsoCfg, callback),
+                callback => this._reapStaleLocks(callback),
                 callback => this._reapInboundTemps(binkpCfg, callback),
-                callback => this._startInbound(binkpCfg, ftnBsoCfg, callback),
+                callback => this._startInbound(binkpCfg, callback),
                 callback => this._startPullSchedule(binkpCfg, callback),
-                callback => this._startCrashmailListener(binkpCfg, callback),
+                callback => this._startCrashmailListener(callback),
+                callback => this._startConfigWatch(binkpCfg, callback),
             ],
             cb
         );
@@ -117,6 +140,13 @@ exports.getModule = class BinkpModule extends MessageScanTossModule {
             this._crashmailTimer = null;
         }
         this._crashmailPending.clear();
+        if (this._configChangedListener) {
+            Events.removeListener(
+                Events.getSystemEvents().ConfigChanged,
+                this._configChangedListener
+            );
+            this._configChangedListener = null;
+        }
         if (this._crashmailListener) {
             Events.removeListener(
                 Events.getSystemEvents().NewOutboundBSO,
@@ -154,14 +184,8 @@ exports.getModule = class BinkpModule extends MessageScanTossModule {
     //  Sweep orphaned .bsy locks left by a prior crashed run before we start
     //  anything that depends on them. Runs unconditionally — outbound sessions
     //  acquire locks too, so this matters even when inbound is disabled.
-    _reapStaleLocks(binkpCfg, ftnBsoCfg, cb) {
-        const spool = new BsoSpool({
-            paths: ftnBsoCfg.paths,
-            networks: _.get(Config(), 'messageNetworks.ftn.networks', {}),
-            defaultNetwork: ftnBsoCfg.defaultNetwork,
-            staleLockMaxAgeMs: binkpCfg.staleLockMaxAgeMs,
-        });
-        spool
+    _reapStaleLocks(cb) {
+        buildSpool(Config())
             .reapStaleLocks()
             .then(reaped => {
                 if (reaped > 0) {
@@ -208,23 +232,17 @@ exports.getModule = class BinkpModule extends MessageScanTossModule {
             });
     }
 
-    _startInbound(binkpCfg, ftnBsoCfg, cb) {
+    _startInbound(binkpCfg, cb) {
         const inbound = _.get(binkpCfg, 'inbound', {});
         if (!inbound.enabled) return cb(null);
 
-        const spool = new BsoSpool({
-            paths: ftnBsoCfg.paths,
-            networks: _.get(Config(), 'messageNetworks.ftn.networks', {}),
-            defaultNetwork: ftnBsoCfg.defaultNetwork,
-            staleLockMaxAgeMs: binkpCfg.staleLockMaxAgeMs,
-        });
-
-        const addresses = localAddresses(Config());
-        const tempDir = _.get(binkpCfg, 'tempDir', os.tmpdir());
         const bindAddress = inbound.address || '0.0.0.0';
 
+        //  Only the binding itself is fixed for the life of the socket.
+        //  Everything a session reads is resolved per connection in
+        //  _handleConnection() so a config reload applies without a restart.
         this._server = net.createServer(socket => {
-            this._handleConnection(socket, spool, addresses, binkpCfg, tempDir);
+            this._handleConnection(socket);
         });
         this._server.on('error', err => {
             Log.error({ error: err.message }, '[BinkP] Server error');
@@ -257,7 +275,7 @@ exports.getModule = class BinkpModule extends MessageScanTossModule {
         Promise.all([fsp.readFile(tlsCfg.certFile), fsp.readFile(tlsCfg.keyFile)])
             .then(([cert, key]) => {
                 this._tlsServer = tls.createServer({ cert, key }, socket => {
-                    this._handleConnection(socket, spool, addresses, binkpCfg, tempDir);
+                    this._handleConnection(socket);
                 });
                 this._tlsServer.on('error', err => {
                     Log.error({ error: err.message }, '[BinkP] TLS server error');
@@ -312,7 +330,7 @@ exports.getModule = class BinkpModule extends MessageScanTossModule {
         this._pullTimer = later.setInterval(() => {
             if (polling) return;
             polling = true;
-            const addrs = this._pullAddresses(binkpCfg);
+            const addrs = this._pullAddresses();
             Log.info({ count: addrs.length }, '[BinkP] Scheduled pull cycle starting');
             pollNodes(addrs, () => {
                 polling = false;
@@ -331,13 +349,7 @@ exports.getModule = class BinkpModule extends MessageScanTossModule {
     //  the same peer turns into one session, not N. After the debounce
     //  window elapses, dial whatever set of addresses accumulated.
     //
-    _startCrashmailListener(binkpCfg, cb) {
-        const debounceMs = _.get(
-            binkpCfg,
-            'crashmailDebounceMs',
-            DEFAULT_CRASHMAIL_DEBOUNCE_MS
-        );
-
+    _startCrashmailListener(cb) {
         this._crashmailListener = ({ address }) => {
             //  Drop malformed events: a crashmail entry with an undefined
             //  net/node would dedupe to "0:undefined/0" and corrupt the
@@ -351,6 +363,13 @@ exports.getModule = class BinkpModule extends MessageScanTossModule {
             this._crashmailPending.set(key, address);
 
             if (this._crashmailTimer) return; // window already open
+
+            //  Read per burst so a reload retunes the coalescing window
+            const debounceMs = _.get(
+                Config(),
+                'scannerTossers.ftn_bso.binkp.crashmailDebounceMs',
+                DEFAULT_CRASHMAIL_DEBOUNCE_MS
+            );
             this._crashmailTimer = setTimeout(() => {
                 this._crashmailTimer = null;
                 const addrs = Array.from(this._crashmailPending.values());
@@ -374,10 +393,75 @@ exports.getModule = class BinkpModule extends MessageScanTossModule {
         return cb(null);
     }
 
+    //
+    //  config.hjson is hot-reloadable. Almost everything this module needs is
+    //  read at the point of use -- per inbound connection, per poll, per
+    //  crashmail burst -- so a reload applies on its own. Two things can't
+    //  work that way and are reconciled here:
+    //
+    //    * the pull schedule, which is compiled into a timer -> rebuild it
+    //    * the inbound listener bindings, which are baked into a socket ->
+    //      report that a restart is needed rather than silently ignoring them
+    //
+    _startConfigWatch(binkpCfg, cb) {
+        this._listenerConfig = this._listenerSnapshot(binkpCfg);
+        this._pullSchedule = binkpCfg.pullSchedule;
+
+        this._configChangedListener = () => this._applyConfigChange();
+        Events.addListener(
+            Events.getSystemEvents().ConfigChanged,
+            this._configChangedListener
+        );
+        return cb(null);
+    }
+
+    _listenerSnapshot(binkpCfg) {
+        return LISTENER_BOUND_KEYS.reduce((snapshot, key) => {
+            snapshot[key] = _.get(binkpCfg, key);
+            return snapshot;
+        }, {});
+    }
+
+    _applyConfigChange() {
+        const binkpCfg = _.get(Config(), 'scannerTossers.ftn_bso.binkp', {});
+
+        if (binkpCfg.pullSchedule !== this._pullSchedule) {
+            this._pullSchedule = binkpCfg.pullSchedule;
+            if (this._pullTimer) {
+                this._pullTimer.clear();
+                this._pullTimer = null;
+            }
+            //  _startPullSchedule logs the outcome, including a disabled or
+            //  unparsable schedule, and never errors
+            this._startPullSchedule(binkpCfg, () => {});
+            Log.info(
+                { schedule: binkpCfg.pullSchedule || null },
+                '[BinkP] Pull schedule reloaded'
+            );
+        }
+
+        //  Compared against the boot-time snapshot rather than the previous
+        //  reload: the mismatch stands until the BBS is restarted, so it is
+        //  still worth saying on a later reload.
+        const current = this._listenerSnapshot(binkpCfg);
+        const changed = LISTENER_BOUND_KEYS.filter(
+            key => !_.isEqual(current[key], this._listenerConfig[key])
+        );
+        if (changed.length > 0) {
+            Log.warn(
+                { changed },
+                '[BinkP] Inbound listener settings changed; restart required for them to take effect'
+            );
+        }
+    }
+
     //  Build the list of addresses for a pull cycle: every entry in
     //  binkp.nodes whose pattern parses as a concrete address (not a
     //  wildcard) and whose config doesn't set `pull: false`.
+    //  |binkpCfg| defaults to the live config; pass one explicitly only to
+    //  evaluate a set of nodes other than what is currently configured.
     _pullAddresses(binkpCfg) {
+        binkpCfg = binkpCfg || _.get(Config(), 'scannerTossers.ftn_bso.binkp', {});
         const nodes = binkpCfg.nodes || {};
         const out = [];
         for (const [pattern, conf] of Object.entries(nodes)) {
@@ -395,9 +479,19 @@ exports.getModule = class BinkpModule extends MessageScanTossModule {
         return out;
     }
 
-    async _handleConnection(socket, spool, addresses, binkpCfg, tempDir) {
+    async _handleConnection(socket) {
         const remote = `${socket.remoteAddress}:${socket.remotePort}`;
         Log.info({ remote }, '[BinkP] Inbound connection');
+
+        //  Resolved per connection, not per process: config.hjson is
+        //  hot-reloadable and a session opened after a reload must honour the
+        //  new spool paths, local addresses, node passwords and FREQ config.
+        //  Read once here so the values can't shift mid-session.
+        const config = Config();
+        const binkpCfg = _.get(config, 'scannerTossers.ftn_bso.binkp', {});
+        const spool = buildSpool(config);
+        const addresses = localAddresses(config);
+        const tempDir = _.get(binkpCfg, 'tempDir', os.tmpdir());
 
         const session = new BinkpSession(socket, {
             role: 'answering',

--- a/docs/_docs/messageareas/binkp.md
+++ b/docs/_docs/messageareas/binkp.md
@@ -242,6 +242,26 @@ freq: {
 
 With this setup, every new nodelist that arrives via TIC is immediately FREQ-serveable — no path configuration to maintain.
 
+#### Reloading configuration
+
+`config.hjson` is watched and reloaded while the BBS runs. Almost everything under `binkp` is read at the moment it is used, so a reload applies on its own:
+
+| Setting | Applies to | When it takes effect |
+|---------|-----------|----------------------|
+| `nodes` (hosts, ports, passwords, `pull`, TLS) | next session, inbound or outbound | Immediately |
+| `freq` | next inbound session | Immediately |
+| `crashmailDebounceMs` | next crashmail burst | Immediately |
+| `tempDir`, `staleLockMaxAgeMs` | next session | Immediately |
+| `ftn_bso` `paths` and `messageNetworks.ftn.networks` | next session or poll | Immediately |
+| `pullSchedule` | the pull timer | On reload — the timer is rebuilt |
+| `inbound.enabled`, `inbound.port`, `inbound.address`, `inbound.tls.*` | the listening socket | **Restart required** |
+
+The last row is bound into the socket when it starts listening; changing it under live sessions is not something a reload can do safely. A reload that touches those keys logs a warning naming them so the change isn't silently lost:
+
+```
+[BinkP] Inbound listener settings changed; restart required for them to take effect
+```
+
 ---
 
 ### How it works with `ftn_bso`

--- a/test/binkp_server.test.js
+++ b/test/binkp_server.test.js
@@ -628,4 +628,257 @@ describe('BinkP server', function () {
                 .catch(done);
         });
     });
+
+    // ── configuration hot-reload ──────────────────────────────────────────────────
+    //
+    //  config.hjson is hot-reloadable. Anything a session or a poll reads must
+    //  be resolved when that work happens, not captured at startup — otherwise
+    //  the process stays pinned to boot-time config until it is restarted.
+    //  What genuinely cannot work that way (the pull timer, the listener
+    //  bindings) is reconciled on the ConfigChanged event instead.
+
+    describe('BinkpModule — configuration hot-reload', () => {
+        //  Push a second config over the one startModule() installed. Returns a
+        //  restore fn; call it before the module's own stop().
+        function reload(cfg, { emit = true } = {}) {
+            const prev = configModule._pushTestConfig(cfg);
+            if (emit) {
+                Events.emit(Events.getSystemEvents().ConfigChanged);
+            }
+            return () => configModule._popTestConfig(prev);
+        }
+
+        //  Collect Log.warn calls. binkp.js holds a reference to the logger
+        //  object from setup.js, so patching the method is enough.
+        function captureWarnings() {
+            const Log = require('../core/logger.js').log;
+            const original = Log.warn;
+            const captured = [];
+            Log.warn = (obj, msg) => captured.push({ obj, msg });
+            return {
+                captured,
+                restore: () => {
+                    Log.warn = original;
+                },
+            };
+        }
+
+        it('advertises a local address added after startup', done => {
+            startModule()
+                .then(({ port, stop }) => {
+                    //  testnet moves to a different node number mid-run
+                    const changed = makeConfig();
+                    changed.messageNetworks.ftn.networks.testnet.localAddress =
+                        '1:218/777';
+                    const restore = reload(changed);
+
+                    const { session } = connectClient(port);
+                    let receivedAddrs = [];
+                    session.on('addresses', addrs => {
+                        receivedAddrs = addrs;
+                    });
+                    const finish = err => {
+                        restore();
+                        stop()
+                            .then(() => done(err))
+                            .catch(done);
+                    };
+                    session.on('session-end', () => {
+                        try {
+                            assert.ok(
+                                receivedAddrs.some(a => a.includes('1:218/777')),
+                                `expected reloaded address 1:218/777 in: ${receivedAddrs.join(', ')}`
+                            );
+                            finish();
+                        } catch (e) {
+                            finish(e);
+                        }
+                    });
+                    session.on('error', finish);
+                    session.start();
+                })
+                .catch(done);
+        });
+
+        it('serves outbound mail from an outbound path set after startup', done => {
+            //  The spool used to be built once at startup, so a reloaded
+            //  paths.outbound was invisible to every inbound session.
+            startModule()
+                .then(async ({ port, stop }) => {
+                    const newSpoolDir = await fsp.mkdtemp(
+                        path.join(os.tmpdir(), 'enigma_reload_spool_')
+                    );
+                    const outDir = path.join(newSpoolDir, 'outbound');
+                    await fsp.mkdir(outDir, { recursive: true });
+
+                    //  Mail for the connecting client, 1:218/701 -> 00da02bd
+                    const pkt = path.join(outDir, 'reloaded.pkt');
+                    await fsp.writeFile(pkt, 'RELOADED');
+                    await fsp.writeFile(path.join(outDir, '00da02bd.flo'), `^${pkt}\n`);
+
+                    const changed = makeConfig();
+                    changed.scannerTossers.ftn_bso.paths.outbound = newSpoolDir;
+                    const restore = reload(changed);
+
+                    const { session } = connectClient(port);
+                    const received = [];
+                    session.on('file-received', name => received.push(name));
+
+                    const finish = err => {
+                        restore();
+                        fsp.rm(newSpoolDir, { recursive: true, force: true })
+                            .then(() => stop())
+                            .then(() => done(err))
+                            .catch(done);
+                    };
+                    session.on('session-end', () => {
+                        try {
+                            assert.deepEqual(
+                                received,
+                                ['reloaded.pkt'],
+                                'file queued under the reloaded outbound path should be sent'
+                            );
+                            finish();
+                        } catch (e) {
+                            finish(e);
+                        }
+                    });
+                    session.on('error', finish);
+                    session.start();
+                })
+                .catch(done);
+        });
+
+        it('_pullAddresses reflects nodes added after startup', async () => {
+            const { mod, stop } = await startModule({ nodes: {} });
+            assert.deepEqual(mod._pullAddresses(), []);
+
+            const restore = reload(
+                makeConfig({
+                    nodes: { '1:218/900': { host: 'example.com' } },
+                })
+            );
+            try {
+                assert.deepEqual(
+                    mod._pullAddresses().map(a => a.toString('3D')),
+                    ['1:218/900'],
+                    'pull cycle should dial nodes added by a reload'
+                );
+
+                //  An explicit argument still wins, for callers evaluating a
+                //  node set other than the configured one
+                assert.deepEqual(mod._pullAddresses({ nodes: {} }), []);
+            } finally {
+                restore();
+                await stop();
+            }
+        });
+
+        it('rebuilds the pull timer when pullSchedule changes', async () => {
+            const { mod, stop } = await startModule({
+                pullSchedule: 'every 15 minutes',
+            });
+            const originalTimer = mod._pullTimer;
+            assert.ok(originalTimer, 'pull timer should exist at startup');
+
+            const restore = reload(makeConfig({ pullSchedule: 'every 30 minutes' }));
+            try {
+                assert.ok(mod._pullTimer, 'pull timer should still be running');
+                assert.notEqual(
+                    mod._pullTimer,
+                    originalTimer,
+                    'timer should be rebuilt, not left on the old schedule'
+                );
+                assert.equal(mod._pullSchedule, 'every 30 minutes');
+            } finally {
+                restore();
+                await stop();
+            }
+        });
+
+        it('stops the pull timer when pullSchedule is removed', async () => {
+            const { mod, stop } = await startModule({
+                pullSchedule: 'every 15 minutes',
+            });
+            assert.ok(mod._pullTimer);
+
+            const restore = reload(makeConfig({ pullSchedule: null }));
+            try {
+                assert.equal(mod._pullTimer, null);
+            } finally {
+                restore();
+                await stop();
+            }
+        });
+
+        it('leaves the pull timer alone when pullSchedule is unchanged', async () => {
+            const { mod, stop } = await startModule({
+                pullSchedule: 'every 15 minutes',
+            });
+            const originalTimer = mod._pullTimer;
+
+            const restore = reload(
+                makeConfig({
+                    pullSchedule: 'every 15 minutes',
+                    crashmailDebounceMs: 999,
+                })
+            );
+            try {
+                assert.equal(mod._pullTimer, originalTimer);
+            } finally {
+                restore();
+                await stop();
+            }
+        });
+
+        it('warns that a restart is required when a listener binding changes', async () => {
+            const { mod, stop } = await startModule();
+            const warn = captureWarnings();
+
+            const changed = makeConfig();
+            changed.scannerTossers.ftn_bso.binkp.inbound.port = 24999;
+            const restore = reload(changed);
+            try {
+                const restartWarnings = warn.captured.filter(w =>
+                    /restart required/i.test(w.msg || '')
+                );
+                assert.equal(restartWarnings.length, 1);
+                assert.deepEqual(restartWarnings[0].obj.changed, ['inbound.port']);
+            } finally {
+                warn.restore();
+                restore();
+                await stop();
+            }
+            assert.ok(mod);
+        });
+
+        it('does not warn when only hot-appliable settings change', async () => {
+            const { stop } = await startModule();
+            const warn = captureWarnings();
+
+            const restore = reload(makeConfig({ crashmailDebounceMs: 999 }));
+            try {
+                assert.deepEqual(
+                    warn.captured.filter(w => /restart required/i.test(w.msg || '')),
+                    []
+                );
+            } finally {
+                warn.restore();
+                restore();
+                await stop();
+            }
+        });
+
+        it('removes its ConfigChanged listener on shutdown', async () => {
+            const eventName = Events.getSystemEvents().ConfigChanged;
+            const before = Events.listenerCount(eventName);
+
+            const { mod, stop } = await startModule();
+            assert.equal(Events.listenerCount(eventName), before + 1);
+
+            await stop();
+            assert.equal(Events.listenerCount(eventName), before);
+            assert.equal(mod._configChangedListener, null);
+        });
+    });
 }); // describe('BinkP server')

--- a/test/binkp_util.test.js
+++ b/test/binkp_util.test.js
@@ -2,10 +2,15 @@
 
 const { strict: assert } = require('assert');
 
+const fsp = require('fs/promises');
+const path = require('path');
+const os = require('os');
+
 const {
     localAddresses,
     addressKey,
     findBestNodeMatch,
+    buildSpool,
 } = require('../core/binkp/util.js');
 const Address = require('../core/ftn_address.js');
 
@@ -140,5 +145,67 @@ describe('binkp/util — findBestNodeMatch', () => {
         const nodes = { '21:1/100': { host: 'plain.example' } };
         const got = findBestNodeMatch(nodes, { zone: 21, net: 1, node: 100 });
         assert.equal(got.host, 'plain.example');
+    });
+});
+
+describe('binkp/util — buildSpool', () => {
+    let tmpDir;
+
+    before(async () => {
+        tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'enigma_buildspool_'));
+    });
+
+    after(async () => {
+        await fsp.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    function makeConfig(overrides = {}) {
+        return {
+            scannerTossers: {
+                ftn_bso: Object.assign(
+                    {
+                        paths: {
+                            outbound: tmpDir,
+                            inbound: path.join(tmpDir, 'in'),
+                            secInbound: path.join(tmpDir, 'secin'),
+                        },
+                    },
+                    overrides
+                ),
+            },
+            messageNetworks: {
+                ftn: {
+                    networks: {
+                        testnet: { localAddress: '1:218/700', defaultZone: 1 },
+                    },
+                },
+            },
+        };
+    }
+
+    it('wires paths and networks through to the spool', async () => {
+        //  Round-trip rather than inspect: a spool built from |config| must
+        //  find mail written under that config's outbound path.
+        const outDir = path.join(tmpDir, 'outbound');
+        await fsp.mkdir(outDir, { recursive: true });
+        const pkt = path.join(outDir, 'pending.pkt');
+        await fsp.writeFile(pkt, 'DATA');
+        await fsp.writeFile(path.join(outDir, '00da02bd.flo'), `^${pkt}\n`);
+
+        const spool = buildSpool(makeConfig());
+        const pending = await spool.getNodesWithPendingMail();
+
+        assert.equal(pending.length, 1);
+        assert.equal(pending[0].toString('3D'), '1:218/701');
+    });
+
+    it('passes staleLockMaxAgeMs through when configured', () => {
+        const spool = buildSpool(makeConfig({ binkp: { staleLockMaxAgeMs: 1234 } }));
+        assert.equal(spool._staleLockMaxAgeMs, 1234);
+    });
+
+    it('tolerates an empty or absent config rather than throwing', () => {
+        assert.doesNotThrow(() => buildSpool({}));
+        assert.doesNotThrow(() => buildSpool(undefined));
     });
 });


### PR DESCRIPTION
config.hjson is watched and reloaded at runtime, but the BinkP module read most of its configuration once during startup and threaded the values into long-lived closures. The inbound listener in particular captured a BsoSpool, the local address list, and the whole binkp config block, then reused them for every connection for the life of the process. After a reload, inbound sessions kept resolving outbound directories against the old paths and networks, advertised the old local addresses, and authenticated against the old node passwords -- silently, until the BBS was restarted. The pull cycle dialed the node set as it was at boot, and the crashmail debounce window was fixed at its startup value.

Nothing here needed a new mechanism: binkp.js binds Config as a call-time indirection already, so the fix is to stop reading early.

  * _handleConnection() resolves the spool, local addresses, node/FREQ config, and tempDir per connection -- once at the top, so values can't shift mid-session. Both listeners now close over nothing but `this`.
  * _pullAddresses() defaults to the live config; the parameter stays for callers evaluating some other node set.
  * the crashmail debounce window is read per burst.

Two things can't be fixed by reading later, and are reconciled on the ConfigChanged event instead:

  * pullSchedule is compiled into a later.js timer, so the timer is rebuilt when the expression changes (and cleared when it is removed).
  * the inbound listener bindings -- enabled, port, address, tls.* -- are baked into a socket at listen() time. Rebinding under live sessions is not something a reload should do, so a change to those keys is reported as restart-required rather than silently ignored.

Also consolidates the three near-identical BsoSpool constructions into a single buildSpool() in binkp/util.js, whose header already asked for exactly that ("...so the three callsites can't drift").