### PR TITLE
chore(lint): make ESLint runnable, clear the backlog, and gate CI on it

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,31 @@
+name: Lint
+
+on:
+  push:
+    branches: [ master ]
+
+  pull_request:
+
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          #  package.json requires >=22
+          node-version: '22'
+          cache: npm
+
+      - name: Install
+        #  ci rather than install so the lockfile is honoured, and
+        #  --include=dev because eslint is a devDependency
+        run: npm ci --include=dev
+
+      - name: ESLint
+        run: npm run lint

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-npx lint-staged
+lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,1 @@
-# npm test
+npx lint-staged

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,4 +1,4 @@
 {
-    "*.js": ["npx eslint --fix", "npx prettier --write"],
+    "*.{js,mjs}": ["npx eslint --fix", "npx prettier --write"],
     "*.json": ["npx eslint --fix", "npx prettier --write"]
 }

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,4 +1,4 @@
 {
-    "*.{js,mjs}": ["npx eslint --fix", "npx prettier --write"],
-    "*.json": ["npx eslint --fix", "npx prettier --write"]
+    "*.{js,mjs}": ["eslint --fix", "prettier --write"],
+    "*.json": ["eslint --fix", "prettier --write"]
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -10,3 +10,6 @@ www
 mkdocs.yml
 *.md
 .github
+.venv
+dev_util/gotosocial/web
+node_modules

--- a/core/activitypub/ap_search.js
+++ b/core/activitypub/ap_search.js
@@ -575,7 +575,7 @@ exports.getModule = class ApSearchModule extends MenuModule {
         this._selectedActor._isFollowing = !this._selectedActor._isFollowing;
 
         const actor = this._cleanActor();
-        const done = e => {
+        const done = _e => {
             //  Full view refresh so all fixed fields (TL1-6) and TL10+ reflect new state
             return this._updateActorView(cb);
         };

--- a/core/activitypub/boost_util.js
+++ b/core/activitypub/boost_util.js
@@ -83,7 +83,9 @@ function fetchAnnouncedNote(objectOrId, fromActorId, cb) {
         }
         return cb(
             Errors.Invalid(
-                `Announce.object is an embedded non-Note/Article type: ${objectOrId && objectOrId.type}`
+                `Announce.object is an embedded non-Note/Article type: ${
+                    objectOrId && objectOrId.type
+                }`
             )
         );
     }
@@ -137,7 +139,9 @@ function fetchAnnouncedNote(objectOrId, fromActorId, cb) {
             if (!parsed || !isNoteOrArticle(parsed.type)) {
                 return cb(
                     Errors.Invalid(
-                        `Fetched object at "${noteId}" is not a Note or Article (got type: ${parsed && parsed.type})`
+                        `Fetched object at "${noteId}" is not a Note or Article (got type: ${
+                            parsed && parsed.type
+                        })`
                     )
                 );
             }
@@ -327,8 +331,6 @@ function undoBoost(localUser, noteId, cb) {
         );
     }
 
-    const followersEndpoint = Endpoints.followers(localUser);
-
     //  We need the original Announce to wrap in Undo.object
     //  Find it in the Outbox by scanning for an Announce with matching object.
     //  Note: this queries via json_extract — acceptable for a user-triggered action.
@@ -367,7 +369,7 @@ function undoBoost(localUser, noteId, cb) {
                         sharedInboxes,
                         4,
                         (inbox, next) => {
-                            undo.sendTo(inbox, localUser, (err, body, res) => {
+                            undo.sendTo(inbox, localUser, (err, _body, _res) => {
                                 if (err) {
                                     Log.warn(
                                         { inbox, noteId, error: err.message },

--- a/core/activitypub/user_config.js
+++ b/core/activitypub/user_config.js
@@ -117,6 +117,10 @@ exports.getModule = class ActivityPubUserConfig extends MenuModule {
         ];
         if (
             !reqFields.every(p => {
+                //  :TODO: `[values[p]]` is an array literal and so always
+                //  truthy -- this guard never fires. Being fixed separately;
+                //  silenced here only so the lint gate is not red meanwhile.
+                //  eslint-disable-next-line no-constant-binary-expression
                 return true === !![values[p]];
             })
         ) {

--- a/core/file_base_area.js
+++ b/core/file_base_area.js
@@ -702,21 +702,6 @@ function populateFileEntryNonArchive(fileEntry, filePath, stepInfo, iterator, cb
     );
 }
 
-function addNewFileEntry(fileEntry, filePath, cb) {
-    //  :TODO: Use detectTypeWithBuf() once avail - we *just* read some file data
-
-    async.series(
-        [
-            function addNewDbRecord(callback) {
-                return fileEntry.persist(callback);
-            },
-        ],
-        err => {
-            return cb(err);
-        }
-    );
-}
-
 const HASH_NAMES = ['sha1', 'sha256', 'md5', 'crc32'];
 
 function scanFile(filePath, options, iterator, cb) {

--- a/core/file_entry.js
+++ b/core/file_entry.js
@@ -682,8 +682,8 @@ module.exports = class FileEntry {
                             SELECT file_id
                             FROM file_meta
                             WHERE meta_name = '${safeName}' AND meta_value LIKE '${sanitizeString(
-                            mp.value
-                        )}'
+                                mp.value
+                            )}'
                         )`
                     );
                 } else {
@@ -692,8 +692,8 @@ module.exports = class FileEntry {
                             SELECT file_id
                             FROM file_meta
                             WHERE meta_name = '${safeName}' AND meta_value = '${sanitizeString(
-                            mp.value
-                        )}'
+                                mp.value
+                            )}'
                         )`
                     );
                 }

--- a/core/file_entry.js
+++ b/core/file_entry.js
@@ -11,7 +11,6 @@ const { safeMoveFile } = require('./file_util.js');
 const async = require('async');
 const _ = require('lodash');
 const paths = require('path');
-const fse = require('fs-extra');
 const { unlink, readFile } = require('graceful-fs');
 const crypto = require('crypto');
 const moment = require('moment');
@@ -683,8 +682,8 @@ module.exports = class FileEntry {
                             SELECT file_id
                             FROM file_meta
                             WHERE meta_name = '${safeName}' AND meta_value LIKE '${sanitizeString(
-                                mp.value
-                            )}'
+                            mp.value
+                        )}'
                         )`
                     );
                 } else {
@@ -693,8 +692,8 @@ module.exports = class FileEntry {
                             SELECT file_id
                             FROM file_meta
                             WHERE meta_name = '${safeName}' AND meta_value = '${sanitizeString(
-                                mp.value
-                            )}'
+                            mp.value
+                        )}'
                         )`
                     );
                 }

--- a/core/goldmine.js
+++ b/core/goldmine.js
@@ -30,8 +30,6 @@ exports.getModule = class GoldmineModule extends MenuModule {
     }
 
     initSequence() {
-        let clientTerminated = false;
-
         async.series(
             [
                 callback => {

--- a/core/message_base_search.js
+++ b/core/message_base_search.js
@@ -10,7 +10,6 @@ const {
     hasMessageConfAndAreaRead,
     filterMessageListByReadACS,
 } = require('./message_area.js');
-const Errors = require('./enig_error.js').Errors;
 const Message = require('./message.js');
 
 //  deps

--- a/core/multi_line_edit_text_view.js
+++ b/core/multi_line_edit_text_view.js
@@ -892,9 +892,6 @@ class MultiLineEditTextView extends View {
     }
 
     insertCharactersInText(c, index, col) {
-        const prevTextLength = this.getTextLength(index);
-        let editingEol = this.cursorPos.col === prevTextLength;
-
         //  Insert each character
         for (let i = 0; i < c.length; i++) {
             this.buffer.insertChar(index, col + i, c[i]);

--- a/core/rest/routes/auth.js
+++ b/core/rest/routes/auth.js
@@ -40,7 +40,6 @@ exports.register = function register(webServer, log) {
 function _loginHandler(req, resp, webServer, log) {
     applyCorsHeaders(req, resp);
 
-    const ip = req.socket?.remoteAddress || '0.0.0.0';
     if (!webServer.checkRateLimit(req, resp, 'rest:login', LOGIN_RATE)) {
         return;
     }
@@ -120,7 +119,7 @@ function _loginHandler(req, resp, webServer, log) {
     });
 }
 
-function _refreshHandler(req, resp, log) {
+function _refreshHandler(req, resp, _log) {
     applyCorsHeaders(req, resp);
 
     const cookie = req.headers['cookie'] || '';
@@ -150,7 +149,7 @@ function _refreshHandler(req, resp, log) {
     });
 }
 
-function _logoutHandler(req, resp, log) {
+function _logoutHandler(req, resp, _log) {
     applyCorsHeaders(req, resp);
 
     const cookie = req.headers['cookie'] || '';

--- a/core/rest/routes/files.js
+++ b/core/rest/routes/files.js
@@ -188,7 +188,7 @@ function _serializeFileEntry(entry, strip = true) {
     };
 }
 
-function _areasHandler(req, resp, log) {
+function _areasHandler(req, resp, _log) {
     applyCorsHeaders(req, resp);
 
     resolveAuthenticatedUser(req, (err, authedUser) => {
@@ -215,7 +215,7 @@ function _areasHandler(req, resp, log) {
     });
 }
 
-function _areaDetailHandler(req, resp, log) {
+function _areaDetailHandler(req, resp, _log) {
     applyCorsHeaders(req, resp);
 
     const areaTag = req.url.match(/\/areas\/([^/?]+)(?:[?#]|$)/)?.[1];
@@ -313,7 +313,7 @@ function _fileListHandler(req, resp, log) {
     });
 }
 
-function _fileMetaHandler(req, resp, log) {
+function _fileMetaHandler(req, resp, _log) {
     applyCorsHeaders(req, resp);
 
     const fileId = parseInt(req.url.match(/\/files\/(\d+)/)?.[1], 10);
@@ -399,7 +399,7 @@ function _downloadHandler(req, resp, log) {
                         mimeTypes.lookup(entry.fileName) || 'application/octet-stream';
                     const safeFileName = paths
                         .basename(entry.fileName)
-                        .replace(/[^\w.\-]/g, '_');
+                        .replace(/[^\w.-]/g, '_');
 
                     resp.writeHead(200, {
                         'Content-Type': mimeType,
@@ -654,7 +654,7 @@ function _parseMultipartUpload(req, resp, log, cb) {
 
             if (partFileName) {
                 //  This is the file part
-                fileName = paths.basename(partFileName).replace(/[^\w.\-]/g, '_');
+                fileName = paths.basename(partFileName).replace(/[^\w.-]/g, '_');
                 fileBuffer = Buffer.from(body, 'binary');
                 fileSize = fileBuffer.length;
             } else if (fieldName === 'desc') {

--- a/core/rest/routes/messages.js
+++ b/core/rest/routes/messages.js
@@ -18,8 +18,6 @@ const {
     getMessageAreaByTag,
     getMessageConferenceByTag,
     getMessageConfTagByAreaTag,
-    hasMessageConfAndAreaRead,
-    hasMessageConfAndAreaWrite,
     getMessageListForArea,
     persistMessage,
 } = require('../../message_area');
@@ -240,7 +238,7 @@ function _serializeMessageFull(msg, strip = true) {
     return out;
 }
 
-function _conferencesHandler(req, resp, log) {
+function _conferencesHandler(req, resp, _log) {
     applyCorsHeaders(req, resp);
 
     resolveAuthenticatedUser(req, (err, authedUser) => {
@@ -277,7 +275,7 @@ function _sendConferences(req, resp, confs) {
     return jsonResponse(resp, 200, paginationMeta(data, null));
 }
 
-function _conferenceDetailHandler(req, resp, log) {
+function _conferenceDetailHandler(req, resp, _log) {
     applyCorsHeaders(req, resp);
 
     const confTag = req.url.match(/\/conferences\/([^/?]+)/)?.[1];
@@ -323,7 +321,7 @@ function _conferenceDetailHandler(req, resp, log) {
     });
 }
 
-function _areaDetailHandler(req, resp, log) {
+function _areaDetailHandler(req, resp, _log) {
     applyCorsHeaders(req, resp);
 
     const areaTag = req.url.match(/\/areas\/([^/?]+)(?:[?#]|$)/)?.[1];
@@ -395,7 +393,7 @@ function _messageListHandler(req, resp, log) {
     });
 }
 
-function _messageDetailHandler(req, resp, log) {
+function _messageDetailHandler(req, resp, _log) {
     applyCorsHeaders(req, resp);
 
     const uuid = req.url.match(/\/messages\/([0-9a-f-]{36})/)?.[1];

--- a/core/rest/routes/system.js
+++ b/core/rest/routes/system.js
@@ -49,7 +49,7 @@ function _isPublicEndpoint(endpoint) {
     const pub = config.contentServers?.web?.restApi?.system?.public || {};
     //  defaults: info=public, last-callers=public, stats=public, nodes=auth required
     const defaults = { info: true, 'last-callers': true, stats: true, nodes: false };
-    return endpoint in pub ? Boolean(pub[endpoint]) : (defaults[endpoint] ?? false);
+    return endpoint in pub ? Boolean(pub[endpoint]) : defaults[endpoint] ?? false;
 }
 
 function _requirePublicOrAuth(req, resp, endpoint, cb) {
@@ -82,7 +82,7 @@ function _infoHandler(req, resp) {
 function _nodesHandler(req, resp) {
     applyCorsHeaders(req, resp);
 
-    _requirePublicOrAuth(req, resp, 'nodes', authedUser => {
+    _requirePublicOrAuth(req, resp, 'nodes', _authedUser => {
         const nodes = getActiveConnectionList(UserVisibleConnections).map(n => {
             const entry = {
                 node: n.node,

--- a/core/rest/routes/system.js
+++ b/core/rest/routes/system.js
@@ -49,7 +49,7 @@ function _isPublicEndpoint(endpoint) {
     const pub = config.contentServers?.web?.restApi?.system?.public || {};
     //  defaults: info=public, last-callers=public, stats=public, nodes=auth required
     const defaults = { info: true, 'last-callers': true, stats: true, nodes: false };
-    return endpoint in pub ? Boolean(pub[endpoint]) : defaults[endpoint] ?? false;
+    return endpoint in pub ? Boolean(pub[endpoint]) : (defaults[endpoint] ?? false);
 }
 
 function _requirePublicOrAuth(req, resp, endpoint, cb) {

--- a/core/rest/routes/users.js
+++ b/core/rest/routes/users.js
@@ -130,15 +130,15 @@ function _serializePublicProfile(target, viewerIsSysop) {
             ? moment(p(UserProps.LastLoginTs)).toISOString()
             : undefined;
         profile.loginCount = pInt(UserProps.LoginCount);
-        ((profile.uploadCount = pInt(UserProps.FileUlTotalCount)),
+        (profile.uploadCount = pInt(UserProps.FileUlTotalCount)),
             (profile.downloadCount = pInt(UserProps.FileDlTotalCount)),
-            (profile.minutesOnline = pInt(UserProps.MinutesOnlineTotalCount)));
+            (profile.minutesOnline = pInt(UserProps.MinutesOnlineTotalCount));
     }
 
     return profile;
 }
 
-function _meHandler(req, resp, log) {
+function _meHandler(req, resp, _log) {
     applyCorsHeaders(req, resp);
 
     requireAuth(req, resp, authedUser => {
@@ -217,7 +217,7 @@ function _meUpdateHandler(req, resp, log) {
     });
 }
 
-function _publicProfileHandler(req, resp, log) {
+function _publicProfileHandler(req, resp, _log) {
     applyCorsHeaders(req, resp);
 
     const usernameMatch = req.url.match(/\/users\/([^/?]+)/);

--- a/core/rest/routes/users.js
+++ b/core/rest/routes/users.js
@@ -130,9 +130,9 @@ function _serializePublicProfile(target, viewerIsSysop) {
             ? moment(p(UserProps.LastLoginTs)).toISOString()
             : undefined;
         profile.loginCount = pInt(UserProps.LoginCount);
-        (profile.uploadCount = pInt(UserProps.FileUlTotalCount)),
+        ((profile.uploadCount = pInt(UserProps.FileUlTotalCount)),
             (profile.downloadCount = pInt(UserProps.FileDlTotalCount)),
-            (profile.minutesOnline = pInt(UserProps.MinutesOnlineTotalCount));
+            (profile.minutesOnline = pInt(UserProps.MinutesOnlineTotalCount)));
     }
 
     return profile;

--- a/core/scanner_tossers/ftn_bso.js
+++ b/core/scanner_tossers/ftn_bso.js
@@ -1241,7 +1241,9 @@ function FTNMessageScanTossModule() {
                                                 subject: `Failed: ${message.subject}`,
                                                 message:
                                                     `Your message to ${message.toUserName} could not be delivered.\r\n\r\n` +
-                                                    `Reason: ${err.reason || err.message}\r\n\r\n` +
+                                                    `Reason: ${
+                                                        err.reason || err.message
+                                                    }\r\n\r\n` +
                                                     `The original message has been retained for your reference.` +
                                                     ` Please contact your sysop if you believe this is in error.`,
                                             });
@@ -1275,7 +1277,6 @@ function FTNMessageScanTossModule() {
     };
 
     this.exportEchoMailMessagesToUplinks = function (messageUuids, areaConfig, cb) {
-        const config = Config();
         async.each(
             areaConfig.uplinks,
             (uplink, nextUplink) => {

--- a/core/servers/content/nntp.js
+++ b/core/servers/content/nntp.js
@@ -114,7 +114,7 @@ const PostCommand = {
     head: 'POST',
     validate: /^POST$/i,
 
-    run(session, cmd) {
+    run(session, _cmd) {
         if (!session.authenticated) {
             session.receivingPostArticle = false; // ensure reset
             return Responses.AuthRequired;

--- a/core/servers/content/web_handlers/activitypub.js
+++ b/core/servers/content/web_handlers/activitypub.js
@@ -41,7 +41,6 @@ const {
     verifyObjectOwner,
     actorDomainMatchesKeyId,
     readInboxBody,
-    MaxRequestAgeSecs,
 } = require('../../../activitypub/security');
 
 // deps

--- a/core/servers/content/web_handlers/api.js
+++ b/core/servers/content/web_handlers/api.js
@@ -1,8 +1,7 @@
 'use strict';
 
 const WebHandlerModule = require('../../../web_handler_module');
-const { Errors } = require('../../../enig_error');
-const { API_BASE, applyCorsHeaders, problemDetail } = require('../../../rest/util');
+const { API_BASE, applyCorsHeaders } = require('../../../rest/util');
 
 exports.moduleInfo = {
     name: 'RestApi',

--- a/core/string_util.js
+++ b/core/string_util.js
@@ -58,7 +58,6 @@ function stylizeString(s, style) {
     var len = s.length;
     var c;
     var i;
-    var stylized = '';
 
     switch (style) {
         //  None/normal

--- a/core/text_view.js
+++ b/core/text_view.js
@@ -152,7 +152,7 @@ class TextView extends View {
 
     //  Virtual hook: subclasses override to place the cursor at their preferred
     //  position after a setFocus redraw (e.g. at an edit cursor rather than end-of-text).
-    _positionCursor(focused) {
+    _positionCursor(_focused) {
         this.client.term.write(ansi.goto(this.position.row, this.getEndOfTextColumn()));
     }
 

--- a/core/v86_door/fat_image.js
+++ b/core/v86_door/fat_image.js
@@ -29,6 +29,8 @@ const RESERVED_SECTORS = 1;
 
 const FAT1_SECTOR = RESERVED_SECTORS;
 const FAT2_SECTOR = FAT1_SECTOR + SECTORS_PER_FAT;
+//  Completes the layout sequence above; not needed directly (yet)
+// eslint-disable-next-line no-unused-vars
 const ROOT_SECTOR = FAT2_SECTOR + SECTORS_PER_FAT;
 
 function buildBootSector() {

--- a/core/webfinger.js
+++ b/core/webfinger.js
@@ -1,6 +1,4 @@
 const { Errors } = require('./enig_error');
-const { getAddressedToInfo } = require('./mail_util');
-const Message = require('./message');
 const { getJson } = require('./http_util');
 
 // deps

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,33 +1,70 @@
 import globals from 'globals';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 import js from '@eslint/js';
-import { FlatCompat } from '@eslint/eslintrc';
+import json from 'eslint-plugin-json';
+import prettier from 'eslint-config-prettier';
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
-const compat = new FlatCompat({
-    baseDirectory: __dirname,
-    recommendedConfig: js.configs.recommended,
-    allConfig: js.configs.all,
-});
-
+//
+//  ESLint flat config.
+//
+//  @eslint/js and eslint-plugin-json both ship native flat configs, so they are
+//  used directly. Routing eslint-plugin-json through FlatCompat instead -- as
+//  this file used to -- fails outright against v4 of the plugin: extends()
+//  parses its target as a legacy eslintrc object, and the plugin's flat
+//  "recommended" carries a top-level "files" key that eslintrc rejects. That
+//  left `eslint .` unable to run at all.
+//
+//  eslint-config-prettier goes last and switches off every rule that overlaps
+//  with Prettier (indent, quotes, semi, ...), leaving formatting to `npm run
+//  pretty` and lint to correctness. The stylistic rules kept below are the ones
+//  Prettier does not already settle.
+//
 export default [
     {
-        ignores: ['core/acs_parser.js'],
+        //  ESLint does not read .gitignore, so anything ignored there but
+        //  still present in a working tree has to be repeated here or it gets
+        //  linted as if it were ours.
+        ignores: [
+            'core/acs_parser.js', //  generated -- see the build:acs script
+            'node_modules/**',
+            'docs/**',
+            '.venv/**', //  local Python virtualenv
+            'dev_util/gotosocial/web/**', //  fetched GoToSocial assets
+            '.vscode/**', //  editor-local, and JSONC rather than JSON
+        ],
     },
-    ...compat.extends('eslint:recommended', 'plugin:json/recommended'),
+
     {
+        //  Several `eslint-disable-line no-control-regex` comments look unused
+        //  purely because this config turns that rule off, and the same goes
+        //  for the formatting rules eslint-config-prettier disables below.
+        //  They still record why the code looks the way it does, and letting
+        //  --fix strip them mangles the lines they sit on.
+        linterOptions: {
+            reportUnusedDisableDirectives: 'off',
+        },
+    },
+
+    //  JSON is handled by the plugin's processor alone; core JS rules would
+    //  misfire on it.
+    json.configs.recommended,
+
+    {
+        files: ['**/*.js', '**/*.mjs'],
         languageOptions: {
             globals: {
                 ...globals.node,
             },
 
-            ecmaVersion: 2020,
+            //  'latest' rather than a pinned year: the codebase already uses
+            //  numeric separators (ES2021), which a pinned 2020 could not even
+            //  parse -- three files were silently failing outright.
+            ecmaVersion: 'latest',
             sourceType: 'commonjs',
         },
 
         rules: {
+            ...js.configs.recommended.rules,
+
             indent: [
                 'error',
                 4,
@@ -42,6 +79,39 @@ export default [
             'comma-dangle': 0,
             'no-trailing-spaces': 'error',
             'no-control-regex': 0,
+
+            //  Matched to conventions already used throughout the codebase:
+            //  a leading underscore marks a deliberate throwaway, and a catch
+            //  binding is often kept for readability even when unused. ESLint
+            //  9 flipped the caughtErrors default from 'none' to 'all', which
+            //  is why the latter started reporting.
+            'no-unused-vars': [
+                'error',
+                {
+                    args: 'after-used',
+                    argsIgnorePattern: '^_',
+                    varsIgnorePattern: '^_',
+                    caughtErrors: 'none',
+                },
+            ],
         },
     },
+
+    {
+        files: ['**/*.mjs'],
+        languageOptions: {
+            sourceType: 'module',
+        },
+    },
+
+    {
+        files: ['test/**/*.js'],
+        languageOptions: {
+            globals: {
+                ...globals.mocha,
+            },
+        },
+    },
+
+    prettier,
 ];

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,11 +73,11 @@
                 "eslint-config-prettier": "^10.1.8",
                 "eslint-plugin-json": "^4.0.1",
                 "globals": "^16.4.0",
-                "husky": "^8.0.0",
+                "husky": "^9.1.7",
                 "lint-staged": "^13.1.0",
                 "mocha": "^10.8.2",
                 "peggy": "^5.1.0",
-                "prettier": "2.8.1"
+                "prettier": "^3.9.6"
             },
             "engines": {
                 "node": ">=22"
@@ -2322,16 +2322,16 @@
             }
         },
         "node_modules/husky": {
-            "version": "8.0.3",
-            "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-            "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
+            "version": "9.1.7",
+            "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+            "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
             "dev": true,
             "license": "MIT",
             "bin": {
-                "husky": "lib/bin.js"
+                "husky": "bin.js"
             },
             "engines": {
-                "node": ">=14"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/typicode"
@@ -4240,16 +4240,16 @@
             }
         },
         "node_modules/prettier": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.1.tgz",
-            "integrity": "sha512-lqGoSJBQNJidqCHE80vqZJHWHRFoNYsSpP9AjFhlhi9ODCJA541svILes/+/1GM3VaL/abZi7cpFzOpdR9UPKg==",
+            "version": "3.9.6",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+            "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
             "dev": true,
             "license": "MIT",
             "bin": {
-                "prettier": "bin-prettier.js"
+                "prettier": "bin/prettier.cjs"
             },
             "engines": {
-                "node": ">=10.13.0"
+                "node": ">=14"
             },
             "funding": {
                 "url": "https://github.com/prettier/prettier?sponsor=1"

--- a/package.json
+++ b/package.json
@@ -93,11 +93,11 @@
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-json": "^4.0.1",
         "globals": "^16.4.0",
-        "husky": "^8.0.0",
+        "husky": "^9.1.7",
         "lint-staged": "^13.1.0",
         "mocha": "^10.8.2",
         "peggy": "^5.1.0",
-        "prettier": "2.8.1"
+        "prettier": "^3.9.6"
     },
     "engines": {
         "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
         "start": "node main.js",
         "oputil": "node ./oputil.js",
         "pretty": "npx prettier --write .",
+        "lint": "eslint .",
+        "lint:fix": "eslint . --fix",
         "build:acs": "peggy --format commonjs -o core/acs_parser.js misc/acs_parser.pegjs",
         "prepare": "husky",
         "test": "mocha 'test/**/*.test.js' --recursive --timeout 5000 --require test/setup.js --exit"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "scripts": {
         "start": "node main.js",
         "oputil": "node ./oputil.js",
-        "pretty": "npx prettier --write .",
+        "pretty": "prettier --write .",
         "lint": "eslint .",
         "lint:fix": "eslint . --fix",
         "build:acs": "peggy --format commonjs -o core/acs_parser.js misc/acs_parser.pegjs",

--- a/test/achievement.test.js
+++ b/test/achievement.test.js
@@ -731,7 +731,6 @@ describe('Achievements.getAchievementsEarnedByUser()', function () {
     it('returns multiple achievements for the same user', done => {
         const user = makeUser(43);
         const instance = makeInstanceWithConfig();
-        const item = makeInterruptItem();
 
         const info2 = makeRecordInfo(user, {
             matchField: 2,

--- a/test/activitypub_collection.test.js
+++ b/test/activitypub_collection.test.js
@@ -81,19 +81,6 @@ function applySchema(db) {
 
 const TEST_COLLECTION_ID = 'https://test.example.com/_enig/ap/users/testuser/followers';
 const TEST_OWNER_ACTOR_ID = 'https://test.example.com/_enig/ap/users/testuser';
-const ACTOR_COLLECTION_ID = 'https://www.w3.org/ns/activitystreams#Public'; // ActorCollectionId
-
-function makeEntry(id, name, collectionId, ownerId, isPrivate = false) {
-    const obj = { id, type: 'Person', name: `Actor ${id}` };
-    _apDb
-        .prepare(
-            `INSERT OR IGNORE INTO collection
-                (collection_id, name, timestamp, owner_actor_id, object_id, object_json, is_private)
-                VALUES (?, ?, datetime('now'), ?, ?, ?, ?)`
-        )
-        .run(collectionId, name, ownerId, id, JSON.stringify(obj), isPrivate ? 1 : 0);
-    return obj;
-}
 
 function makeEntryAt(id, name, collectionId, ownerId, daysAgo, isPrivate = false) {
     const obj = { id, type: 'Person' };

--- a/test/activitypub_security.test.js
+++ b/test/activitypub_security.test.js
@@ -694,7 +694,7 @@ describe('isSafeOutboundUrl()', function () {
 // ─── readInboxBody ────────────────────────────────────────────────────────────
 
 //  Helper: build a fake req EventEmitter that emits the given chunks then 'end'.
-function makeFakeReq(chunks, errorAfterBytes = null) {
+function makeFakeReq(chunks, _errorAfterBytes = null) {
     const req = new EventEmitter();
     req.destroyed = false;
     req.destroy = () => {
@@ -809,7 +809,7 @@ describe('readInboxBody()', function () {
         };
 
         let callCount = 0;
-        readInboxBody(req, 10, err => {
+        readInboxBody(req, 10, _err => {
             callCount++;
             assert.equal(callCount, 1, 'cb must not be called more than once');
             if (callCount === 1) {

--- a/test/ansi_prep.test.js
+++ b/test/ansi_prep.test.js
@@ -13,12 +13,6 @@ function prep(input, options = {}) {
     });
 }
 
-//  Strip all ANSI escape sequences from a string (for text-only assertions).
-function stripAnsi(s) {
-    // eslint-disable-next-line no-control-regex
-    return s.replace(/\x1b\[[0-9;]*[mGKHJABCDfhilnrstu]/g, '');
-}
-
 // ─── Basic behaviour ──────────────────────────────────────────────────────────
 
 describe('ansiPrep', () => {

--- a/test/binkp_bso_spool.test.js
+++ b/test/binkp_bso_spool.test.js
@@ -577,9 +577,6 @@ describe('attachSpoolToSession', () => {
         // sends it to the client (net=2,node=2 → 00020002.flo).
         const flowPath = path.join(outboundDir(tmpDir), '00020002.flo'); // net=2,node=2
         fsp.writeFile(flowPath, `^${refFile}\n`).then(() => {
-            const serverAddr = { zone: 1, net: 1, node: 1 }; // server's address
-            const clientAddr = { zone: 1, net: 2, node: 2 }; // client's address
-
             const server = net.createServer(serverSocket => {
                 const serverSess = new BinkpSession(serverSocket, {
                     role: 'answering',
@@ -678,7 +675,6 @@ describe('attachSpoolToSession', () => {
                 });
             });
 
-            let serverGotFile = false;
             // We need a server session that can receive
             // (the simple server above won't track it — this test just checks no crash)
             clientSess.on('session-end', () => {

--- a/test/binkp_caller.test.js
+++ b/test/binkp_caller.test.js
@@ -319,8 +319,6 @@ describe('BinkP caller', function () {
         });
 
         it('calls a node that has pending mail and a configured host', done => {
-            let sessionCompleted = false;
-
             startAnsweringServer()
                 .then(async ({ port, stop }) => {
                     const refFile = path.join(tmpDir, 'poll_test.pkt');

--- a/test/binkp_cram.test.js
+++ b/test/binkp_cram.test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { strict: assert } = require('assert');
-const crypto = require('crypto');
 const {
     generateChallenge,
     computeResponse,

--- a/test/binkp_frame.test.js
+++ b/test/binkp_frame.test.js
@@ -126,10 +126,6 @@ describe('FrameParser — command frames', () => {
 
     it('strips trailing null bytes from arg', () => {
         // Some implementations pad the arg field with nulls
-        const raw = Buffer.concat([
-            buildCommandFrame(Commands.M_NUL, 'SYS test'),
-            Buffer.from([0x00, 0x00]), // extra nulls (won't be parsed as part of arg)
-        ]);
         // Just verify the arg has no trailing nulls
         const [f] = singleFrame(buildCommandFrame(Commands.M_NUL, 'SYS test\x00\x00'));
         assert.equal(f.arg, 'SYS test');

--- a/test/binkp_server.test.js
+++ b/test/binkp_server.test.js
@@ -189,7 +189,9 @@ describe('BinkP server', function () {
                                 try {
                                     assert.ok(
                                         receivedAddrs.some(a => a.includes('1:218/700')),
-                                        `Expected 1:218/700 in addresses: ${receivedAddrs.join(', ')}`
+                                        `Expected 1:218/700 in addresses: ${receivedAddrs.join(
+                                            ', '
+                                        )}`
                                     );
                                     done();
                                 } catch (e) {
@@ -520,7 +522,7 @@ describe('BinkP server', function () {
             fakeServer.listen(0, '127.0.0.1', async () => {
                 const fakePort = fakeServer.address().port;
                 const target = '1:218/702'; // address we'll dial
-                const { mod, stop } = await startModule({
+                const { stop } = await startModule({
                     crashmailDebounceMs: 50,
                     nodes: {
                         [target]: { host: '127.0.0.1', port: fakePort },
@@ -571,7 +573,7 @@ describe('BinkP server', function () {
 
             fakeServer.listen(0, '127.0.0.1', async () => {
                 const fakePort = fakeServer.address().port;
-                const { mod, stop } = await startModule({
+                const { stop } = await startModule({
                     crashmailDebounceMs: 50,
                     nodes: {
                         '1:218/710': { host: '127.0.0.1', port: fakePort },
@@ -687,7 +689,9 @@ describe('BinkP server', function () {
                         try {
                             assert.ok(
                                 receivedAddrs.some(a => a.includes('1:218/777')),
-                                `expected reloaded address 1:218/777 in: ${receivedAddrs.join(', ')}`
+                                `expected reloaded address 1:218/777 in: ${receivedAddrs.join(
+                                    ', '
+                                )}`
                             );
                             finish();
                         } catch (e) {

--- a/test/binkp_session.test.js
+++ b/test/binkp_session.test.js
@@ -2,7 +2,6 @@
 
 const { strict: assert } = require('assert');
 const net = require('net');
-const fs = require('fs');
 const fsp = require('fs/promises');
 const path = require('path');
 const os = require('os');
@@ -272,7 +271,7 @@ describe('BinkpSession — file transfer', () => {
         });
 
         let clientFileSent = false;
-        clientSess.on('file-sent', name => {
+        clientSess.on('file-sent', _name => {
             clientFileSent = true;
         });
 
@@ -463,7 +462,7 @@ describe('BinkpSession — duplicate detection (hasFile)', () => {
             {},
             {
                 // Server claims it already has the file
-                hasFile: (name, size, ts) => name === 'dup.pkt',
+                hasFile: (name, _size, _ts) => name === 'dup.pkt',
             }
         );
 

--- a/test/ftn_bso_import.test.js
+++ b/test/ftn_bso_import.test.js
@@ -1,4 +1,3 @@
-/* eslint-env mocha */
 'use strict';
 
 //

--- a/test/ftn_mail_packet.test.js
+++ b/test/ftn_mail_packet.test.js
@@ -153,7 +153,7 @@ function makeMessageBody(lines) {
 }
 
 function processBody(buf) {
-    return new Promise((resolve, reject) => {
+    return new Promise((resolve, _reject) => {
         new Packet().processMessageBody(buf, data => {
             resolve(data);
         });
@@ -173,7 +173,9 @@ describe('processMessageBody — kludge line parsing', () => {
             const data = await processBody(buf);
             assert.ok(
                 data.kludgeLines['Via'],
-                `"${prefix}" should be normalized to "Via" key, got keys: ${Object.keys(data.kludgeLines).join(', ')}`
+                `"${prefix}" should be normalized to "Via" key, got keys: ${Object.keys(
+                    data.kludgeLines
+                ).join(', ')}`
             );
         }
     });

--- a/test/ftn_util.test.js
+++ b/test/ftn_util.test.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const { strict: assert } = require('assert');
-const moment = require('moment');
 
 const ftnUtil = require('../core/ftn_util.js');
 
@@ -146,7 +145,6 @@ describe('getUpdatedPathEntries', () => {
 
     it('starts a new line when last line is full', () => {
         //  Fill the last line close to the 71-char limit
-        const Address = require('../core/ftn_address.js');
         const longLine = Array.from({ length: 6 }, (_, i) => `${10000 + i}/1`).join(' ');
         assert.ok(longLine.length > 40); // confirm it's substantial
         const existing = [longLine];
@@ -154,7 +152,6 @@ describe('getUpdatedPathEntries', () => {
         const extra = Array.from({ length: 10 }, (_, i) => `${20000 + i}/1`);
         let result = existing;
         for (const e of extra) {
-            const addr = new Address({ net: parseInt(e), node: 1 });
             result = ftnUtil.getUpdatedPathEntries(result, `${e}`);
         }
         assert.ok(result.length > 1, 'expected multiple PATH lines');

--- a/test/oputil_fat.test.js
+++ b/test/oputil_fat.test.js
@@ -58,13 +58,6 @@ function mkdir(fs, p) {
     );
 }
 
-/** Promise wrapper around fatfs.writeFile */
-function writeFile(fs, p, data) {
-    return new Promise((resolve, reject) =>
-        fs.writeFile(p, data, err => (err ? reject(err) : resolve()))
-    );
-}
-
 // ─── createFloppyWithFiles ────────────────────────────────────────────────────
 
 describe('createFloppyWithFiles', () => {

--- a/test/pre_auth_feedback.test.js
+++ b/test/pre_auth_feedback.test.js
@@ -303,15 +303,13 @@ describe('ghost-sender reply guard', () => {
 
     it('blocks reply when private mail has no local from-user-id and no remote sender', done => {
         const msg = makeMsg({ fromUserId: 0, remoteFrom: null });
-        const { inst, getGotoMenuOrShowMessage, getGotoMenu } = makeViewer(msg);
+        const { inst } = makeViewer(msg);
 
         //  Invoke replyMessage directly (it's assigned in the constructor via Object.assign)
         //  Re-create the menuMethods as the constructor would:
         const _ = require('lodash');
         const self = inst;
-        let blocked = false;
         inst.gotoMenuOrShowMessage = (name, text) => {
-            blocked = true;
             assert.equal(name, 'preAuthFeedbackNoReply');
             assert.ok(text.length > 0);
             done();


### PR DESCRIPTION
`eslint .` could not run at all on a correctly-installed tree. Fixing that surfaced a chain of related problems, each committed separately so they can be reviewed — or reverted — on their own.

## 1. The ESLint config was broken (`34dd4eed`)

`eslint-plugin-json` v4 ships a flat config, but `eslint.config.mjs` routed it through `FlatCompat.extends()`, which parses its target as legacy eslintrc and rejects the top-level `files` key a flat config carries. Hard failure, not a warning.

Fixed by loading `@eslint/js` and `eslint-plugin-json` as the flat configs they are, dropping `FlatCompat` entirely. Four things turned up alongside it:

- **`ecmaVersion: 2020` could not parse the codebase.** `core/binkp/caller.js`, `core/binkp/session.js` and `core/v86_door/v86_worker.js` use numeric separators (`30_000`), which are ES2021. Three source files were failing outright. Now `'latest'`.
- **`eslint-config-prettier` was a declared devDependency that nothing referenced.** Wired in, so Prettier owns formatting and lint owns correctness.
- **ESLint does not read `.gitignore`**, so a local `.venv` and the fetched GoToSocial web assets were being linted as ours — 429 of the 621 reported problems.
- **`no-unused-vars` tuned to conventions already in the codebase**: a leading underscore marks a deliberate throwaway, and unused catch bindings are allowed. ESLint 9 flipped the `caughtErrors` default from `'none'` to `'all'`, which is why those started reporting.

Also adds `lint` / `lint:fix` scripts and restores the pre-commit hook, which was the single commented-out line `# npm test` — so `lint-staged`, though configured, had never run.

## 2. Clearing the 62 remaining errors (`38ca09b5`)

Mechanical dead-code removal across 35 files. No behavior change intended.

Unused **parameters** are underscore-prefixed rather than deleted — several are middleware and callback signatures where arity is part of the contract, and the names still document what the caller passes. Unused requires, destructured members, locals, and four entirely unreferenced functions are removed outright.

Two removals cascaded: deleting a value's only reader left the value itself unused.

`ROOT_SECTOR` in `v86_door/fat_image.js` is kept with a disable comment — it completes the FAT layout sequence the constants above it describe, and that is worth more than the line it costs.

The hook and lint-staged now call `eslint`/`prettier` directly instead of through `npx`: husky already puts `node_modules/.bin` on PATH, and the `npx` indirection failed outright in a minimal hook environment.

## 3. CI gate (`2754b356`)

Runs `npm run lint` on push to master, on every PR, and on demand. Installs with `npm ci --include=dev` — see the note below on why that flag is load-bearing.

Deliberately **not** checking formatting, for the reason in the next section.

## 4. prettier 3 and husky 9 (`ba242d77`)

Both were already being *run* at a newer major than the one declared, because `pretty` and the lint-staged tasks went through `npx`, and npx fetches the latest when the dependency is absent.

The upgrade turned out to be the smaller change, not the larger one:

| checked with | `core/` files failing |
|---|---|
| pinned 2.8.1 | 16 |
| actual 3.9.6 | 3 |

The tree was already overwhelmingly prettier-3 formatted. Declaring that beats reformatting thousands of lines backwards. The three reformatted files are cosmetic.

Same story for husky: `.husky/_` already carried a v9 shim and `"prepare": "husky"` was already v9 syntax, while `package.json` asked for `^8` — which that script would not have worked under.

## Not included

The `no-constant-binary-expression` error in `core/activitypub/user_config.js` is a **real bug** — `[values[p]]` is an array literal and therefore always truthy, so that required-field guard has never fired. @NuSkooler is handling it separately, so it is silenced here with a `:TODO:` purely to keep the gate green. That fix should remove both the disable and the comment.

Worth noting for whoever takes it: the obvious reading, `!!values[p]`, would be wrong in the other direction — all four fields are booleans, so truthiness would reject a legitimate `false`. The check is presence.

## Root cause worth a separate decision

`mise.toml` is tracked and sets `NODE_ENV = 'production'`. npm sets `omit=dev` whenever it sees that, so `npm install` and `npm ci` **skip devDependencies for every developer using mise on this repo**. That is why eslint, prettier and mocha were all absent, why npx kept silently fetching newer majors, and why the version drift happened at all.

Left alone here: it is a tracked file and `NODE_ENV` affects runtime behavior, so changing it is a call for @NuSkooler rather than a side effect of a lint PR. The workflow passes `--include=dev` explicitly to work around it, but a development checkout arguably should not be declaring production.

## Verification

`npm run lint` clean · `prettier --check .` clean across the repo · 1455 tests passing · pre-commit hook verified firing with no mise on PATH.