### PR TITLE
fix(docker): build on node 22 and stop chasing npm@latest

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM:-linux/amd64} node:20-bookworm-slim
+FROM --platform=${BUILDPLATFORM:-linux/amd64} node:22-bookworm-slim
 
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
@@ -29,7 +29,6 @@ RUN apt-get update \
     p7zip-full \
     dos2unix \
     && npm set progress=false && npm config set depth 0 \
-    && npm install -g npm@latest \
     && npm install -g pm2 \
     && cd /enigma-bbs && npm install
 


### PR DESCRIPTION
The Docker image build has failed on **every** run since at least 2026-08-12, with no commit to blame.

`npm` 12 raised its engine floor to `node ^22.22.2`, and the Dockerfile asked an unpinned `npm install -g npm@latest` to install onto a `node:20` base. Nothing in this repo changed — npm shipped a major and the build rotted where it stood:

```
npm error notsup Not compatible with your version of node/npm: npm@12.0.2
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

## Changes

- base image `node:20-bookworm-slim` → `node:22-bookworm-slim`
- drop `npm install -g npm@latest`

Node 22 is what `package.json` has been asking for all along — `"engines": { "node": ">=22" }` — so the `node:20` base was already inconsistent with the project's own requirement.

Bumping the base *alone* would be enough today: `node:22-bookworm-slim` ships 22.23.2, which satisfies npm 12. But that only re-arms the trap for the next npm major. The image already bundles npm 10.9.8, which builds this project fine, so the upgrade buys nothing and costs a recurring outage.

## Verification

Built locally against the real Dockerfile:

- build completes
- resulting image runs node **22.23.2**, npm **10.9.8**, pm2 **7.0.4**, with `main.js` in place
- the old base/npm combination was re-confirmed to still reproduce the error above, so this addresses the actual cause rather than something adjacent

Worth noting the local build is single-arch; CI publishes `linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v8`, so the workflow run on this PR is the real multi-arch check.

## Deliberately not included

Two adjacent things were considered and left alone:

**`npm ci` for reproducibility.** 33 of 51 runtime dependencies use `^` ranges, so the published image floats and can ship versions nobody tested — the same drift class as the bug above, just quieter. But `.dockerignore` *explicitly* lists `package-lock.json`, so this was a decision rather than an oversight, and the four-architecture build is the likely reason: `npm ci` installs the lockfile exactly, including platform-specific optional deps resolved on an x64 machine, which is a well-known way to break arm builds. Reversing it needs a multi-arch trial, so it belongs in its own PR.

**`--omit=dev` to slim the image.** Measured rather than assumed, and the payoff is poor: `node_modules` goes 234 MB → 197 MB, which is under 3% of the 1.36 GB image — the bulk is the base image and `build-essential`, not devDependencies. It also isn't free: `npm ci --omit=dev` still runs `prepare`, which exits 127 because `husky` is the devDependency just excluded, so it would need `prepare` made tolerant. Not worth it for 3%.