### PR TITLE
fix(binkp): follow binkp/1.1 batching so sessions close instead of timing out

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -22,6 +22,8 @@ Refer to [Upgrading](./docs/_docs/admin/upgrading.md) for details around this pr
 
 ## 0.5.0-beta to 0.5.1-beta
 
+* **BinkP sessions were left to time out rather than closing cleanly.** ENiGMA½ ended after the first binkp/1.1 batch, so the peer waited for an `M_EOB` that never arrived. Mail transferred correctly, but the remote logged the session as failed, and while ours sat waiting it held that node's lock — so crashmail queued for the node during the window was skipped until the next scheduled poll. **No action is required**; if a peer has been reporting failed sessions with your system despite the mail arriving, this is why.
+
 * **BinkP files compressed with GZ were rejected by every other mailer** ([#723](https://github.com/NuSkooler/enigma-bbs/issues/723)). ENiGMA½ wrapped compressed data in the gzip container where [FTS-1029](http://ftsc.org/docs/fts-1029.001) — and binkd, Mystic and the rest — use the zlib one. The receiving mailer rejected the stream immediately; our side logged nothing and re-sent the file on every poll. **Nothing was lost** and **no configuration change is required**: the affected files stayed in the outbound spool and go out on the next poll.
 
   Only nodes with no `archiveType` were affected, since ArcMail bundles are already compressed and never carried GZ.

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -3,6 +3,14 @@ This document attempts to track **major** changes and additions in ENiGMA½. For
 
 ## 0.5.1-beta
 
+* **BinkP sessions ended on a timeout instead of a clean close** — binkp/1.1 runs a session as a series of batches: another follows any batch that carried more than the two `M_EOB`s, and only an empty batch ends the session. ENiGMA½ stopped after the first one, leaving a conforming peer waiting for an `M_EOB` that never came.
+
+  No mail was lost — it had already transferred by then — but the peer sat until its own timeout (five minutes, for binkd) and then recorded an otherwise successful session as `failed`. With binkd's shipped `try`/`hold` settings, enough of those in a row will put us on hold and stop it calling for a while.
+
+  The cost was ours too: an inbound session parked like that still holds the node's lock, so crashmail queued for that node inside the window is skipped and waits for the next scheduled poll — quietly defeating the point of crashmail. Sessions against binkd now finish in milliseconds and log `done (..., OK, ...)`.
+
+  Peers below binkp/1.1, and any that never identify their version, are treated exactly as before.
+
 * **BinkP GZ compression used the wrong container** ([#723](https://github.com/NuSkooler/enigma-bbs/issues/723)) — [FTS-1029](http://ftsc.org/docs/fts-1029.001) specifies zlib's `compress()`/`compress2()`, which produce the RFC 1950 container: two header bytes and an Adler-32 tail. ENiGMA½ emitted RFC 1952 (gzip) instead — the same deflate payload behind a different header — so every conforming peer rejected it on sight. binkd logs `Decompress <file> error -3` and abandons the transfer; the *sending* side saw nothing wrong and re-offered the same file on every poll, for days. Confirmed here against binkd 1.1a-115 and reported against Mystic 1.12A48.
 
   Only nodes **without** `archiveType` were affected: ArcMail bundles and archives are already compressed, so GZ is skipped for them entirely. That is the same set of systems as the packet-naming bug in #722.

--- a/core/binkp/session.js
+++ b/core/binkp/session.js
@@ -16,6 +16,11 @@ const BINKP_VER = '1.1';
 const SEND_CHUNK_SIZE = 4096;
 const SESSION_TIMEOUT_MS = 300_000; // 5 min
 
+//  Runaway guard only, not part of the protocol. A batch carrying nothing but
+//  the two M_EOBs always ends the session, so this can only be reached by a
+//  peer that keeps talking; better to hang up than to loop forever.
+const MAX_BATCHES = 16;
+
 // Extensions that are already compressed — don't waste CPU trying to GZ them.
 // Arcmail day-of-week bundles (*.mo0, *.tu1, etc.) are also pre-compressed.
 const ALREADY_COMPRESSED_RE = /\.(zip|arc|arj|lzh|lha|gz|bz2|zst|pk[34]|zoo)$/i;
@@ -103,6 +108,13 @@ class BinkpSession extends EventEmitter {
         this._localEOBSent = false;
         this._localEOB = false;
         this._remoteEOB = false;
+
+        //  binkp/1.1 batches. |_batchMsgCount| counts command frames both
+        //  sent and received since the batch began, which is what decides
+        //  whether another one follows -- see _onBatchComplete.
+        this._batchMsgCount = 0;
+        this._batchesDone = 0;
+        this._remoteVer = null; // { major, minor } from the remote's VER
 
         this._sendHeld = false;
         this._timeoutHandle = null;
@@ -257,6 +269,7 @@ class BinkpSession extends EventEmitter {
         if (this._state === 'handshake') {
             this._onHandshakeCommand(cmd, arg);
         } else if (this._state === 'transfer') {
+            ++this._batchMsgCount;
             this._onTransferCommand(cmd, arg);
         }
     }
@@ -317,6 +330,16 @@ class BinkpSession extends EventEmitter {
         const value = spaceIdx < 0 ? '' : arg.slice(spaceIdx + 1);
 
         if (keyword !== 'OPT') {
+            if ('VER' === keyword) {
+                //  e.g. "binkd/1.1a-115/Linux binkp/1.1"
+                const m = /binkp\/(\d+)\.(\d+)/i.exec(value);
+                if (m) {
+                    this._remoteVer = {
+                        major: parseInt(m[1], 10),
+                        minor: parseInt(m[2], 10),
+                    };
+                }
+            }
             return;
         }
 
@@ -1171,15 +1194,28 @@ class BinkpSession extends EventEmitter {
 
         const afterHook = () => {
             this._batchEndPending = false;
-            const hookQueuedFiles = this._sendQueue.length > queueBefore;
-            if (hookQueuedFiles) {
-                //  Hook added files — start another batch. Reset both EOB
-                //  flags; remote will send a new M_EOB when its side is done.
-                this._localEOB = false;
-                this._localEOBSent = false;
-                this._remoteEOB = false;
-                setImmediate(() => this._sendNext());
-            } else if (this._opts.role === 'originating') {
+            ++this._batchesDone;
+
+            //  Hook added files — start another batch to carry them.
+            if (this._sendQueue.length > queueBefore) {
+                return this._startNextBatch();
+            }
+
+            //  binkp/1.1 batching: a batch that carried more than the two
+            //  M_EOBs is followed by another, and only an empty batch ends
+            //  the session. Skipping that leaves a 1.1 peer waiting for an
+            //  M_EOB that never comes — binkd sits until its own timeout and
+            //  books the session as failed even though the mail arrived,
+            //  while we hold the node's lock for the duration and skip any
+            //  crashmail for it in the meantime.
+            //
+            //  Both sides count every command frame, sent and received, so
+            //  they arrive at the same total and reach the same decision.
+            if (this._shouldStartAnotherBatch()) {
+                return this._startNextBatch();
+            }
+
+            if (this._opts.role === 'originating') {
                 //  Originating side controls session lifetime: nothing left →
                 //  close the connection.
                 this._finishSession();
@@ -1207,6 +1243,33 @@ class BinkpSession extends EventEmitter {
             });
     }
 
+    //  Another batch follows unless this one was empty. Gated on the remote
+    //  actually speaking binkp/1.1: a 1.0 peer closes after the first batch,
+    //  so offering it a second one would strand us.
+    _shouldStartAnotherBatch() {
+        if (this._batchMsgCount <= 2) {
+            return false; //  our M_EOB and theirs, nothing else
+        }
+        if (this._batchesDone >= MAX_BATCHES) {
+            Log.warn(
+                { batches: this._batchesDone },
+                '[BinkP] Batch limit reached; ending session'
+            );
+            return false;
+        }
+        const ver = this._remoteVer;
+        return !!ver && ver.major * 100 + ver.minor > 100;
+    }
+
+    _startNextBatch() {
+        this._batchMsgCount = 0;
+        this._localEOB = false;
+        this._localEOBSent = false;
+        this._remoteEOB = false;
+        this._waitingForClose = false;
+        setImmediate(() => this._sendNext());
+    }
+
     _finishSession() {
         if (this._state === 'done') return;
         this._state = 'done';
@@ -1218,6 +1281,9 @@ class BinkpSession extends EventEmitter {
     // ── Utility ─────────────────────────────────────────────────────────────
 
     _sendCmd(cmd, arg) {
+        if (this._state === 'transfer') {
+            ++this._batchMsgCount;
+        }
         if (!this._socket.destroyed) {
             this._socket.write(buildCommandFrame(cmd, arg));
         }
@@ -1319,12 +1385,12 @@ class BinkpSession extends EventEmitter {
             //  finalizing state: EOF was received and we're just waiting for
             //  the async writeStream flush. The file was fully transferred.
             const recvDone = !this._currentRecv || this._currentRecv._finalizing;
+            //  A close between batches counts too: the peer decided the
+            //  session was over one batch sooner than we did, and with
+            //  nothing outstanding there is nothing to report.
+            const settled = (this._localEOB && this._remoteEOB) || this._batchesDone > 0;
             const cleanEnd =
-                this._localEOB &&
-                this._remoteEOB &&
-                this._pendingGots.size === 0 &&
-                !this._currentSend &&
-                recvDone;
+                settled && this._pendingGots.size === 0 && !this._currentSend && recvDone;
 
             if (this._waitingForClose || cleanEnd) {
                 this._finishSession();

--- a/dev_util/binkp_interop.js
+++ b/dev_util/binkp_interop.js
@@ -444,8 +444,9 @@ async function scenarioAnswer(binkd, root) {
     const weGot = 1 === received.length && received[0].intact;
 
     //  binkd/1.1 opens another batch after any batch that carried more than
-    //  the two M_EOBs and waits for our M_EOB, which we never send. It is
-    //  tracked separately; both files still transfer, so judge on those.
+    //  the two M_EOBs and waits for our M_EOB before hanging up. If it does
+    //  not exit, that exchange did not complete — look for a "done (..., OK"
+    //  line in its log to tell a clean finish from a timeout.
     const stalled = 'timeout' === exit;
 
     return reportBody(
@@ -458,7 +459,7 @@ async function scenarioAnswer(binkd, root) {
             binkdInbound: binkdGot,
             binkdBytesIntact: binkdIntact,
             note: stalled
-                ? 'binkd did not exit — expected until multi-batch support lands'
+                ? 'binkd did not exit — it is still waiting on the batch exchange'
                 : undefined,
         },
         log

--- a/docs/_docs/messageareas/binkp.md
+++ b/docs/_docs/messageareas/binkp.md
@@ -262,6 +262,12 @@ freq: {
 
 With this setup, every new nodelist that arrives via TIC is immediately FREQ-serveable — no path configuration to maintain.
 
+#### Sessions and batches
+
+A binkp/1.1 session is a series of *batches*. Each ends when both sides have sent `M_EOB`, and another follows any batch that carried more than that pair — so a session that moved mail always ends on a short empty batch. Each new batch is also an opportunity: anything that turned up mid-session, such as a FREQ response or mail tossed from a packet that just arrived, goes out on the same connection instead of waiting for the next poll.
+
+Both sides decide this the same way, by counting the command frames sent and received since the batch began, so they agree without negotiating. A peer that identifies itself as binkp/1.0, or that never sends a version at all, is not offered a second batch.
+
 #### Reloading configuration
 
 `config.hjson` is watched and reloaded while the BBS runs. Almost everything under `binkp` is read at the moment it is used, so a reload applies on its own:

--- a/test/binkp_batch.test.js
+++ b/test/binkp_batch.test.js
@@ -1,0 +1,249 @@
+'use strict';
+
+const { strict: assert } = require('assert');
+
+const {
+    makeScriptedPair,
+    runAnswering,
+    runSession,
+    makeTempFile,
+} = require('./binkp_peer.js');
+
+//
+//  binkp/1.1 batching.
+//
+//  A session is a series of batches. Each ends when both sides have sent
+//  M_EOB, and another follows unless the batch carried nothing but that pair
+//  — so a session that moved any mail always ends on a trailing empty batch.
+//  binkd decides this by counting every command frame it sent and received
+//  since the batch began (protocol.c:3275-3293); because each frame is
+//  counted once by its sender and once by its receiver, both sides arrive at
+//  the same total and take the same decision.
+//
+//  Skipping the empty batch does not lose mail, which is why it went
+//  unnoticed: it leaves the peer waiting for an M_EOB that never arrives
+//  until something times out. binkd then books an otherwise successful
+//  session as failed, and on our side the node's lock stays held for the
+//  duration, so a crashmail dispatch to that node in the meantime is skipped.
+//
+
+describe('BinkpSession — binkp/1.1 batching', function () {
+    this.timeout(10000);
+
+    it('follows a batch that carried a file with an empty one', async () => {
+        const f = await makeTempFile('BATCHED');
+        const { session, peer } = await makeScriptedPair({ opts: [] });
+        session.queueFile(f.filePath, f.name, f.size, f.timestamp, 'keep');
+
+        await runSession(session);
+
+        assert.equal(peer.batches.length, 2, 'one working batch, then an empty one');
+        assert.ok(peer.batches[0] > 2, 'the first batch carried more than the M_EOBs');
+        assert.equal(peer.batches[1], 2, 'the last batch is just the two M_EOBs');
+        assert.equal(peer.received[0].data.toString(), 'BATCHED');
+    });
+
+    it('ends after a single batch when nothing was transferred', async () => {
+        const { session, peer } = await makeScriptedPair({ opts: [] });
+
+        await runSession(session);
+
+        //  An empty session is already an empty batch; adding another would
+        //  be a pointless round trip on every poll of a quiet node.
+        assert.deepEqual(peer.batches, [2]);
+    });
+
+    it('keeps batching while files keep moving', async () => {
+        const a = await makeTempFile('FIRST');
+        const b = await makeTempFile('SECOND');
+
+        const { session, peer } = await makeScriptedPair({
+            opts: [],
+            filesToSend: [
+                {
+                    name: 'inbound.pkt',
+                    size: 7,
+                    timestamp: 1700000000,
+                    data: Buffer.from('INBOUND'),
+                },
+            ],
+        });
+        session.queueFile(a.filePath, a.name, a.size, a.timestamp, 'keep');
+        session.queueFile(b.filePath, b.name, b.size, b.timestamp, 'keep');
+
+        await runSession(session);
+
+        assert.equal(peer.batches[peer.batches.length - 1], 2, 'ends on an empty batch');
+        assert.equal(peer.received.length, 2, 'both files still went out');
+    });
+
+    it('does the same when we are the answering side', async () => {
+        const f = await makeTempFile('ANSWERED');
+
+        const { peer } = await runAnswering({ opts: [] }, {}, session => {
+            session.queueFile(f.filePath, f.name, f.size, f.timestamp, 'keep');
+        });
+
+        assert.equal(peer.batches[peer.batches.length - 1], 2);
+        assert.equal(peer.received[0].data.toString(), 'ANSWERED');
+    });
+
+    it('carries a file queued by the onBatchEnd hook', async () => {
+        const first = await makeTempFile('BATCH-ONE');
+        const second = await makeTempFile('BATCH-TWO');
+
+        let queued = false;
+        const { session, peer } = await makeScriptedPair(
+            { opts: [] },
+            {
+                onBatchEnd: sess => {
+                    if (queued) {
+                        return;
+                    }
+                    queued = true;
+                    sess.queueFile(
+                        second.filePath,
+                        second.name,
+                        second.size,
+                        second.timestamp,
+                        'keep'
+                    );
+                },
+            }
+        );
+        session.queueFile(
+            first.filePath,
+            first.name,
+            first.size,
+            first.timestamp,
+            'keep'
+        );
+
+        await runSession(session);
+
+        assert.deepEqual(
+            peer.received.map(r => r.data.toString()),
+            ['BATCH-ONE', 'BATCH-TWO']
+        );
+        assert.equal(peer.batches[peer.batches.length - 1], 2);
+    });
+});
+
+// ── Peers that do not batch ───────────────────────────────────────────────────
+
+describe('BinkpSession — batching against older peers', function () {
+    this.timeout(10000);
+
+    it('does not offer another batch to a binkp/1.0 peer', async () => {
+        const f = await makeTempFile('OLD-PEER');
+        const { session, peer } = await makeScriptedPair({
+            opts: [],
+            protocolVer: '1.0',
+            singleBatch: true,
+        });
+        session.queueFile(f.filePath, f.name, f.size, f.timestamp, 'keep');
+
+        await runSession(session);
+
+        //  binkd stops after the first batch below 1.1, so a second M_EOB
+        //  round would be talking to nobody.
+        assert.equal(peer.batches.length, 1);
+        assert.equal(peer.received[0].data.toString(), 'OLD-PEER');
+    });
+
+    it('does not assume 1.1 from a peer that never sent VER', async () => {
+        const f = await makeTempFile('NO-VER');
+        const { session, peer } = await makeScriptedPair({
+            opts: [],
+            noVer: true,
+            singleBatch: true,
+        });
+        session.queueFile(f.filePath, f.name, f.size, f.timestamp, 'keep');
+
+        await runSession(session);
+
+        assert.equal(peer.batches.length, 1);
+        assert.equal(peer.received[0].data.toString(), 'NO-VER');
+    });
+
+    it('finishes cleanly when the caller hangs up a batch early', async () => {
+        //  We answer, expect another batch, and the caller closes instead.
+        //  Everything had been acknowledged, so that is a clean end rather
+        //  than a dropped session — the caller simply counted the session
+        //  over one batch sooner than we did.
+        const f = await makeTempFile('EARLY-CLOSE');
+
+        const { peer } = await runAnswering(
+            { opts: [], singleBatch: true },
+            {},
+            session => {
+                session.queueFile(f.filePath, f.name, f.size, f.timestamp, 'keep');
+            }
+        );
+
+        assert.equal(peer.batches.length, 1, 'the caller stopped after one batch');
+        assert.equal(peer.received[0].data.toString(), 'EARLY-CLOSE');
+    });
+});
+
+// ── The counting rule itself ──────────────────────────────────────────────────
+
+describe('BinkpSession — batch continuation rule', function () {
+    this.timeout(10000);
+
+    async function session() {
+        const { session: s } = await makeScriptedPair({ opts: [] });
+        return s;
+    }
+
+    it('needs more than the two M_EOBs to continue', async () => {
+        const s = await session();
+        s._remoteVer = { major: 1, minor: 1 };
+
+        s._batchMsgCount = 2;
+        assert.equal(s._shouldStartAnotherBatch(), false);
+        s._batchMsgCount = 3;
+        assert.equal(s._shouldStartAnotherBatch(), true);
+
+        s._destroy();
+    });
+
+    it('needs the remote to be above binkp/1.0', async () => {
+        const s = await session();
+        s._batchMsgCount = 10;
+
+        s._remoteVer = null;
+        assert.equal(s._shouldStartAnotherBatch(), false, 'no VER seen');
+        s._remoteVer = { major: 1, minor: 0 };
+        assert.equal(s._shouldStartAnotherBatch(), false, 'binkp/1.0');
+        s._remoteVer = { major: 1, minor: 1 };
+        assert.equal(s._shouldStartAnotherBatch(), true, 'binkp/1.1');
+        s._remoteVer = { major: 2, minor: 0 };
+        assert.equal(s._shouldStartAnotherBatch(), true, 'anything newer');
+
+        s._destroy();
+    });
+
+    it('stops after the batch limit however talkative the peer is', async () => {
+        const s = await session();
+        s._remoteVer = { major: 1, minor: 1 };
+        s._batchMsgCount = 1000;
+
+        s._batchesDone = 15;
+        assert.equal(s._shouldStartAnotherBatch(), true);
+        s._batchesDone = 16;
+        assert.equal(
+            s._shouldStartAnotherBatch(),
+            false,
+            'a peer that never falls quiet must not hold the session open'
+        );
+
+        s._destroy();
+    });
+
+    it('reads the version out of the VER frame', async () => {
+        const { session: s } = await makeScriptedPair({ opts: [] });
+        await runSession(s);
+        assert.deepEqual(s._remoteVer, { major: 1, minor: 1 });
+    });
+});

--- a/test/binkp_peer.js
+++ b/test/binkp_peer.js
@@ -72,6 +72,13 @@ class ScriptedPeer {
         this.sendQueue = (opts.filesToSend || []).slice();
         this.currentSend = null;
         this.nzRequestedFor = null;
+        //  binkd counts every command frame, sent and received, since the
+        //  batch began, and only closes after one that carried nothing but
+        //  the two M_EOBs (protocol.c:3275-3293).
+        this.msgsInBatch = 0;
+        this.batches = []; //  message count of each completed batch
+        this.batchClosed = false;
+        this.closed = false;
         this.nzRequests = []; //  files we were asked to resend in the clear
         this.skipsReceived = [];
 
@@ -100,6 +107,9 @@ class ScriptedPeer {
     }
 
     _send(cmd, arg) {
+        if ('transfer' === this.state) {
+            ++this.msgsInBatch;
+        }
         if (!this.socket.destroyed) {
             this.socket.write(buildCommandFrame(cmd, arg));
         }
@@ -107,7 +117,14 @@ class ScriptedPeer {
 
     _sendGreeting() {
         this._send(Commands.M_NUL, 'SYS Scripted Peer');
-        this._send(Commands.M_NUL, 'VER binkd/1.1a-115/Linux binkp/1.1');
+        //  |noVer| models a peer that never identifies its protocol version,
+        //  which has to be read conservatively rather than assumed to be 1.1.
+        if (!this.opts.noVer) {
+            this._send(
+                Commands.M_NUL,
+                `VER binkd/1.1a-115/Linux binkp/${this.opts.protocolVer || '1.1'}`
+            );
+        }
         this._send(Commands.M_ADR, '1:1/1@testnet');
     }
 
@@ -136,6 +153,9 @@ class ScriptedPeer {
         }
 
         this.framesIn.push({ cmd: frame.cmd, arg: frame.arg });
+        if ('transfer' === this.state) {
+            ++this.msgsInBatch;
+        }
 
         switch (frame.cmd) {
             case Commands.M_PWD:
@@ -289,6 +309,31 @@ class ScriptedPeer {
     _onEob() {
         this.remoteEOB = true;
         this._maybeEob();
+        this._endOfBatch();
+    }
+
+    //  Both M_EOBs are in and nothing is in flight. binkd starts another
+    //  batch unless this one was empty; |singleBatch| models a binkp/1.0
+    //  peer, which always stops here.
+    _endOfBatch() {
+        //  Reached from both _onEob and _maybeEob, which can fire in the same
+        //  tick when the two M_EOBs cross; count the batch once.
+        if (this.batchClosed) {
+            return;
+        }
+        if (!this.eobSent || !this.remoteEOB || this.currentSend || this.inFile) {
+            return;
+        }
+        this.batchClosed = true;
+        this.batches.push(this.msgsInBatch);
+        if (this.msgsInBatch > 2 && !this.opts.singleBatch) {
+            this.msgsInBatch = 0;
+            this.eobSent = false;
+            this.remoteEOB = false;
+            this.batchClosed = false;
+            this._sendNext();
+            return;
+        }
         this._maybeClose();
     }
 
@@ -402,17 +447,15 @@ class ScriptedPeer {
         }
         this.eobSent = true;
         this._send(Commands.M_EOB, '');
-        this._maybeClose();
+        this._endOfBatch();
     }
 
     //  binkp leaves it to the originating side to hang up.
     _maybeClose() {
-        if ('originating' !== this.opts.role) {
+        if ('originating' !== this.opts.role || this.closed) {
             return;
         }
-        if (!this.eobSent || !this.remoteEOB || this.inFile || this.currentSend) {
-            return;
-        }
+        this.closed = true;
         setImmediate(() => this.socket.end());
     }
 }

--- a/test/binkp_session.test.js
+++ b/test/binkp_session.test.js
@@ -704,7 +704,9 @@ describe('BinkpSession — multi-batch (onBatchEnd)', () => {
                             'keep'
                         );
                     }
-                    //  batchCount === 2: nothing more → originating closes.
+                    //  Nothing more is queued after this. batchCount then
+                    //  reaches 3: the trailing empty batch is what actually
+                    //  ends a binkp/1.1 session — see the note below.
                 },
             },
             {} // server has no hook — waits for originating to close
@@ -726,7 +728,11 @@ describe('BinkpSession — multi-batch (onBatchEnd)', () => {
 
         await runToEnd(clientSess, serverSess);
 
-        assert.equal(batchCount, 2, 'onBatchEnd should fire for each batch');
+        //  Two batches carried a file each, and a third carried nothing but
+        //  the pair of M_EOBs. That empty batch is not waste: binkp/1.1 ends
+        //  a session on it, and skipping it leaves the peer waiting for an
+        //  M_EOB that never comes.
+        assert.equal(batchCount, 3, 'onBatchEnd should fire for each batch');
         assert.ok(serverReceived.includes('batch1.pkt'), 'server should receive batch1');
         assert.ok(serverReceived.includes('batch2.pkt'), 'server should receive batch2');
 
@@ -742,7 +748,8 @@ describe('BinkpSession — multi-batch (onBatchEnd)', () => {
             {
                 onBatchEnd: () => {
                     batchCount++;
-                    // queue nothing — originating closes after this
+                    //  Queues nothing, so the batch after this one is empty
+                    //  and the originating side closes on it.
                 },
             },
             {}
@@ -755,7 +762,8 @@ describe('BinkpSession — multi-batch (onBatchEnd)', () => {
         clientSess.queueFile(f.filePath, 'only.pkt', f.size, f.timestamp, 'keep');
         await runToEnd(clientSess, serverSess);
 
-        assert.equal(batchCount, 1);
+        //  One batch for the file, then the empty one that ends the session.
+        assert.equal(batchCount, 2);
         await fsp.unlink(f.filePath).catch(() => {});
     });
 


### PR DESCRIPTION
No issue filed for this one — it surfaced while validating #728 against real binkd.

A binkp/1.1 session is a series of *batches*. Each ends when both sides have sent `M_EOB`, and another follows any batch that carried more than that pair; only an empty batch ends the session. We stopped after the first one, leaving a conforming peer waiting for an `M_EOB` that never came (`protocol.c:3275-3293`).

**No mail was lost** — it had already transferred by the time this bites — which is why it went unnoticed for so long. The costs were elsewhere.

## What it was actually costing

**binkd booked successful sessions as failed.** It waited out its own timeout (300 s) and then logged `done (..., failed, ...)`, or never reached a verdict at all. It also calls `bad_try(&to->fa, "Timeout!", BAD_IO)` on that timeout (`protocol.c:3349`), and the **shipped Debian/Ubuntu `binkd.cfg` has `try 10` and `hold 10m` uncommented** — not settings a sysop had to opt into. Enough consecutive sessions and a peer stops calling us for a while.

**Ours was worse, and quieter.** An inbound session parked waiting still holds that node's lock: `releaseLock` fires only on `session-end`, and for an answering session `session-end` comes from the socket closing — i.e. the timeout. `callNode` skips a locked node, and crashmail dispatch runs through `pollNodes` → `callNode`. So **crashmail queued for a node was silently skipped for five minutes after every inbound session from that node**, waiting instead for the next scheduled poll. That defeats the entire point of crashmail, and nothing in our logs would connect the two.

## Result, from binkd's own log

Same harness, same two scenarios, before and after:

| | before | after |
|---|---|---|
| ENiGMA calls binkd | `done (…, failed, …)` | `done (…, OK, …)` |
| binkd calls ENiGMA | no verdict — sat in `select()` | `done (…, OK, …)` |
| binkd process exit | `"timeout"` | `0` |

Verified with `dev_util/binkp_interop.js` against binkd 1.1a-115, both roles, files byte-intact.

## How the decision is made

Both sides count every command frame, sent and received, since the batch began. Each frame is counted once by its sender and once by its receiver, so the two totals agree and the rule is self-synchronising — which is why binkd needs no negotiation for it.

Gated on the remote's `VER`: a peer identifying as binkp/1.0, or one that never sends `VER` at all, closes after the first batch and is left exactly as before. `MAX_BATCHES` is a runaway guard against a peer that never falls quiet, not part of the protocol.

A close arriving *between* batches now counts as clean rather than a disconnect. The peer decided the session was over one batch sooner than we did; with nothing outstanding there is nothing to report.

## Bonus

Each new batch is also an opportunity: anything that turned up mid-session — a FREQ response, or mail tossed from a packet that just arrived — can go out on the same connection instead of waiting for the next poll. We already did this in the one case where `onBatchEnd` queued files; it now works generally.

## Verification

**1542 tests passing**, stable across repeated runs. New `test/binkp_batch.test.js`; **8 of its 12 tests fail against master**.

**Two existing `onBatchEnd` tests changed expectations**, 2 → 3 and 1 → 2 hook calls. That is the fix, not a regression: a session that carried a file now ends on a trailing empty batch, and that batch is what ends it. Both files still transfer and both sessions still complete; I have commented the reasoning at each assertion.

The scripted peer in `test/binkp_peer.js` learned the same batching rule, so it still models binkd rather than agreeing with us. Two bugs of my own on the way: it double-counted a batch when the two `M_EOB`s crossed in a single tick (`_endOfBatch` is reachable from both `_onEob` and `_maybeEob`), and my first "peer hangs up early" test had a bad premise — an *answering* peer never closes — so it is rewritten around `runAnswering`, where the caller genuinely can hang up first.

With this, all three BinkP issues found in this pass are closed: #724 (NR mode), #723 (GZ container), and this.
