### PR TITLE
fix(servers): surface port bind failures instead of hanging startup (#547)

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -22,6 +22,10 @@ Refer to [Upgrading](./docs/_docs/admin/upgrading.md) for details around this pr
 
 ## 0.5.0-beta to 0.5.1-beta
 
+* **A port conflict now stops startup instead of being ignored** ([#547](https://github.com/NuSkooler/enigma-bbs/issues/547)). Previously a server that could not bind its port left the startup sequence hanging with no message and no exit; NNTP specifically logged a warning and carried on, so the board ran with NNTP silently absent. Bind failures are now reported on the console and are **fatal for every server**, and ENiGMA½ exits with a non-zero status.
+
+  **Action:** if you run NNTP, Gopher, or the web server on a port something else on the host also uses, a start that previously "worked" (minus that service) will now stop with an explicit error. Fix the conflicting port in `config.hjson`, or disable the service with `enabled: false`.
+
 * **BinkP sessions were left to time out rather than closing cleanly.** ENiGMA½ ended after the first binkp/1.1 batch, so the peer waited for an `M_EOB` that never arrived. Mail transferred correctly, but the remote logged the session as failed, and while ours sat waiting it held that node's lock — so crashmail queued for the node during the window was skipped until the next scheduled poll. **No action is required**; if a peer has been reporting failed sessions with your system despite the mail arriving, this is why.
 
 * **BinkP files compressed with GZ were rejected by every other mailer** ([#723](https://github.com/NuSkooler/enigma-bbs/issues/723)). ENiGMA½ wrapped compressed data in the gzip container where [FTS-1029](http://ftsc.org/docs/fts-1029.001) — and binkd, Mystic and the rest — use the zlib one. The receiving mailer rejected the stream immediately; our side logged nothing and re-sent the file on every poll. **Nothing was lost** and **no configuration change is required**: the affected files stayed in the outbound spool and go out on the next poll.

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -9,6 +9,8 @@ This document attempts to track **major** changes and additions in ENiGMA½. For
 
   Every login, content, and chat server now binds through a shared helper that listens for both `'listening'` and `'error'` and calls back exactly once, with an error an operator can act on — `EADDRINUSE`, `EACCES` on a privileged port, and `EADDRNOTAVAIL` each get an explanation rather than a bare code. A bind failure is now fatal for **every** server, including NNTP; see [UPGRADE.md](UPGRADE.md).
 
+  * **Startup output now reads in the order things happen** -- the banner, then any configuration warnings, then the server list, then `System started!`. The banner was previously printed at the very end, underneath everything it was supposed to introduce.
+
   * **Startup now reports what actually bound.** One line per server with its address and port, so a misconfigured or missing service is visible at a glance instead of only in the log. Colour is used only when stdout is a TTY and [`NO_COLOR`](https://no-color.org/) is unset, so piped output and journals stay clean.
 
   * **Startup failures always exit non-zero.** An error that had already been displayed previously fell through the final handler and the process wound down with status `0`, so service managers and install scripts saw a clean exit from a failed start.

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -3,6 +3,16 @@ This document attempts to track **major** changes and additions in ENiGMA½. For
 
 ## 0.5.1-beta
 
+* **A second instance bound nothing, said nothing, and kept running** ([#547](https://github.com/NuSkooler/enigma-bbs/issues/547)) — starting ENiGMA½ while another instance already held its ports produced no error, no `System started!`, and no exit. The process simply sat there, serving no one.
+
+  Node's `server.listen(port, host, cb)` registers `cb` as a one-shot `'listening'` listener: it never receives an error argument, and on a failed bind it never fires at all. Every server treated it as an error-first callback, so `EADDRINUSE` left the startup series in `listening_server.js` waiting for a callback that would never come. Telnet caught the event but logged it at `info` — and the default logging config writes to a rotating file with no console stream, so nothing reached the terminal. The remaining servers had no server-level `'error'` handler at all, so the event fell through to the process-level `uncaughtException` net, which by design keeps the process alive.
+
+  Every login, content, and chat server now binds through a shared helper that listens for both `'listening'` and `'error'` and calls back exactly once, with an error an operator can act on — `EADDRINUSE`, `EACCES` on a privileged port, and `EADDRNOTAVAIL` each get an explanation rather than a bare code. A bind failure is now fatal for **every** server, including NNTP; see [UPGRADE.md](UPGRADE.md).
+
+  * **Startup now reports what actually bound.** One line per server with its address and port, so a misconfigured or missing service is visible at a glance instead of only in the log. Colour is used only when stdout is a TTY and [`NO_COLOR`](https://no-color.org/) is unset, so piped output and journals stay clean.
+
+  * **Startup failures always exit non-zero.** An error that had already been displayed previously fell through the final handler and the process wound down with status `0`, so service managers and install scripts saw a clean exit from a failed start.
+
 * **BinkP sessions ended on a timeout instead of a clean close** — binkp/1.1 runs a session as a series of batches: another follows any batch that carried more than the two `M_EOB`s, and only an empty batch ends the session. ENiGMA½ stopped after the first one, leaving a conforming peer waiting for an `M_EOB` that never came.
 
   No mail was lost — it had already transferred by then — but the peer sat until its own timeout (five minutes, for binkd) and then recorded an otherwise successful session as `failed`. With binkd's shipped `try`/`hold` settings, enough of those in a row will put us on hold and stop it calling for a while.

--- a/core/bbs.js
+++ b/core/bbs.js
@@ -11,6 +11,7 @@ const UserProps = require('./user_property.js');
 const SysProps = require('./system_property.js');
 const SysLogKeys = require('./system_log.js');
 const UserLogNames = require('./user_log_name');
+const { consoleStyle } = require('./server_listen.js');
 
 //  deps
 const async = require('async');
@@ -52,6 +53,28 @@ function printVersionAndExit() {
     console.info(require('../package.json').version);
 }
 
+//
+//  Banner first, so anything the startup then has to say -- config warnings,
+//  which servers bound, a failure -- appears underneath it in the order it
+//  actually happened. It used to be printed at the very end, which put the
+//  warnings and the server list above it and read backwards.
+//
+function displayStartupBanner(cb) {
+    fs.readFile(
+        paths.join(__dirname, '../misc/startup_banner.asc'),
+        'utf8',
+        (err, banner) => {
+            console.info(FULL_COPYRIGHT);
+            if (!err) {
+                //  note this is escaped:
+                console.info(banner);
+            }
+            console.info(consoleStyle('|07System starting up...'));
+            return cb();
+        }
+    );
+}
+
 function main() {
     let errorDisplayed = false;
 
@@ -70,10 +93,12 @@ function main() {
 
                 const configOverridePath = argv.config;
 
-                return callback(
-                    null,
-                    configOverridePath || conf.Config.getDefaultPath(),
-                    _.isString(configOverridePath)
+                return displayStartupBanner(() =>
+                    callback(
+                        null,
+                        configOverridePath || conf.Config.getDefaultPath(),
+                        _.isString(configOverridePath)
+                    )
                 );
             },
             function initConfig(configPath, configPathSupplied, callback) {
@@ -121,18 +146,7 @@ function main() {
         ],
         function complete(err) {
             if (!err) {
-                //  note this is escaped:
-                fs.readFile(
-                    paths.join(__dirname, '../misc/startup_banner.asc'),
-                    'utf8',
-                    (err, banner) => {
-                        console.info(FULL_COPYRIGHT);
-                        if (!err) {
-                            console.info(banner);
-                        }
-                        console.info('System started!');
-                    }
-                );
+                console.info(consoleStyle('|10System started!'));
             }
 
             if (err) {

--- a/core/bbs.js
+++ b/core/bbs.js
@@ -106,8 +106,14 @@ function main() {
             },
             function initSystem(callback) {
                 initialize(function init(err) {
-                    if (err) {
+                    //  Bind failures and friends have already printed something
+                    //  an operator can act on; a util.inspect() dump on top of
+                    //  that is just noise.
+                    if (err && !err.consoleReported) {
                         console.error('Error initializing: ' + util.inspect(err));
+                    }
+                    if (err) {
+                        errorDisplayed = true;
                     }
                     return callback(err);
                 });
@@ -129,8 +135,14 @@ function main() {
                 );
             }
 
-            if (err && !errorDisplayed) {
-                console.error('Error initializing: ' + util.inspect(err));
+            if (err) {
+                if (!errorDisplayed && !err.consoleReported) {
+                    console.error('Error initializing: ' + util.inspect(err));
+                }
+                //  Always exit non-zero on a startup failure. Previously an
+                //  error that had already been displayed fell through here and
+                //  the process wound down with status 0, so service managers
+                //  and scripts saw a clean exit. See issue #547.
                 return process.exit(1);
             }
         }

--- a/core/listening_server.js
+++ b/core/listening_server.js
@@ -3,6 +3,7 @@
 
 //  ENiGMA½
 const logger = require('./logger.js');
+const { consoleStyle } = require('./server_listen.js');
 
 //  deps
 const async = require('async');
@@ -15,6 +16,7 @@ exports.shutdown = shutdown;
 exports.getServer = getServer;
 
 function startup(cb) {
+    console.info(consoleStyle('|07Starting servers...'));
     return startListening(cb);
 }
 

--- a/core/server_listen.js
+++ b/core/server_listen.js
@@ -1,0 +1,184 @@
+/* jslint node: true */
+'use strict';
+
+//  ENiGMA½
+const { EnigError, ErrorCodes } = require('./enig_error.js');
+const logger = require('./logger.js');
+
+exports.listenServer = listenServer;
+exports.makeBindError = makeBindError;
+exports.reportListening = reportListening;
+exports.reportBindFailure = reportBindFailure;
+exports.formatBindTarget = formatBindTarget;
+exports.consoleStyle = consoleStyle;
+
+const ANSI_RESET = '\u001b[0m';
+
+//  Width of the server name column in startup output. Long enough for
+//  'websocket' and 'gopher' to line up without wrapping a narrow terminal.
+const NAME_COLUMN_WIDTH = 10;
+
+//
+//  Human readable description of what we tried to bind.
+//
+//  |address| is frequently undefined: none of the login or content servers
+//  define an address default (only BinkP does), and Node treats a missing
+//  host as "every interface". Render that as '*' rather than 'undefined'.
+//
+function formatBindTarget(address, port) {
+    return `${address || '*'}:${port}`;
+}
+
+//
+//  Turn a bind failure into an EnigError carrying a message an operator can
+//  act on. The raw Node errors ('listen EADDRINUSE: address already in use
+//  0.0.0.0:8888') do not say which ENiGMA½ server failed, and EACCES in
+//  particular gives no hint as to why.
+//
+function makeBindError(err, { name, port, address }) {
+    const target = formatBindTarget(address, port);
+
+    let reason;
+    switch (err.code) {
+        case 'EADDRINUSE':
+            reason =
+                `${target} is already in use - is another ENiGMA½ instance ` +
+                'or another service already running?';
+            break;
+
+        case 'EACCES':
+            reason =
+                `permission denied binding ${target} - ports below 1024 require ` +
+                'elevated privileges or CAP_NET_BIND_SERVICE';
+            break;
+
+        case 'EADDRNOTAVAIL':
+            reason =
+                `${target} is not available on this host - check the configured ` +
+                'address';
+            break;
+
+        default:
+            reason = `${target}: ${err.message}`;
+            break;
+    }
+
+    const bindErr = new EnigError(
+        `${name} server could not bind`,
+        ErrorCodes.UnexpectedState,
+        reason,
+        err.code
+    );
+
+    //  So callers can special case, and so bbs.js knows this has already been
+    //  presented to the operator and should not be dumped a second time.
+    bindErr.bindFailure = true;
+    bindErr.consoleReported = false;
+    return bindErr;
+}
+
+//
+//  Colour for the console, but only when it will actually help: a TTY, and
+//  NO_COLOR unset (https://no-color.org/). Anything redirected to a file, a
+//  pipe, or a systemd journal gets clean text.
+//
+//  Input is pipe/Renegade coded so it matches the rest of the codebase rather
+//  than introducing a second colour vocabulary.
+//
+function consoleStyle(s, stream) {
+    stream = stream || process.stdout;
+
+    //  Required at call time, not module load: color_codes.js reaches back
+    //  here through predefined_mci -> message_area -> activitypub -> web.js,
+    //  and destructuring at load time in that cycle yields undefined.
+    const { renegadeToAnsi, stripMciColorCodes } = require('./color_codes.js');
+
+    const useColor = !('NO_COLOR' in process.env) && true === stream.isTTY;
+    if (!useColor) {
+        return stripMciColorCodes(s);
+    }
+
+    return `${renegadeToAnsi(s)}${ANSI_RESET}`;
+}
+
+function nameColumn(name) {
+    return name.padEnd(NAME_COLUMN_WIDTH);
+}
+
+function reportListening({ name, port, address }) {
+    const target = formatBindTarget(address, port);
+    console.info(consoleStyle(`  |10${nameColumn(name)}|07listening on |15${target}`));
+}
+
+function reportBindFailure(bindErr, { name }) {
+    console.error(
+        consoleStyle(
+            `  |12${nameColumn(name)}FAILED: |15${bindErr.reason}`,
+            process.stderr
+        )
+    );
+    bindErr.consoleReported = true;
+}
+
+//
+//  Bind |server| and call back exactly once.
+//
+//  Node's server.listen(port, host, cb) registers |cb| as a one-shot
+//  'listening' listener: it never receives an error argument, and on a failed
+//  bind it never fires at all. Every ENiGMA½ server used it as though it were
+//  an error-first callback, so a port conflict left the startup waterfall in
+//  core/listening_server.js waiting forever — no message, no exit, and no
+//  'System started!'. See issue #547.
+//
+//  Listening for both 'listening' and 'error' is the only way to get a
+//  definitive answer. A pre-flight "is the port free?" probe cannot do it:
+//  connecting to a port answers a different question than binding one, and
+//  anything learned before the bind is already stale by the time it happens.
+//
+function listenServer(server, options, cb) {
+    const { port, address, name, log } = options;
+
+    let settled = false;
+
+    const finish = err => {
+        if (settled) {
+            return;
+        }
+        settled = true;
+
+        server.removeListener('listening', onListening);
+        server.removeListener('error', onError);
+
+        if (!err) {
+            //  Now that the bind has succeeded, keep a persistent handler so a
+            //  later socket-level error (EMFILE and friends) is logged rather
+            //  than thrown as an unhandled 'error' event.
+            server.on('error', runtimeErr => {
+                (log || logger.log).warn(
+                    { server: name, error: runtimeErr.message },
+                    'Server error'
+                );
+            });
+
+            reportListening(options);
+        } else {
+            reportBindFailure(err, options);
+        }
+
+        return cb(err);
+    };
+
+    const onListening = () => finish(null);
+    const onError = err => finish(makeBindError(err, options));
+
+    server.on('listening', onListening);
+    server.on('error', onError);
+
+    try {
+        server.listen(port, address);
+    } catch (e) {
+        //  Node throws synchronously for a malformed address/port rather than
+        //  emitting 'error'.
+        return finish(makeBindError(e, options));
+    }
+}

--- a/core/server_listen.js
+++ b/core/server_listen.js
@@ -85,20 +85,46 @@ function makeBindError(err, { name, port, address }) {
 //  Input is pipe/Renegade coded so it matches the rest of the codebase rather
 //  than introducing a second colour vocabulary.
 //
+//
+//  Renegade pipe colour index -> ANSI foreground digit. |00-|07 are normal
+//  intensity, |08-|15 the bright pair.
+//
+const PIPE_COLOR_TO_ANSI = [0, 4, 2, 6, 1, 5, 3, 7];
+const PIPE_CODE_RE = /\|([0-9]{2})/g;
+
+//
+//  Deliberately *not* color_codes.js. That module reaches stat_log.js through
+//  predefined_mci -> message_area, and this runs before the databases are
+//  initialized -- stat_log captures dbs.system at load time, so pulling it in
+//  this early leaves it permanently undefined and StatLog.init() then throws.
+//  (color_codes.js also reaches back here via activitypub -> web.js, so a
+//  load-time require would be circular besides.) Four colours do not justify
+//  either hazard.
+//
+function pipeToAnsi(s) {
+    return s.replace(PIPE_CODE_RE, (_m, digits) => {
+        const idx = parseInt(digits, 10);
+        if (idx > 15) {
+            return ''; //  background/unsupported: drop rather than mis-render
+        }
+        const intensity = idx > 7 ? 1 : 22;
+        return `\u001b[${intensity};3${PIPE_COLOR_TO_ANSI[idx % 8]}m`;
+    });
+}
+
+function stripPipeCodes(s) {
+    return s.replace(PIPE_CODE_RE, '');
+}
+
 function consoleStyle(s, stream) {
     stream = stream || process.stdout;
 
-    //  Required at call time, not module load: color_codes.js reaches back
-    //  here through predefined_mci -> message_area -> activitypub -> web.js,
-    //  and destructuring at load time in that cycle yields undefined.
-    const { renegadeToAnsi, stripMciColorCodes } = require('./color_codes.js');
-
     const useColor = !('NO_COLOR' in process.env) && true === stream.isTTY;
     if (!useColor) {
-        return stripMciColorCodes(s);
+        return stripPipeCodes(s);
     }
 
-    return `${renegadeToAnsi(s)}${ANSI_RESET}`;
+    return `${pipeToAnsi(s)}${ANSI_RESET}`;
 }
 
 function nameColumn(name) {

--- a/core/servers/chat/mrc_multiplexer.js
+++ b/core/servers/chat/mrc_multiplexer.js
@@ -8,6 +8,7 @@ const Config = require('../../config.js').get;
 const { Errors } = require('../../enig_error.js');
 const SysProps = require('../../system_property.js');
 const StatLog = require('../../stat_log.js');
+const { listenServer } = require('../../server_listen.js');
 
 //  deps
 const net = require('net');
@@ -120,7 +121,7 @@ exports.getModule = class MrcModule extends ServerModule {
             { server: ModuleInfo.name, port: config.chatServers.mrc.multiplexerPort },
             'MRC multiplexer starting up'
         );
-        return this.server.listen(port, cb);
+        return listenServer(this.server, { name: 'mrc', port, log: Log }, cb);
     }
 
     /**

--- a/core/servers/content/gopher.js
+++ b/core/servers/content/gopher.js
@@ -22,6 +22,7 @@ const { sortAreasOrConfs } = require('../../conf_area_util.js');
 const AnsiPrep = require('../../ansi_prep.js');
 const { wordWrapText } = require('../../word_wrap.js');
 const { stripMciColorCodes } = require('../../color_codes.js');
+const { listenServer } = require('../../server_listen.js');
 
 //  deps
 const net = require('net');
@@ -131,7 +132,9 @@ exports.getModule = class GopherModule extends ServerModule {
             );
         }
 
-        return this.server.listen(port, config.contentServers.gopher.address, cb);
+        const address = config.contentServers.gopher.address;
+
+        return listenServer(this.server, { name: 'gopher', port, address, log: Log }, cb);
     }
 
     get enabled() {

--- a/core/servers/content/nntp.js
+++ b/core/servers/content/nntp.js
@@ -27,6 +27,11 @@ const {
 const AnsiPrep = require('../../ansi_prep.js');
 const { stripMciColorCodes } = require('../../color_codes.js');
 const ACS = require('../../acs');
+const {
+    makeBindError,
+    reportListening,
+    reportBindFailure,
+} = require('../../server_listen.js');
 
 //  deps
 const NNTPServerBase = require('nntp-server');
@@ -1414,14 +1419,28 @@ exports.getModule = class NNTPServerModule extends ServerModule {
                 const server = this[`${service}Server`];
                 if (server) {
                     const port = config.contentServers.nntp[service].port;
+
+                    //  listenURI() binds all interfaces; report the same thing
+                    //  we actually asked for.
+                    const bindInfo = { name: service, port, address: '0.0.0.0' };
+
                     server.listen(this.listenURI(port, service)).then(
-                        () => nextService(null),
-                        e => {
-                            Log.warn(
-                                { error: e.message, port },
-                                `${service.toUpperCase()} failed to listen`
+                        () => {
+                            reportListening(bindInfo);
+                            Log.info(
+                                { server: service, port },
+                                'Listening for connections'
                             );
-                            return nextService(null); //  try next anyway
+                            return nextService(null);
+                        },
+                        e => {
+                            //  A port conflict here used to be logged and
+                            //  skipped, which left the board running with NNTP
+                            //  silently absent. Treat it like every other
+                            //  server: report it and stop startup.
+                            const bindErr = makeBindError(e, bindInfo);
+                            reportBindFailure(bindErr, bindInfo);
+                            return nextService(bindErr);
                         }
                     );
                 } else {

--- a/core/servers/content/web.js
+++ b/core/servers/content/web.js
@@ -3,6 +3,7 @@ const SysLogger = require('../../logger.js').log;
 const ServerModule = require('../../server_module.js').ServerModule;
 const Config = require('../../config.js').get;
 const { Errors } = require('../../enig_error.js');
+const { listenServer } = require('../../server_listen.js');
 const { loadModulesForCategory, moduleCategories } = require('../../module_util');
 const WebHandlerModule = require('../../web_handler_module');
 
@@ -212,9 +213,14 @@ exports.getModule = class WebServerModule extends ServerModule {
                         );
                     }
 
-                    this[name].listen(
-                        port,
-                        config.contentServers.web[service].address,
+                    return listenServer(
+                        this[name],
+                        {
+                            name: service,
+                            port,
+                            address: config.contentServers.web[service].address,
+                            log: SysLogger,
+                        },
                         err => {
                             return nextService(err);
                         }

--- a/core/servers/login/ssh.js
+++ b/core/servers/login/ssh.js
@@ -11,6 +11,7 @@ const enigVersion = require('../../../package.json').version;
 const theme = require('../../theme.js');
 const stringFormat = require('../../string_format.js');
 const { Errors, ErrorReasons } = require('../../enig_error.js');
+const { listenServer } = require('../../server_listen.js');
 const User = require('../../user.js');
 const UserProps = require('../../user_property.js');
 
@@ -471,14 +472,20 @@ exports.getModule = class SSHServerModule extends LoginServerModule {
             return cb(Errors.Invalid(`Invalid port: ${config.loginServers.ssh.port}`));
         }
 
-        this.server.listen(port, config.loginServers.ssh.address, err => {
-            if (!err) {
-                Log.info(
-                    { server: ModuleInfo.name, port: port },
-                    'Listening for connections'
-                );
+        const address = config.loginServers.ssh.address;
+
+        return listenServer(
+            this.server,
+            { name: 'ssh', port, address, log: Log },
+            err => {
+                if (!err) {
+                    Log.info(
+                        { server: ModuleInfo.name, port, address },
+                        'Listening for connections'
+                    );
+                }
+                return cb(err);
             }
-            return cb(err);
-        });
+        );
     }
 };

--- a/core/servers/login/telnet.js
+++ b/core/servers/login/telnet.js
@@ -4,6 +4,7 @@ const { Client } = require('../../client');
 const Config = require('../../config').get;
 const { log: Log } = require('../../logger');
 const { Errors } = require('../../enig_error');
+const { listenServer } = require('../../server_listen');
 
 //  deps
 const net = require('net');
@@ -266,10 +267,6 @@ exports.getModule = class TelnetServerModule extends LoginServerModule {
             this.handleNewClient(client, socket, ModuleInfo);
         });
 
-        this.server.on('error', err => {
-            Log.info({ error: err.message }, 'Telnet server error');
-        });
-
         return cb(null);
     }
 
@@ -284,15 +281,21 @@ exports.getModule = class TelnetServerModule extends LoginServerModule {
             return cb(Errors.Invalid(`Invalid port: ${config.loginServers.telnet.port}`));
         }
 
-        this.server.listen(port, config.loginServers.telnet.address, err => {
-            if (!err) {
-                Log.info(
-                    { server: ModuleInfo.name, port: port },
-                    'Listening for connections'
-                );
+        const address = config.loginServers.telnet.address;
+
+        return listenServer(
+            this.server,
+            { name: 'telnet', port, address, log: Log },
+            err => {
+                if (!err) {
+                    Log.info(
+                        { server: ModuleInfo.name, port, address },
+                        'Listening for connections'
+                    );
+                }
+                return cb(err);
             }
-            return cb(err);
-        });
+        );
     }
 };
 

--- a/core/servers/login/websocket.js
+++ b/core/servers/login/websocket.js
@@ -7,6 +7,7 @@ const TelnetClient = require('./telnet.js').TelnetClient;
 const Log = require('../../logger.js').log;
 const LoginServerModule = require('../../login_server_module.js');
 const { Errors } = require('../../enig_error.js');
+const { listenServer } = require('../../server_listen.js');
 
 //  deps
 const _ = require('lodash');
@@ -226,26 +227,39 @@ exports.getModule = class WebSocketLoginServer extends LoginServerModule {
                     return nextServerType(Errors.Invalid(`Invalid port: ${confPort}`));
                 }
 
-                server.httpServer.listen(port, conf.address, err => {
-                    if (err) {
-                        return nextServerType(err);
-                    }
+                return listenServer(
+                    server.httpServer,
+                    {
+                        name: 'secure' === serverType ? 'wss' : 'ws',
+                        port,
+                        address: conf.address,
+                        log: Log,
+                    },
+                    err => {
+                        if (err) {
+                            return nextServerType(err);
+                        }
 
-                    server.wsServer.on('connection', (ws, req) => {
-                        const webSocketClient = new WebSocketClient(ws, req, serverType);
-                        this.handleNewClient(
-                            webSocketClient,
-                            webSocketClient.socket,
-                            ModuleInfo
+                        server.wsServer.on('connection', (ws, req) => {
+                            const webSocketClient = new WebSocketClient(
+                                ws,
+                                req,
+                                serverType
+                            );
+                            this.handleNewClient(
+                                webSocketClient,
+                                webSocketClient.socket,
+                                ModuleInfo
+                            );
+                        });
+
+                        Log.info(
+                            { server: serverName, port, address: conf.address },
+                            'Listening for connections'
                         );
-                    });
-
-                    Log.info(
-                        { server: serverName, port: port },
-                        'Listening for connections'
-                    );
-                    return nextServerType(null);
-                });
+                        return nextServerType(null);
+                    }
+                );
             },
             err => {
                 cb(err);

--- a/test/server_listen.test.js
+++ b/test/server_listen.test.js
@@ -1,0 +1,254 @@
+/* eslint-disable no-console */
+'use strict';
+
+const { strict: assert } = require('assert');
+const net = require('net');
+
+const {
+    listenServer,
+    makeBindError,
+    formatBindTarget,
+    consoleStyle,
+} = require('../core/server_listen.js');
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+//  listenServer() and friends report to the console by design; keep the mocha
+//  output readable and let individual tests assert on what was written.
+function captureConsole() {
+    const captured = { info: [], error: [] };
+    const original = { info: console.info, error: console.error };
+
+    console.info = (...args) => captured.info.push(args.join(' '));
+    console.error = (...args) => captured.error.push(args.join(' '));
+
+    captured.restore = () => {
+        console.info = original.info;
+        console.error = original.error;
+    };
+    return captured;
+}
+
+//  Occupy an ephemeral port and hand back both the port and a closer. Binding
+//  port 0 lets the OS pick something guaranteed free, which avoids the flakiness
+//  of hard-coding a port that may be in use on a developer's machine or in CI.
+function occupyPort(cb) {
+    const blocker = net.createServer();
+    blocker.listen(0, '127.0.0.1', () => {
+        return cb(blocker.address().port, done => blocker.close(done));
+    });
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe('server_listen — bind result reporting', () => {
+    let consoleOut;
+
+    beforeEach(() => {
+        consoleOut = captureConsole();
+    });
+
+    afterEach(() => {
+        consoleOut.restore();
+    });
+
+    describe('listenServer', () => {
+        it('calls back once with no error when the bind succeeds', done => {
+            const server = net.createServer();
+            let calls = 0;
+
+            listenServer(server, { port: 0, address: '127.0.0.1', name: 'test' }, err => {
+                calls += 1;
+                assert.equal(err, null);
+                assert.equal(server.listening, true);
+
+                //  give any stray second callback a chance to land
+                setTimeout(() => {
+                    assert.equal(calls, 1);
+                    server.close(() => done());
+                }, 50);
+            });
+        });
+
+        //
+        //  Regression for #547: a second instance bound nothing, printed
+        //  nothing and never exited. The root cause was that Node's
+        //  listen(port, host, cb) callback is a one-shot 'listening' listener,
+        //  so on EADDRINUSE it never fired and the startup waterfall in
+        //  listening_server.js simply stopped advancing.
+        //
+        it('calls back with an error when the port is already in use', done => {
+            occupyPort((port, release) => {
+                const server = net.createServer();
+
+                listenServer(
+                    server,
+                    { port, address: '127.0.0.1', name: 'telnet' },
+                    err => {
+                        assert.ok(err, 'expected a bind error');
+                        assert.equal(err.bindFailure, true);
+                        assert.equal(err.reasonCode, 'EADDRINUSE');
+                        assert.match(err.message, /telnet server could not bind/);
+                        assert.match(err.reason, /already in use/);
+                        assert.equal(server.listening, false);
+
+                        release(() => done());
+                    }
+                );
+            });
+        });
+
+        it('calls back exactly once even though listen() never fires its callback', done => {
+            occupyPort((port, release) => {
+                const server = net.createServer();
+                let calls = 0;
+
+                listenServer(
+                    server,
+                    { port, address: '127.0.0.1', name: 'telnet' },
+                    () => {
+                        calls += 1;
+                    }
+                );
+
+                setTimeout(() => {
+                    assert.equal(calls, 1, 'callback should fire exactly once');
+                    release(() => done());
+                }, 100);
+            });
+        });
+
+        it('reports the failure to the console so the operator sees it', done => {
+            occupyPort((port, release) => {
+                const server = net.createServer();
+
+                listenServer(
+                    server,
+                    { port, address: '127.0.0.1', name: 'telnet' },
+                    err => {
+                        assert.equal(err.consoleReported, true);
+                        assert.equal(consoleOut.error.length, 1);
+                        assert.match(consoleOut.error[0], /telnet/);
+                        assert.match(consoleOut.error[0], /FAILED/);
+                        release(() => done());
+                    }
+                );
+            });
+        });
+
+        it('reports a successful bind to the console', done => {
+            const server = net.createServer();
+            listenServer(
+                server,
+                { port: 0, address: '127.0.0.1', name: 'gopher' },
+                () => {
+                    assert.equal(consoleOut.info.length, 1);
+                    assert.match(consoleOut.info[0], /gopher/);
+                    assert.match(consoleOut.info[0], /listening on/);
+                    server.close(() => done());
+                }
+            );
+        });
+
+        //  Once bound, a later socket error must not re-enter the callback --
+        //  that would be a double call into async.series during startup.
+        it('does not call back again on a post-bind error', done => {
+            const server = net.createServer();
+            let calls = 0;
+
+            listenServer(server, { port: 0, address: '127.0.0.1', name: 'test' }, () => {
+                calls += 1;
+
+                //  Emitting 'error' with no listener would throw; the persistent
+                //  handler installed after a successful bind should absorb it.
+                assert.doesNotThrow(() => {
+                    server.emit('error', new Error('later boom'));
+                });
+
+                setTimeout(() => {
+                    assert.equal(calls, 1);
+                    server.close(() => done());
+                }, 50);
+            });
+        });
+
+        it('surfaces a synchronous listen() throw as a bind error', done => {
+            const server = net.createServer();
+
+            //  A negative port makes Node throw rather than emit 'error'.
+            listenServer(server, { port: -1, address: '127.0.0.1', name: 'web' }, err => {
+                assert.ok(err, 'expected an error');
+                assert.equal(err.bindFailure, true);
+                done();
+            });
+        });
+    });
+
+    describe('formatBindTarget', () => {
+        it('renders a configured address', () => {
+            assert.equal(formatBindTarget('10.0.0.5', 8888), '10.0.0.5:8888');
+        });
+
+        //  Only BinkP defines an address default; every other server leaves it
+        //  undefined and Node binds all interfaces.
+        it('renders a missing address as a wildcard rather than "undefined"', () => {
+            assert.equal(formatBindTarget(undefined, 8888), '*:8888');
+        });
+    });
+
+    describe('makeBindError', () => {
+        const opts = { name: 'telnet', port: 8888, address: '0.0.0.0' };
+
+        it('explains EADDRINUSE in terms an operator can act on', () => {
+            const err = makeBindError({ code: 'EADDRINUSE' }, opts);
+            assert.match(err.reason, /0\.0\.0\.0:8888 is already in use/);
+            assert.match(err.reason, /another ENiGMA½ instance/);
+            assert.equal(err.reasonCode, 'EADDRINUSE');
+        });
+
+        it('explains EACCES as a privilege problem', () => {
+            const err = makeBindError({ code: 'EACCES' }, { ...opts, port: 23 });
+            assert.match(err.reason, /permission denied/);
+            assert.match(err.reason, /below 1024/);
+        });
+
+        it('falls back to the underlying message for unknown codes', () => {
+            const err = makeBindError({ code: 'EWAT', message: 'something odd' }, opts);
+            assert.match(err.reason, /something odd/);
+        });
+
+        it('marks the error as a bind failure', () => {
+            const err = makeBindError({ code: 'EADDRINUSE' }, opts);
+            assert.equal(err.bindFailure, true);
+        });
+    });
+
+    describe('consoleStyle', () => {
+        const PIPE = '|10hello |15world';
+
+        it('strips pipe codes when the stream is not a TTY', () => {
+            assert.equal(consoleStyle(PIPE, { isTTY: false }), 'hello world');
+        });
+
+        it('emits ANSI when the stream is a TTY', () => {
+            const out = consoleStyle(PIPE, { isTTY: true });
+            assert.ok(out.includes('\u001b['), 'expected ANSI escapes');
+            assert.ok(out.endsWith('\u001b[0m'), 'expected a trailing reset');
+        });
+
+        it('honours NO_COLOR even on a TTY', () => {
+            const had = 'NO_COLOR' in process.env;
+            const prev = process.env.NO_COLOR;
+            process.env.NO_COLOR = '1';
+            try {
+                assert.equal(consoleStyle(PIPE, { isTTY: true }), 'hello world');
+            } finally {
+                if (had) {
+                    process.env.NO_COLOR = prev;
+                } else {
+                    delete process.env.NO_COLOR;
+                }
+            }
+        });
+    });
+});

--- a/test/server_listen.test.js
+++ b/test/server_listen.test.js
@@ -3,6 +3,7 @@
 
 const { strict: assert } = require('assert');
 const net = require('net');
+const { execFileSync } = require('child_process');
 
 const {
     listenServer,
@@ -220,6 +221,39 @@ describe('server_listen — bind result reporting', () => {
         it('marks the error as a bind failure', () => {
             const err = makeBindError({ code: 'EADDRINUSE' }, opts);
             assert.equal(err.bindFailure, true);
+        });
+    });
+
+    //
+    //  server_listen runs before initializeDatabases(). stat_log.js captures
+    //  dbs.system at load time, so anything that pulls it in this early leaves
+    //  it undefined for the life of the process and StatLog.init() then throws
+    //  'Cannot read properties of undefined (reading prepare)'. color_codes.js
+    //  reaches it via predefined_mci -> message_area, which is why this module
+    //  renders its own pipe codes. Guard that boundary.
+    //
+    describe('module isolation', () => {
+        it('does not pull in the database-dependent module graph', () => {
+            const probe = [
+                `const { consoleStyle } = require(${JSON.stringify(
+                    require.resolve('../core/server_listen.js')
+                )});`,
+                "consoleStyle('|07probe', { isTTY: true });",
+                'const re = /core\\/(stat_log|message_area|predefined_mci|color_codes)\\.js$/;',
+                'console.log(',
+                '    JSON.stringify(Object.keys(require.cache).filter(f => re.test(f)))',
+                ');',
+            ].join('\n');
+
+            const out = execFileSync(process.execPath, ['-e', probe], {
+                encoding: 'utf8',
+            });
+
+            assert.deepEqual(
+                JSON.parse(out.trim()),
+                [],
+                'server_listen must stay standalone at startup'
+            );
         });
     });
 

--- a/test/server_listen_telnet.test.js
+++ b/test/server_listen_telnet.test.js
@@ -1,0 +1,109 @@
+/* eslint-disable no-console */
+'use strict';
+
+//
+//  Integration coverage for issue #547.
+//
+//  server_listen.test.js exercises the helper directly; this drives a real
+//  server module end to end, so the wiring in telnet.js is covered too. Telnet
+//  stands in for the rest: every login/content/chat server now routes its bind
+//  through the same helper.
+//
+
+const { strict: assert } = require('assert');
+const net = require('net');
+
+const configModule = require('../core/config.js');
+
+//  Quiet the startup reporting for this suite.
+function silenceConsole() {
+    const original = { info: console.info, error: console.error };
+    console.info = () => {};
+    console.error = () => {};
+    return () => {
+        console.info = original.info;
+        console.error = original.error;
+    };
+}
+
+function occupyPort(cb) {
+    const blocker = net.createServer();
+    blocker.listen(0, '127.0.0.1', () => {
+        return cb(blocker.address().port, done => blocker.close(done));
+    });
+}
+
+//
+//  telnet.js captures `Config` at first require, so the test config has to be
+//  in place before the module is (re)loaded — see the note in test/setup.js.
+//
+function loadTelnetWith(config) {
+    const previous = configModule._pushTestConfig(config);
+    delete require.cache[require.resolve('../core/servers/login/telnet.js')];
+    const telnet = require('../core/servers/login/telnet.js');
+    return {
+        telnet,
+        restore: () => {
+            configModule._popTestConfig(previous);
+            delete require.cache[require.resolve('../core/servers/login/telnet.js')];
+        },
+    };
+}
+
+describe('telnet server — bind failure reaches the startup callback (#547)', () => {
+    let restoreConsole;
+
+    beforeEach(() => {
+        restoreConsole = silenceConsole();
+    });
+
+    afterEach(() => {
+        restoreConsole();
+    });
+
+    it('calls back with an EADDRINUSE error when the port is taken', done => {
+        occupyPort((port, release) => {
+            const { telnet, restore } = loadTelnetWith({
+                debug: { assertsEnabled: false },
+                menus: { cls: false },
+                loginServers: { telnet: { port, address: '127.0.0.1' } },
+            });
+
+            const mod = new telnet.getModule();
+            mod.createServer(createErr => {
+                assert.equal(createErr, null);
+
+                mod.listen(err => {
+                    assert.ok(err, 'listen() must report the bind failure');
+                    assert.equal(err.bindFailure, true);
+                    assert.equal(err.reasonCode, 'EADDRINUSE');
+                    assert.match(err.message, /telnet server could not bind/);
+
+                    restore();
+                    release(() => done());
+                });
+            });
+        });
+    });
+
+    it('calls back cleanly when the port is free', done => {
+        const { telnet, restore } = loadTelnetWith({
+            debug: { assertsEnabled: false },
+            menus: { cls: false },
+            loginServers: { telnet: { port: 0, address: '127.0.0.1' } },
+        });
+
+        const mod = new telnet.getModule();
+        mod.createServer(() => {
+            mod.listen(err => {
+                assert.equal(err, null);
+                assert.equal(mod.server.listening, true);
+
+                mod.server.close(() => {
+                    restore();
+                    done();
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
Fixes #547. Supersedes #592.

## The bug

Starting a second instance while another already held the ports bound nothing, printed nothing, and never exited — the process just sat there serving no one.

Node's `server.listen(port, host, cb)` registers `cb` as a one-shot `'listening'` listener: it never receives an error argument, and on a failed bind **it never fires at all**. Every server treated it as an error-first callback, so `EADDRINUSE` left the startup series in `listening_server.js` waiting for a callback that would never come — no error, no `System started!`, no exit.

Two things kept it quiet:

* `telnet.js` caught the `'error'` event but logged it at `info`, and the default logging config writes to a rotating **file** with no console stream, so nothing reached the terminal.
* Every other server had no server-level `'error'` handler at all, so the event fell through to the process-level `uncaughtException` handler, which by design keeps the process alive.

The behaviour @voipmeister asked for — a message and an exit — was already implemented in `bbs.js`. It was simply unreachable.

## The fix

New `core/server_listen.js` binds by listening for both `'listening'` and `'error'`, and calls back exactly once. Every login, content and chat server routes through it.

A pre-flight "is the port free?" probe is deliberately **not** used: connecting to a port answers a different question than binding one (a firewalled port refuses neither, and a wildcard bind conflicts with a loopback listener the probe would call free), and anything it learns is already stale by the time the bind happens.

* Bind failures are now **fatal for every server**, including NNTP — which previously warned and carried on with the service silently absent.
* `EADDRINUSE`, `EACCES` and `EADDRNOTAVAIL` get an explanation rather than a bare code.
* Startup prints one line per bound server. Colour only when stdout is a TTY and [`NO_COLOR`](https://no-color.org/) is unset, so pipes and journals stay clean.
* Startup failures always exit non-zero. An already-displayed error previously fell through the final handler and wound down with status `0`, so service managers saw a clean exit from a failed start.
* A post-bind socket error is logged rather than re-entering the startup callback or throwing as an unhandled `'error'` event.

## What it looks like

Piped / non-TTY:

```
Starting servers...
  telnet    listening on *:8888
  ssh       listening on 0.0.0.0:8889
  http      listening on 0.0.0.0:8080
  gopher    listening on *:8070
```

On a conflict:

```
  telnet    FAILED: *:8888 is already in use - is another ENiGMA½ instance or another service already running?
```

...followed by exit status 1.

## Relationship to #592

#592 aimed at the same issue and its user-facing goal was right, but it added a `tcp-port-used` pre-flight check in front of the broken code rather than fixing it — the check was never awaited, so `listen()` ran regardless, and in `web.js`/`nntp.js` the promise handler called the outer `cb` from inside a `forEachSeries` iterator. The underlying swallowed `'error'` event and misused `listen` callback were untouched.

This PR takes the intent — console feedback at startup, and a real failure on a port conflict — and no new dependency.

## Testing

* `test/server_listen.test.js` — 16 unit tests: single-callback guarantees, EADDRINUSE against a real occupied port, post-bind errors, synchronous `listen()` throws, message formatting, and `NO_COLOR`/TTY handling.
* `test/server_listen_telnet.test.js` — drives the real telnet module end to end, so the per-server wiring is covered, not just the helper.

Full suite: 1560 passing. `npm run lint` and `prettier --check` clean.

## Notes

* `UPGRADE.md` carries the NNTP behaviour change — a sysop with a conflicting NNTP/Gopher/web port will now get an explicit failure where startup previously "worked" minus that service.
* Not included: a "disabled" line per inactive server. Disabled modules are skipped at load in `module_util.js` and never reach `listen()`, so such a line would only appear for the two modules that re-check `enabled` inside `listen()` — inconsistent output rather than useful output.