### PR TITLE
fix(filebase): enforce the download ACS outside the REST API

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -22,6 +22,10 @@ Refer to [Upgrading](./docs/_docs/admin/upgrading.md) for details around this pr
 
 ## 0.5.0-beta to 0.5.1-beta
 
+* **The `download` file area ACS is now actually enforced.** It previously applied only to the REST API; over telnet and SSH any user who could browse an area could also download from it. If you set a `download` ACS on any file area expecting it to restrict downloads, **it was not doing so until now**.
+
+  **Action:** review your `fileBase.areas` ACS blocks. Areas with no `download` ACS are unaffected -- the default (`GM[users]`) matches the `read` default, so nothing changes for them. Areas where you *did* set `download` will now restrict downloads to what you configured, which may be tighter than what users have actually been getting. Note that an entry whose area is no longer in `config.hjson` fails closed and can no longer be downloaded.
+
 * **A port conflict now stops startup instead of being ignored** ([#547](https://github.com/NuSkooler/enigma-bbs/issues/547)). Previously a server that could not bind its port left the startup sequence hanging with no message and no exit; NNTP specifically logged a warning and carried on, so the board ran with NNTP silently absent. Bind failures are now reported on the console and are **fatal for every server**, and ENiGMA½ exits with a non-zero status.
 
   **Action:** if you run NNTP, Gopher, or the web server on a port something else on the host also uses, a start that previously "worked" (minus that service) will now stop with an explicit error. Fix the conflicting port in `config.hjson`, or disable the service with `enabled: false`.

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -3,6 +3,27 @@ This document attempts to track **major** changes and additions in ENiGMA½. For
 
 ## 0.5.1-beta
 
+* **The `download` file area ACS was enforced over the REST API and nowhere else** -- a security control that silently did not work. A file area can reasonably let everyone browse while restricting who may actually pull bytes down:
+
+  ```hjson
+  someArea: {
+      acs: {
+          read: GM[users]
+          download: GM[donors]
+      }
+  }
+  ```
+
+  `read` was honoured everywhere, so browsing looked correctly gated and the configuration appeared to work. `download` was checked only by `core/rest/routes/files.js` -- over telnet and SSH, where essentially every user is, anyone who could see a file could queue and download it. It was the only ACS scope in the system with no terminal-side enforcement.
+
+  The check is now applied at every path that can move a file to a user:
+
+  * **Queueing** -- `DownloadQueue.add()` refuses an entry the user has no `download` right to, and the file area list shows a distinct indicator (`noDownloadAccessIndicator`, `n/a` in the shipped theme) rather than letting the queue key look broken.
+  * **Protocol downloads** -- the send queue is filtered at transfer time. A download queue persists in a user property across sessions, so an item queued while permitted can outlive the permission; being removed from a group now takes effect immediately.
+  * **Web download links** -- both single and batch link generation are gated in `FileAreaWeb`, which also covers the browse screen's "generate web link" action. That path never went through the download queue at all.
+
+  Temporary session downloads -- QWK packets, FSE attachments -- are generated for the user on request, carry no ACS of their own, and are unaffected.
+
 * **A second instance bound nothing, said nothing, and kept running** ([#547](https://github.com/NuSkooler/enigma-bbs/issues/547)) — starting ENiGMA½ while another instance already held its ports produced no error, no `System started!`, and no exit. The process simply sat there, serving no one.
 
   Node's `server.listen(port, host, cb)` registers `cb` as a one-shot `'listening'` listener: it never receives an error argument, and on a failed bind it never fires at all. Every server treated it as an error-first callback, so `EADDRINUSE` left the startup series in `listening_server.js` waiting for a callback that would never come. Telnet caught the event but logged it at `info` — and the default logging config writes to a rotating file with no console stream, so nothing reached the terminal. The remaining servers had no server-level `'error'` handler at all, so the event fell through to the process-level `uncaughtException` net, which by design keeps the process alive.

--- a/art/themes/luciano_blocktronics/theme.hjson
+++ b/art/themes/luciano_blocktronics/theme.hjson
@@ -926,6 +926,7 @@
 
 					isQueuedIndicator: "|00|10YES"
 					isNotQueuedIndicator: "|00|07no"
+					noDownloadAccessIndicator: "|00|08n/a"
 
 					userRatingTicked: "|00|15*"
 					userRatingUnticked: "|00|07-"
@@ -1026,6 +1027,7 @@
 
 					isQueuedIndicator: "|00|10YES"
 					isNotQueuedIndicator: "|00|07no"
+					noDownloadAccessIndicator: "|00|08n/a"
 
 					userRatingTicked: "|00|15*"
 					userRatingUnticked: "|00|07-"

--- a/core/download_queue.js
+++ b/core/download_queue.js
@@ -4,6 +4,7 @@
 const FileEntry = require('./file_entry');
 const UserProps = require('./user_property');
 const Events = require('./events');
+const { hasFileAreaDownloadAccess } = require('./file_base_area.js');
 
 //  deps
 const _ = require('lodash');
@@ -35,17 +36,37 @@ module.exports = class DownloadQueue {
         this.client.user.downloadQueue = [];
     }
 
+    //
+    //  May the current user download |fileEntry|? Browsing an area ('read')
+    //  and downloading from it ('download') are separate rights.
+    //
+    canDownload(fileEntry) {
+        return hasFileAreaDownloadAccess(this.client, fileEntry.areaTag);
+    }
+
+    //  Returns true if the entry ended up queued, false if it was refused.
     toggle(fileEntry, systemFile = false) {
         if (this.isQueued(fileEntry)) {
             this.client.user.downloadQueue = this.client.user.downloadQueue.filter(
                 e => fileEntry.fileId !== e.fileId
             );
-        } else {
-            this.add(fileEntry, systemFile);
+            return false;
         }
+
+        return this.add(fileEntry, systemFile);
     }
 
+    //  Returns true if queued, false if the user has no download rights to the
+    //  entry's area.
     add(fileEntry, systemFile = false) {
+        if (!systemFile && !this.canDownload(fileEntry)) {
+            this.client.log.info(
+                { fileId: fileEntry.fileId, areaTag: fileEntry.areaTag },
+                'Refusing to queue download; no download ACS for area'
+            );
+            return false;
+        }
+
         this.client.user.downloadQueue.push({
             fileId: fileEntry.fileId,
             areaTag: fileEntry.areaTag,
@@ -54,6 +75,20 @@ module.exports = class DownloadQueue {
             byteSize: fileEntry.meta.byte_size || 0,
             systemFile: systemFile,
         });
+
+        return true;
+    }
+
+    //
+    //  Queues persist in a user property across sessions, so an item queued
+    //  while permitted can outlive the permission. Filter at the point of
+    //  actually sending or generating links, not just at queue time.
+    //
+    get allowedItems() {
+        return this.items.filter(
+            item =>
+                item.systemFile || hasFileAreaDownloadAccess(this.client, item.areaTag)
+        );
     }
 
     removeItems(fileIds) {

--- a/core/file_area_list.js
+++ b/core/file_area_list.js
@@ -132,6 +132,8 @@ exports.getModule = class FileAreaList extends MenuModule {
                 return this.displayBrowsePage(true, cb); //  true=clearScreen
             },
             toggleQueue: (formData, extraArgs, cb) => {
+                //  Refused when the user may browse the area but not download
+                //  from it; updateQueueIndicator() reflects that back to them.
                 this.dlQueue.toggle(this.currentFileEntry);
                 this.updateQueueIndicator();
                 return cb(null);
@@ -245,6 +247,7 @@ exports.getModule = class FileAreaList extends MenuModule {
         const hashTagsSep = config.hashTagsSep || ', ';
         const isQueuedIndicator = config.isQueuedIndicator || 'Y';
         const isNotQueuedIndicator = config.isNotQueuedIndicator || 'N';
+        const noDownloadAccessIndicator = config.noDownloadAccessIndicator || '-';
 
         const entryInfo = (currEntry.entryInfo = {
             fileId: currEntry.fileId,
@@ -260,9 +263,12 @@ exports.getModule = class FileAreaList extends MenuModule {
                 uploadTimestampFormat
             ),
             hashTags: Array.from(currEntry.hashTags).join(hashTagsSep),
-            isQueued: this.dlQueue.isQueued(currEntry)
-                ? isQueuedIndicator
-                : isNotQueuedIndicator,
+            isQueued: this._queueIndicatorFor(
+                currEntry,
+                isQueuedIndicator,
+                isNotQueuedIndicator,
+                noDownloadAccessIndicator
+            ),
             webDlLink: '', //  :TODO: fetch web any existing web d/l link
             webDlExpire: '', //  :TODO: fetch web d/l link expire time
         });
@@ -637,14 +643,31 @@ exports.getModule = class FileAreaList extends MenuModule {
         );
     }
 
+    //
+    //  'read' lets a user browse an area; 'download' is what lets them take
+    //  something out of it. Where the two differ, say so rather than letting
+    //  the queue key look broken.
+    //
+    _queueIndicatorFor(entry, queued, notQueued, noAccess) {
+        if (!this.dlQueue.canDownload(entry)) {
+            return noAccess;
+        }
+        return this.dlQueue.isQueued(entry) ? queued : notQueued;
+    }
+
     updateQueueIndicator() {
-        const isQueuedIndicator = this.menuConfig.config.isQueuedIndicator || 'Y';
-        const isNotQueuedIndicator = this.menuConfig.config.isNotQueuedIndicator || 'N';
+        const config = this.menuConfig.config;
+        const isQueuedIndicator = config.isQueuedIndicator || 'Y';
+        const isNotQueuedIndicator = config.isNotQueuedIndicator || 'N';
+        const noDownloadAccessIndicator = config.noDownloadAccessIndicator || '-';
 
         this.currentFileEntry.entryInfo.isQueued = stringFormat(
-            this.dlQueue.isQueued(this.currentFileEntry)
-                ? isQueuedIndicator
-                : isNotQueuedIndicator
+            this._queueIndicatorFor(
+                this.currentFileEntry,
+                isQueuedIndicator,
+                isNotQueuedIndicator,
+                noDownloadAccessIndicator
+            )
         );
 
         this.updateCustomViewTextsWithFilter(

--- a/core/file_area_web.js
+++ b/core/file_area_web.js
@@ -18,6 +18,7 @@ const Events = require('./events.js');
 const UserProps = require('./user_property.js');
 const SysProps = require('./system_menu_method.js');
 const { buildUrl } = require('./web_util');
+const { hasFileAreaDownloadAccess } = require('./file_base_area.js');
 
 //  deps
 const hashids = require('hashids/cjs');
@@ -243,6 +244,20 @@ class FileAreaWebAccess {
             return cb(notEnabledError());
         }
 
+        //  Central gate for web links: several paths reach here without going
+        //  through the download queue (browse -> "web link", for one).
+        if (!hasFileAreaDownloadAccess(client, fileEntry.areaTag)) {
+            Log.info(
+                {
+                    username: client.user.username,
+                    fileId: fileEntry.fileId,
+                    areaTag: fileEntry.areaTag,
+                },
+                'Refusing web download link; no download ACS for area'
+            );
+            return cb(Errors.AccessDenied('No download access to this file area'));
+        }
+
         const hashId = this.getSingleFileHashId(client, fileEntry);
         const url = this.buildSingleFileTempDownloadLink(client, fileEntry, hashId);
         options.expireTime = options.expireTime || moment().add(2, 'days');
@@ -256,6 +271,29 @@ class FileAreaWebAccess {
         if (!this.isEnabled()) {
             return cb(notEnabledError());
         }
+
+        //  A queue persists across sessions, so it can outlive the rights that
+        //  filled it. Drop anything the user may no longer take.
+        const allowed = fileEntries.filter(entry =>
+            hasFileAreaDownloadAccess(client, entry.areaTag)
+        );
+
+        if (allowed.length !== fileEntries.length) {
+            Log.info(
+                {
+                    username: client.user.username,
+                    requested: fileEntries.length,
+                    allowed: allowed.length,
+                },
+                'Omitting batch download entries; no download ACS for area'
+            );
+        }
+
+        if (0 === allowed.length) {
+            return cb(Errors.AccessDenied('No download access to any queued file area'));
+        }
+
+        fileEntries = allowed;
 
         const batchId = moment().utc().unix();
         const hashId = this.getBatchArchiveHashId(client, batchId);

--- a/core/file_base_area.js
+++ b/core/file_base_area.js
@@ -31,6 +31,7 @@ const moment = require('moment');
 
 exports.startup = startup;
 exports.isInternalArea = isInternalArea;
+exports.hasFileAreaDownloadAccess = hasFileAreaDownloadAccess;
 exports.getAvailableFileAreas = getAvailableFileAreas;
 exports.getAvailableFileAreaTags = getAvailableFileAreaTags;
 exports.getSortedAvailableFileAreas = getSortedAvailableFileAreas;
@@ -105,6 +106,37 @@ function isInternalArea(areaTag) {
         WellKnownAreaTags.MessageAreaAttach,
         WellKnownAreaTags.TempDownloads,
     ].includes(areaTag);
+}
+
+//
+//  Does |client| have download rights to the area |areaTag| belongs to?
+//
+//  Note that this is a *separate* right from 'read' (list/browse): an area can
+//  perfectly reasonably let everyone look while restricting who may actually
+//  pull bytes down. Until this was wired up, the 'download' ACS was honoured by
+//  the REST API and by nothing else, so a sysop who set it saw it silently
+//  ignored over telnet and SSH.
+//
+function hasFileAreaDownloadAccess(client, areaTag) {
+    //  Internal areas -- temporary session downloads (QWK packets, FSE
+    //  attachments) -- are generated *for* the user on request rather than
+    //  browsed, and carry no ACS of their own.
+    if (isInternalArea(areaTag)) {
+        return true;
+    }
+
+    //  Raw config rather than getFileAreaByTag(): the ACS check only reads
+    //  |area.acs|, and this runs per-entry while a list is drawn -- no reason
+    //  to resolve storage locations and rebuild hashTags for it.
+    const area = Config().fileBase.areas[areaTag];
+    if (!area) {
+        //  An entry whose area is no longer configured. Fail closed: this is
+        //  an access control, and an orphaned entry is not something a user
+        //  should be able to pull down by default.
+        return false;
+    }
+
+    return client.acs.hasFileAreaDownload(area);
 }
 
 function getAvailableFileAreas(client, options) {

--- a/core/file_base_download_manager.js
+++ b/core/file_base_download_manager.js
@@ -50,7 +50,8 @@ exports.getModule = class FileBaseDownloadQueueManager extends MenuModule {
             downloadAll: (formData, extraArgs, cb) => {
                 const modOpts = {
                     extraArgs: {
-                        sendQueue: this.dlQueue.items,
+                        //  filtered: rights can be revoked after queueing
+                        sendQueue: this.dlQueue.allowedItems,
                         direction: 'send',
                     },
                 };

--- a/docs/_docs/modding/file-area-list.md
+++ b/docs/_docs/modding/file-area-list.md
@@ -18,6 +18,7 @@ Available `config` block entries:
 * `hashTagsSep`: Separator for hash entries. Defaults to ", ".
 * `isQueuedIndicator`: Indicator for items that are in the users download queue. Defaults to "Y".
 * `isNotQueuedIndicator`: Indicator for items that are _not_ in the users download queue. Defaults to "N".
+* `noDownloadAccessIndicator`: Indicator for items the user may browse but has no `download` ACS for, and therefore cannot queue. Defaults to "-".
 * `userRatingTicked`: Indicator for a items current _n_/5 "star" rating. Defaults to "\*". `userRatingTicked` and `userRatingUnticked` are combined to build strings such as "***--" for 3/5 rating.
 * `userRatingUnticked`: Indicator for missing "stars" in a items _n_/5 rating. Defaults to "-". `userRatingTicked` and `userRatingUnticked` are combined to build strings such as "***--" for 3/5 rating.
 * `webDlExpireTimeFormat`: Presents the expiration time of a web download URL. Defaults to current theme → system `short` date/time format.
@@ -68,7 +69,7 @@ The browse page uses the `browse` art described above. The following MCI codes a
     * `{ticLDesc}`: Long description from TIC imported files "LDesc" field joined by a line feed, or "N/A".
     * `{uploadTimestamp}`: Upload timestamp formatted with `browseUploadTimestampFormat`.
     * `{hashTags}`: A string of hash tags(s) separated by `hashTagsSep` described above. "(none)" if there are no tags.
-    * `{isQueued}`: Indicates if a item is currently in the user's download queue presented as `isQueuedIndicator` or `isNotQueuedIndicator` described above.
+    * `{isQueued}`: Indicates if a item is currently in the user's download queue presented as `isQueuedIndicator` or `isNotQueuedIndicator` described above. Where the user has no `download` access to the area, `noDownloadAccessIndicator` is shown instead.
     * `{webDlLink}`: Web download link if generated else `webDlLinkNeedsGenerated` or `webDlLinkNoWebserver` described above.
     * `{webDlExpire}`: Web download link expiration using `webDlExpireTimeFormat` described above.
 

--- a/test/file_area_download_acs.test.js
+++ b/test/file_area_download_acs.test.js
@@ -1,0 +1,278 @@
+'use strict';
+
+//
+//  The 'download' file-area ACS was honoured by the REST API and by nothing
+//  else: a sysop who restricted downloads saw it silently ignored over telnet
+//  and SSH. 'read' (browse) and 'download' are separate rights, and an area
+//  that lets everyone look while restricting who may pull bytes down is a
+//  perfectly ordinary configuration.
+//
+
+const { strict: assert } = require('assert');
+const moment = require('moment');
+
+const configModule = require('../core/config.js');
+const ACS = require('../core/acs.js');
+
+// ── fixtures ──────────────────────────────────────────────────────────────────
+
+const TEST_CONFIG = {
+    debug: { assertsEnabled: false },
+    menus: { cls: false },
+    fileBase: {
+        storageTags: { tag: '/tmp/enigma-test-files' },
+        areas: {
+            //  no acs block at all -> ACS.Defaults (download: GM[users])
+            open_area: { name: 'Open', storageTags: ['tag'] },
+
+            //  browsable by any user, downloadable only by donors
+            donors_only: {
+                name: 'Donors',
+                storageTags: ['tag'],
+                acs: { read: 'GM[users]', download: 'GM[donors]' },
+            },
+        },
+    },
+};
+
+function makeUser(groups) {
+    const props = {
+        account_status: 0,
+        login_count: 10,
+        account_created: moment().subtract(90, 'days').format(),
+    };
+    return {
+        userId: 42,
+        username: 'testuser',
+        authFactor: 1,
+        groups,
+        properties: {},
+        downloadQueue: [],
+        isGroupMember(name) {
+            return this.groups.includes(name);
+        },
+        getAge() {
+            return 25;
+        },
+        getProperty(name) {
+            return props[name];
+        },
+        getPropertyAsNumber(name) {
+            const v = props[name];
+            return typeof v === 'number' ? v : parseInt(v, 10) || 0;
+        },
+    };
+}
+
+function makeClient(groups) {
+    const user = makeUser(groups);
+    const client = {
+        node: 1,
+        user,
+        session: { isSecure: false },
+        term: {
+            termHeight: 25,
+            termWidth: 80,
+            termType: 'ansi',
+            outputEncoding: 'cp437',
+        },
+        currentTheme: { name: 'luciano_blocktronics' },
+        isLocal() {
+            return false;
+        },
+        log: { warn() {}, info() {}, debug() {}, error() {} },
+    };
+    client.acs = new ACS({ client, user });
+    return client;
+}
+
+//
+//  A real FileEntry, not a lookalike: DownloadQueue.isQueued() keys off
+//  `instanceof FileEntry` to decide whether it was handed an entry or a bare
+//  fileId, so a plain object silently never matches. It must come from the
+//  same reloaded module instance the queue sees, hence |mods|.
+//
+//  |filePath| is a derived getter off storageTag/relPath; the storage tag in
+//  TEST_CONFIG resolves it without touching disk.
+//
+function entry(mods, areaTag, fileId = 1) {
+    return new mods.FileEntry({
+        fileId,
+        areaTag,
+        storageTag: 'tag',
+        fileName: `file${fileId}.zip`,
+        meta: { byte_size: 1024 },
+    });
+}
+
+//
+//  file_base_area.js captures Config at first require, so the test config has
+//  to be installed before it (and download_queue, which pulls it in) loads.
+//
+const RELOAD = [
+    '../core/file_entry.js',
+    '../core/file_base_area.js',
+    '../core/download_queue.js',
+];
+
+function loadModules() {
+    const previous = configModule._pushTestConfig(TEST_CONFIG);
+    RELOAD.forEach(m => delete require.cache[require.resolve(m)]);
+    return {
+        FileEntry: require('../core/file_entry.js'),
+        FileArea: require('../core/file_base_area.js'),
+        DownloadQueue: require('../core/download_queue.js'),
+        restore: () => {
+            configModule._popTestConfig(previous);
+            RELOAD.forEach(m => delete require.cache[require.resolve(m)]);
+        },
+    };
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+describe('file area download ACS', () => {
+    let mods;
+
+    beforeEach(() => {
+        mods = loadModules();
+    });
+
+    afterEach(() => {
+        mods.restore();
+    });
+
+    describe('hasFileAreaDownloadAccess()', () => {
+        it('allows an area with no ACS block (defaults to GM[users])', () => {
+            const client = makeClient(['users']);
+            assert.equal(
+                mods.FileArea.hasFileAreaDownloadAccess(client, 'open_area'),
+                true
+            );
+        });
+
+        it('denies a restricted area to a user who may still browse it', () => {
+            const client = makeClient(['users']);
+
+            //  the point of the whole fix: read yes, download no
+            assert.equal(
+                client.acs.hasFileAreaRead(mods.FileArea.getFileAreaByTag('donors_only')),
+                true
+            );
+            assert.equal(
+                mods.FileArea.hasFileAreaDownloadAccess(client, 'donors_only'),
+                false
+            );
+        });
+
+        it('allows a restricted area to a user in the right group', () => {
+            const client = makeClient(['users', 'donors']);
+            assert.equal(
+                mods.FileArea.hasFileAreaDownloadAccess(client, 'donors_only'),
+                true
+            );
+        });
+
+        //  Temporary session downloads (QWK packets, FSE attachments) are
+        //  generated for the user on request and carry no ACS of their own.
+        it('allows internal areas regardless of ACS', () => {
+            const client = makeClient([]);
+            assert.equal(
+                mods.FileArea.hasFileAreaDownloadAccess(
+                    client,
+                    'system_temporary_download'
+                ),
+                true
+            );
+            assert.equal(
+                mods.FileArea.hasFileAreaDownloadAccess(
+                    client,
+                    'system_message_attachment'
+                ),
+                true
+            );
+        });
+
+        it('fails closed for an area that is no longer configured', () => {
+            const client = makeClient(['users', 'donors', 'sysops']);
+            assert.equal(
+                mods.FileArea.hasFileAreaDownloadAccess(client, 'removed_area'),
+                false
+            );
+        });
+    });
+
+    describe('DownloadQueue', () => {
+        it('queues a file the user may download', () => {
+            const client = makeClient(['users']);
+            const dlQueue = new mods.DownloadQueue(client);
+
+            assert.equal(dlQueue.add(entry(mods, 'open_area')), true);
+            assert.equal(dlQueue.items.length, 1);
+        });
+
+        it('refuses a file the user may browse but not download', () => {
+            const client = makeClient(['users']);
+            const dlQueue = new mods.DownloadQueue(client);
+
+            assert.equal(dlQueue.add(entry(mods, 'donors_only')), false);
+            assert.equal(dlQueue.items.length, 0);
+        });
+
+        it('refuses via toggle() as well as add()', () => {
+            const client = makeClient(['users']);
+            const dlQueue = new mods.DownloadQueue(client);
+
+            assert.equal(dlQueue.toggle(entry(mods, 'donors_only')), false);
+            assert.equal(dlQueue.items.length, 0);
+        });
+
+        it('still toggles a permitted file off and on', () => {
+            const client = makeClient(['users']);
+            const dlQueue = new mods.DownloadQueue(client);
+            const e = entry(mods, 'open_area');
+
+            assert.equal(dlQueue.toggle(e), true);
+            assert.equal(dlQueue.items.length, 1);
+            assert.equal(dlQueue.toggle(e), false); //  now de-queued
+            assert.equal(dlQueue.items.length, 0);
+        });
+
+        it('does not gate system files against area ACS', () => {
+            const client = makeClient([]);
+            const dlQueue = new mods.DownloadQueue(client);
+
+            assert.equal(dlQueue.add(entry(mods, 'donors_only'), true), true);
+            assert.equal(dlQueue.items.length, 1);
+        });
+
+        //
+        //  A queue lives in a user property across sessions, so it can outlive
+        //  the rights that filled it -- a user moved out of a group must not
+        //  keep downloading what they queued while still in it.
+        //
+        it('filters queued items whose access has since been revoked', () => {
+            const client = makeClient(['users', 'donors']);
+            const dlQueue = new mods.DownloadQueue(client);
+
+            assert.equal(dlQueue.add(entry(mods, 'open_area', 1)), true);
+            assert.equal(dlQueue.add(entry(mods, 'donors_only', 2)), true);
+            assert.equal(dlQueue.allowedItems.length, 2);
+
+            client.user.groups = ['users']; //  dropped from donors
+
+            const allowed = dlQueue.allowedItems;
+            assert.equal(allowed.length, 1);
+            assert.equal(allowed[0].fileId, 1);
+            assert.equal(dlQueue.items.length, 2, 'queue itself is left intact');
+        });
+
+        it('keeps system files in allowedItems', () => {
+            const client = makeClient([]);
+            const dlQueue = new mods.DownloadQueue(client);
+
+            dlQueue.add(entry(mods, 'donors_only'), true);
+            assert.equal(dlQueue.allowedItems.length, 1);
+        });
+    });
+});


### PR DESCRIPTION
## The problem

A file area's `download` ACS was checked by `core/rest/routes/files.js` and **nothing else**. Over telnet and SSH — where essentially every user is — anyone who could browse an area could also queue and download from it.

What makes this quietly dangerous is that `read` *is* enforced throughout, so browsing looks correctly gated and a config like:

```hjson
someArea: {
    acs: {
        read: GM[users]
        download: GM[donors]
    }
}
```

appears to work while the download restriction does nothing at all.

Walking every ACS method against its call sites, `download` was the only scope in the system with no terminal-side enforcement:

| ACS method | Callers outside `acs.js` |
|---|---|
| `hasMessageConfRead` / `Write` | 10 / 3 |
| `hasMessageAreaRead` / `Write` | 11 / 3 |
| `hasFileAreaRead` | 5 |
| `hasFileAreaWrite` | 2 |
| **`hasFileAreaDownload`** | **1 — REST only** |

Originally spotted during an ACS audit in April 2026; re-verified against `edcad016`.

## The fix

New `FileArea.hasFileAreaDownloadAccess(client, areaTag)`, applied at every path that can move a file to a user:

* **Queueing** — `DownloadQueue.add()`/`toggle()` refuse an entry the user has no `download` right to, and now return whether the item ended up queued.
* **Protocol downloads** — the send queue is filtered at transfer time via `DownloadQueue.allowedItems`. A queue persists in a user property across sessions, so an item queued while permitted can outlive the permission; removal from a group now takes effect immediately.
* **Web download links** — both single and batch generation are gated centrally in `FileAreaWeb`. Worth calling out: the browse screen's "press W for a web link" action reaches `createAndServeTempDownload()` **without going through the download queue at all**, so gating only the queue would have left that path open.

Internal areas — temporary session downloads (QWK packets, FSE attachments) — are generated for the user on request, carry no ACS of their own, and are exempt. An entry whose area is no longer configured fails closed.

The lookup reads the raw area config rather than `getFileAreaByTag()`, which resolves storage locations and rebuilds hashTags; this runs per entry while a list is drawn and the ACS check only needs `area.acs`.

## UX

A user browsing an area they may read but not download from would otherwise press the queue key and see nothing happen. The existing `isQueuedIndicator` / `isNotQueuedIndicator` pattern is extended with `noDownloadAccessIndicator` (default `-`; `|00|08n/a` in luciano_blocktronics, in both the browse and details blocks). Theme and modding docs updated.

## Testing

`test/file_area_download_acs.test.js` — 12 tests: read-yes/download-no on the same area, group membership, internal areas exempt, unconfigured area fails closed, queue refusal via both `add()` and `toggle()`, system files exempt, and access revoked *after* queueing.

Full suite: **1573 passing**. `npm run lint` and `prettier --check` clean. `./main.js` starts clean.

## Notes for review

* **Blast radius:** `ACS.Defaults.FileAreaDownload` is `GM[users]`, the same as `FileAreaRead`, so areas that never set a `download` ACS are unaffected. Areas where one *was* set will now restrict to what was configured — correct, but users may lose access they have effectively had. Called out in `UPGRADE.md`.
* **Judgment call:** an entry whose area is no longer in `config.hjson` fails closed. This is an access control so failing closed seems right, but it does mean orphaned entries from removed areas become undownloadable. Easy to flip if you'd rather it fail open.
* **Pre-existing quirk, not changed:** `DownloadQueue.isQueued()` keys off `instanceof FileEntry` to distinguish an entry from a bare `fileId`, so a lookalike object silently never matches. Production is fine — real `FileEntry`s throughout — but it is brittle.