### PR TITLE
feat(ftn): automatically create message areas for unknown EchoMail (#241)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -16,3 +16,5 @@ optutil.js text eol=lf
 # The devcontainer is also unix
 .devcontainer/Dockerfile text eol=lf
 .devcontainer/devcontainer.json text eol=lf
+# Real-world FTN area list fixtures - byte exact, never normalize line endings
+test/fixtures/area_lists/** -text

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -41,6 +41,8 @@ Refer to [Upgrading](./docs/_docs/admin/upgrading.md) for details around this pr
 
   Lines that are skipped for their own reasons are now listed before the confirmation prompt. `AREAS.BBS` handling is unchanged.
 
+  `oputil fb import-areas` shares the same parser. FileGate `.ZXX` and FILEBONE `.NA` files import exactly as before — verified byte for byte against real network packs — and a file echo list shipped as a plain `TAG  Description` list now imports rather than reporting "Nothing to import". **Be aware** that a plain list looks identical to a *message* echo list; `import-areas` warns before the confirmation prompt, so read the area listing before answering yes, especially with `--create-dirs`.
+
 * **A port conflict now stops startup instead of being ignored** ([#547](https://github.com/NuSkooler/enigma-bbs/issues/547)). Previously a server that could not bind its port left the startup sequence hanging with no message and no exit; NNTP specifically logged a warning and carried on, so the board ran with NNTP silently absent. Bind failures are now reported on the console and are **fatal for every server**, and ENiGMA½ exits with a non-zero status.
 
   **Action:** if you run NNTP, Gopher, or the web server on a port something else on the host also uses, a start that previously "worked" (minus that service) will now stop with an explicit error. Fix the conflicting port in `config.hjson`, or disable the service with `enabled: false`.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -22,6 +22,25 @@ Refer to [Upgrading](./docs/_docs/admin/upgrading.md) for details around this pr
 
 ## 0.5.0-beta to 0.5.1-beta
 
+* **Automatic message area creation is available, and off** ([#241](https://github.com/NuSkooler/enigma-bbs/issues/241)). EchoMail for an FTN area tag you have not configured can now create that area instead of being skipped and lost. **No action is required**: with no `autoAreas` block in your configuration nothing changes, and with no network enabled the feature does no work at all.
+
+  **If you want it**, run `./oputil.js mb auto-areas init` once and then add an `autoAreas` block per network — see [FTN](./docs/_docs/messageareas/ftn.md#automatic-area-creation). Two things are worth knowing before you turn it on:
+
+  * The `init` command adds `auto-areas.hjson` to `includes` in your `config.hjson`. **Do not remove that file while it is still listed** — a file listed in `includes` that does not exist stops the board from starting. To back the feature out, remove the `includes` entry first, then the file.
+  * Created areas are **read-only by design**: no `uplinks`, so nothing exports, plus a write-deny `acs` so nothing can be posted into them. If you want to actually link one, define it in your own `config.hjson` with `uplinks` and your own `acs` — `config.hjson` wins over the generated file, so you do not need to edit or remove anything there.
+
+  Turning it on adds a read-only scan of your inbound directories at the start of each import cycle. For loose `.pkt` files that is a second parse; for bundles it is a second extraction, since the import removes each bundle as it finishes with it. Neither happens while the feature is off.
+
+* **`oputil mb import-areas` is stricter about what it will import** ([#733](https://github.com/NuSkooler/enigma-bbs/issues/733)). It previously imported `;` and `%` comment lines as message areas, and imported a FILEBONE *file* echo list — which most networks ship named `*.na`, alongside their message list — as a set of areas all tagged `Area`. It now works the format out from the file's content.
+
+  **Action:** if you have imported a `.na` file in the past, check `config.hjson` for areas tagged `;`, `%` or `Area` and remove them. Going forward, three things that used to "succeed" now stop with an explanation instead:
+
+  * A FILEBONE list is refused and points you at `oputil.js fb import-areas`.
+  * A list with the columns reversed (description first, tag last) is refused — SpookNet ships one, and the old parser accepted 35 nonsense areas from it.
+  * A file in no recognised format is refused rather than half-imported.
+
+  Lines that are skipped for their own reasons are now listed before the confirmation prompt. `AREAS.BBS` handling is unchanged.
+
 * **A port conflict now stops startup instead of being ignored** ([#547](https://github.com/NuSkooler/enigma-bbs/issues/547)). Previously a server that could not bind its port left the startup sequence hanging with no message and no exit; NNTP specifically logged a warning and carried on, so the board ran with NNTP silently absent. Bind failures are now reported on the console and are **fatal for every server**, and ENiGMA½ exits with a non-zero status.
 
   **Action:** if you run NNTP, Gopher, or the web server on a port something else on the host also uses, a start that previously "worked" (minus that service) will now stop with an explicit error. Fix the conflicting port in `config.hjson`, or disable the service with `enabled: false`.

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -3,6 +3,35 @@ This document attempts to track **major** changes and additions in ENiGMA½. For
 
 ## 0.5.1-beta
 
+* **Message areas can now be created automatically for EchoMail you are not configured for** ([#241](https://github.com/NuSkooler/enigma-bbs/issues/241)) — mail arriving for an unknown FTN area tag was skipped with a warning, and since the packet was then removed, skipped meant *lost*. ENiGMA½ can now create those areas instead. **Off unless you configure it**; a system with no `autoAreas` block behaves exactly as before, and with no network enabled nothing extra runs at all.
+
+  Setup is one command — `./oputil.js mb auto-areas init` — and then a per-network `autoAreas` block. See [FTN](docs/_docs/messageareas/ftn.md#automatic-area-creation).
+
+  * **Created areas are read-only, and that means both halves.** They carry no `uplinks`, so nothing is exported. On its own that is not read-only: a local user could still post into an area that looks live and goes nowhere. So they also carry a write-deny ACS. To adopt one, define it in `config.hjson` with your own `uplinks` and `acs` — `config.hjson` always wins over the generated file.
+
+  * **Nothing is ever written to your `config.hjson`.** Created areas go to a generated `auto-areas.hjson` pulled in through `includes`, which merges such that your own file wins. That file can therefore be rewritten on every pass without ever touching a description you wrote by hand.
+
+  * **Real names and descriptions come from the network info pack.** The pack arrives by TIC like any other file; ENiGMA½ looks for it in the file area you name rather than waiting to be told, so one that landed before you enabled the feature counts too. It only renames areas you already carry — a pack lists what the *network* carries, which would otherwise leave you with hundreds of permanently empty areas.
+
+  * **Collisions are refused, not merged.** An FTN tag lower cases straight onto a local area tag, and `PRIVATE_MAIL` would land an echo in everyone's mailbox. A tag already used in any conference, or carried by another network, is refused too, and the reason is logged.
+
+  * **`ignore` and `maxAutoCreate`.** Adding a tag to `ignore` removes it if it was already created, so it is a real un-create. `maxAutoCreate` caps the total ever created for a network rather than the number per run — a per-run cap compounds.
+
+  * **AreaFix rescan is optional, off, and has no default command.** [FSC-0057](http://ftsc.org/docs/fsc-0057.003) specifies `=TAG R=n` and Mystic and CrashMail II implement it, but husky and SBBSecho do not: they read it as a request to *add* an area with a garbage tag, and a husky hub with `forwardRequests` may pass that upstream. There is no portable form, so you state the one your uplink speaks or nothing is sent. Replies are matched to requests actually sent and summarised to you in NetMail.
+
+* **`oputil mb import-areas` imported comment lines as message areas** ([#733](https://github.com/NuSkooler/enigma-bbs/issues/733)) — a leading `;` or `%` line became an area whose tag was the comment character. Measured against real network info packs, importing fsxNet's file echo list produced 18 of them and AgoraNet's 14, written straight into `config.hjson` for you to find and remove by hand.
+
+  The area list parser is now shared between `oputil` and automatic area creation, and it works out the format from the file's **content** rather than its extension:
+
+  * `;`, `%` and `#` comment lines are skipped. fsxNet used `%` in its 2018 pack and `;` in the current one, so both are needed.
+  * A FILEBONE *file* echo list — which six of eight surveyed networks ship named `*.na`, alongside their message list — is recognised and sent to `fb import-areas` instead of being imported as areas all tagged `Area`.
+  * A list with the columns reversed, description first, is recognised and refused. SpookNet ships one, and the old parser took 35 entries from it with tags like `Aliens,` — nothing on those lines is malformed enough to reject one at a time, so the decision has to be made about the file as a whole.
+  * Lines that survive but cannot be used are listed for you before the confirmation prompt instead of being silently dropped.
+
+  `AREAS.BBS` is unchanged: it cannot be told from a plain area list by shape, so it is still only assumed from the `.bbs` extension or `--type bbs`.
+
+* **A missing `includes:` file said the wrong thing on startup** — a file listed in `includes` that does not exist stops the board from starting, correctly, but the message advised running `./oputil.js config new` as though `config.hjson` itself were missing, and printed the placeholder `'{configFile}'` instead of a path. Both now name the file that is actually missing and say what to do about it.
+
 * **A second instance bound nothing, said nothing, and kept running** ([#547](https://github.com/NuSkooler/enigma-bbs/issues/547)) — starting ENiGMA½ while another instance already held its ports produced no error, no `System started!`, and no exit. The process simply sat there, serving no one.
 
   Node's `server.listen(port, host, cb)` registers `cb` as a one-shot `'listening'` listener: it never receives an error argument, and on a failed bind it never fires at all. Every server treated it as an error-first callback, so `EADDRINUSE` left the startup series in `listening_server.js` waiting for a callback that would never come. Telnet caught the event but logged it at `info` — and the default logging config writes to a rotating file with no console stream, so nothing reached the terminal. The remaining servers had no server-level `'error'` handler at all, so the event fell through to the process-level `uncaughtException` net, which by design keeps the process alive.

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -30,6 +30,8 @@ This document attempts to track **major** changes and additions in ENiGMA½. For
 
   `AREAS.BBS` is unchanged: it cannot be told from a plain area list by shape, so it is still only assumed from the `.bbs` extension or `--type bbs`.
 
+* **`oputil fb import-areas` shares that parser**, so a FILEBONE list is recognised by its content rather than its name, and a *file* echo list shipped as a plain `TAG  Description` list — ArakNet's, among others — imports rather than reporting "Nothing to import". FileGate `.ZXX` and FILEBONE `.NA` files produce byte-identical results to before; a multi-digit area level and flags other than `!` and `*&` are now accepted as well. Since a plain list is indistinguishable from a *message* echo list, `import-areas` says so before the confirmation prompt.
+
 * **A missing `includes:` file said the wrong thing on startup** — a file listed in `includes` that does not exist stops the board from starting, correctly, but the message advised running `./oputil.js config new` as though `config.hjson` itself were missing, and printed the placeholder `'{configFile}'` instead of a path. Both now name the file that is actually missing and say what to do about it.
 
 * **A second instance bound nothing, said nothing, and kept running** ([#547](https://github.com/NuSkooler/enigma-bbs/issues/547)) — starting ENiGMA½ while another instance already held its ports produced no error, no `System started!`, and no exit. The process simply sat there, serving no one.

--- a/core/area_import.js
+++ b/core/area_import.js
@@ -1,0 +1,437 @@
+/* jslint node: true */
+'use strict';
+
+//  ENiGMA½
+const Errors = require('./enig_error.js').Errors;
+
+//
+//  Shared parsing of FTN-style area/echo lists.
+//
+//  Used by `oputil mb import-areas` and by automatic area creation, so both
+//  behave identically. Everything here is pure: no config, no I/O, no logging.
+//
+//  There is no FTSC document specifying the format of a `.na`, `AREAS.BBS` or
+//  FILEBONE list -- FSC-0061 covers FileBone *policy*, not syntax. These are
+//  de-facto conventions, and measured against real info packs from eight
+//  networks (see test/fixtures/area_lists/) they diverge in ways that matter:
+//
+//  * The file extension does not indicate the format. Six of eight networks
+//    ship two `.na` files, one message list and one file list, and the file
+//    list may be FILEBONE ("Area TAG 0 ! Desc") *or* plain "TAG Desc".
+//  * Comment lines start with ';' or '%' depending on network -- and fsxNet
+//    changed from '%' to ';' between its 2018 and 2025 packs.
+//  * At least one network (SpookNet) ships its list with the columns reversed
+//    ("Description ... TAG"). Nothing on such a line is malformed enough to
+//    reject on shape, and most first tokens pass a plausible-tag charset
+//    check, so a parser that only validates characters returns confident
+//    garbage. Detection therefore has to be a property of the *file*, not of
+//    the line, and there has to be a path that refuses rather than guesses.
+//
+
+const AreaListFormat = {
+    //  TAG<ws>Description -- the common ".na" message echo list
+    NA: 'na',
+    //  Area<ws>TAG<ws>level<ws>flags<ws>Description -- FILEBONE file echo list
+    FileBone: 'filebone',
+    //  [path]<ws>TAG<ws>uplink[ uplink...] -- AREAS.BBS
+    AreasBbs: 'bbs',
+    //  Description<ws...>TAG -- recognised, deliberately not parsed
+    DescFirst: 'desc-first',
+    //  Nothing we can identify
+    Unknown: 'unknown',
+};
+
+const FormatDescriptions = {
+    [AreaListFormat.NA]: 'area list (TAG followed by description)',
+    [AreaListFormat.FileBone]: 'FILEBONE file echo list ("Area TAG 0 ! Description")',
+    [AreaListFormat.AreasBbs]: 'AREAS.BBS list',
+    [AreaListFormat.DescFirst]: 'reversed-column list (description first, area tag last)',
+    [AreaListFormat.Unknown]: 'unrecognized format',
+};
+
+//  Comment characters seen in the wild. ';' and '%' are both used by real
+//  networks; '#' is included as it is near universal and no FTN area tag
+//  begins with it.
+const CommentChars = [';', '%', '#'];
+
+const MaxAreaTagLength = 64;
+
+//
+//  What an FTN area tag may contain when we *accept* an entry. Deliberately
+//  permissive on case: tags are compared case-insensitively throughout
+//  (see getLocalAreaTagByFtnAreaTag() in the FTN scanner/tosser).
+//
+const AreaTagRe = /^[A-Za-z0-9][A-Za-z0-9_.-]*$/;
+
+//
+//  What an FTN area tag looks like when we are *sniffing* a file's layout.
+//  Much stricter -- upper case only -- because by universal convention area
+//  tags are written upper case in these lists. A false negative here costs
+//  nothing worse than "unrecognized format"; a false positive would let a
+//  reversed-column list through.
+//
+const StrictAreaTagRe = /^[A-Z0-9][A-Z0-9_.-]*$/;
+
+//  A line is FILEBONE if it opens with the "Area" keyword
+const FileBoneDetectRe = /^Area\b/i;
+//  ...and parses as: Area TAG <level> <flags> Description
+const FileBoneParseRe = /^Area\s+(\S+)\s+(\S+)\s+(\S+)\s+(.+)$/i;
+
+//  TAG Description
+const NaParseRe = /^(\S+)\s+(.+)$/;
+
+//  [path|code] TAG uplink[ uplink...] -- second token is the tag, remainder uplinks
+const AreasBbsParseRe = /^\S+\s+(\S+)\s+(.+)$/;
+
+//
+//  Fraction of data lines that must agree on a layout before we will name it.
+//  Real lists are homogeneous; anything mixed enough to fall below this is
+//  something we should not be guessing about.
+//
+const FormatConfidenceThreshold = 0.6;
+
+const SkipReasons = {
+    InvalidTag: 'area tag contains unexpected characters',
+    NoDescription: 'no description',
+    FileBoneLine: 'FILEBONE-style line in a plain area list',
+    Unparsable: 'does not match the detected format',
+    UnrecognizedFormat: 'file format not recognized',
+};
+
+//  Accepting an entry: permissive, case-insensitive
+function isValidAreaTag(tag) {
+    return (
+        'string' === typeof tag &&
+        tag.length > 0 &&
+        tag.length <= MaxAreaTagLength &&
+        AreaTagRe.test(tag)
+    );
+}
+
+//  Sniffing a layout: strict, and must contain at least one letter so a
+//  numeric column can never be mistaken for a tag.
+function looksLikeAreaTag(token) {
+    return (
+        token.length >= 2 &&
+        token.length <= MaxAreaTagLength &&
+        StrictAreaTagRe.test(token) &&
+        /[A-Z]/.test(token)
+    );
+}
+
+function describeFormat(format) {
+    return FormatDescriptions[format] || FormatDescriptions[AreaListFormat.Unknown];
+}
+
+//  A format we are willing to turn into area records
+function isParsableFormat(format) {
+    return [AreaListFormat.NA, AreaListFormat.FileBone, AreaListFormat.AreasBbs].includes(
+        format
+    );
+}
+
+//
+//  Split into lines and separate comments/blanks from data. Tolerates CRLF,
+//  LF and CR endings, a missing final newline, a leading BOM, and tabs or
+//  runs of spaces as separators -- all of which occur in the fixtures.
+//
+function scanLines(data) {
+    if (data.charCodeAt(0) === 0xfeff) {
+        data = data.slice(1);
+    }
+
+    const result = { dataLines: [], commentCount: 0, blankCount: 0, lineCount: 0 };
+
+    data.split(/\r\n|\n|\r/).forEach((raw, index) => {
+        result.lineCount += 1;
+
+        const text = raw.trim();
+        if (0 === text.length) {
+            result.blankCount += 1;
+            return;
+        }
+
+        if (CommentChars.includes(text.charAt(0))) {
+            result.commentCount += 1;
+            return;
+        }
+
+        result.dataLines.push({ text, lineNumber: index + 1 });
+    });
+
+    return result;
+}
+
+//
+//  Decide what a file *is* from its content. Returns { format, stats }.
+//
+//  AreasBbs is never sniffed: it cannot be told apart from a `.na` list by
+//  shape alone (both are "token whitespace token..."), so it is only ever
+//  used when the caller asks for it explicitly via extension or --type.
+//
+function sniffAreaListFormat(data) {
+    const scan = scanLines(data);
+
+    const stats = {
+        lineCount: scan.lineCount,
+        commentLines: scan.commentCount,
+        blankLines: scan.blankCount,
+        dataLines: scan.dataLines.length,
+        //  data lines carrying enough tokens to say anything about layout
+        classifiableLines: 0,
+        fileBoneLines: 0,
+        tagFirstLines: 0,
+        tagLastLines: 0,
+    };
+
+    scan.dataLines.forEach(({ text }) => {
+        const tokens = text.split(/\s+/);
+
+        //
+        //  A single-token line cannot be "TAG description" nor
+        //  "description ... TAG", so it says nothing about which layout this
+        //  is. Leaving it out of the denominator keeps a stray separator or
+        //  truncated line from dragging a perfectly clear file below the
+        //  confidence threshold; it is still reported as skipped at parse
+        //  time.
+        //
+        if (tokens.length < 2) {
+            return;
+        }
+
+        stats.classifiableLines += 1;
+
+        if (FileBoneDetectRe.test(text)) {
+            stats.fileBoneLines += 1;
+            return;
+        }
+
+        if (looksLikeAreaTag(tokens[0])) {
+            stats.tagFirstLines += 1;
+        }
+        if (looksLikeAreaTag(tokens[tokens.length - 1])) {
+            stats.tagLastLines += 1;
+        }
+    });
+
+    const total = stats.classifiableLines;
+    if (0 === total) {
+        return { format: AreaListFormat.Unknown, stats };
+    }
+
+    if (stats.fileBoneLines / total >= FormatConfidenceThreshold) {
+        return { format: AreaListFormat.FileBone, stats };
+    }
+
+    //
+    //  More lines end with something tag-shaped than begin with one: the
+    //  columns are the other way around. Strictly greater, so a file where
+    //  both hold (all-upper-case descriptions) still reads as a normal list.
+    //
+    if (stats.tagLastLines > stats.tagFirstLines) {
+        return { format: AreaListFormat.DescFirst, stats };
+    }
+
+    if (stats.tagFirstLines / total >= FormatConfidenceThreshold) {
+        return { format: AreaListFormat.NA, stats };
+    }
+
+    return { format: AreaListFormat.Unknown, stats };
+}
+
+function parseNaLine(line, entries, skipped) {
+    if (FileBoneDetectRe.test(line.text)) {
+        skipped.push(Object.assign({ reason: SkipReasons.FileBoneLine }, line));
+        return;
+    }
+
+    const m = NaParseRe.exec(line.text);
+    if (!m) {
+        skipped.push(Object.assign({ reason: SkipReasons.NoDescription }, line));
+        return;
+    }
+
+    const ftnTag = m[1].trim();
+    if (!isValidAreaTag(ftnTag)) {
+        skipped.push(Object.assign({ reason: SkipReasons.InvalidTag }, line));
+        return;
+    }
+
+    entries.push({ ftnTag, name: m[2].trim(), lineNumber: line.lineNumber });
+}
+
+function parseFileBoneLine(line, entries, skipped) {
+    const m = FileBoneParseRe.exec(line.text);
+    if (!m) {
+        skipped.push(Object.assign({ reason: SkipReasons.Unparsable }, line));
+        return;
+    }
+
+    const ftnTag = m[1].trim();
+    if (!isValidAreaTag(ftnTag)) {
+        skipped.push(Object.assign({ reason: SkipReasons.InvalidTag }, line));
+        return;
+    }
+
+    entries.push({ ftnTag, name: m[4].trim(), lineNumber: line.lineNumber });
+}
+
+function parseAreasBbsLine(line, entries, skipped) {
+    //
+    //  Various formats for AREAS.BBS exist; we support as much as possible.
+    //
+    //  SBBS http://www.synchro.net/docs/sbbsecho.html#AREAS.BBS
+    //  CODE    TAG     UPLINKS
+    //
+    //  VADV https://www.vadvbbs.com/products/vadv/support/docs/docs_vfido.php#AREAS.BBS
+    //  TAG     UPLINKS
+    //
+    //  Misc
+    //  PATH|OTHER  TAG     UPLINKS
+    //
+    //  Assume the second item is TAG and 1:n UPLINKS (space and/or comma sep) after.
+    //
+    const m = AreasBbsParseRe.exec(line.text);
+    if (!m) {
+        skipped.push(Object.assign({ reason: SkipReasons.Unparsable }, line));
+        return;
+    }
+
+    const ftnTag = m[1].trim();
+    if (!isValidAreaTag(ftnTag)) {
+        skipped.push(Object.assign({ reason: SkipReasons.InvalidTag }, line));
+        return;
+    }
+
+    entries.push({
+        ftnTag,
+        name: `Area: ${ftnTag}`,
+        uplinks: m[2].trim().split(/[\s,]+/),
+        lineNumber: line.lineNumber,
+    });
+}
+
+//
+//  Parse an area list.
+//
+//  options.format   force a format instead of sniffing. Required for
+//                   AreaListFormat.AreasBbs, which is never sniffed.
+//
+//  Returns:
+//  {
+//      format,     what the file was taken to be
+//      stats,      line counts used to reach that decision
+//      entries,    [ { ftnTag, name, uplinks?, lineNumber } ]
+//      skipped,    [ { text, lineNumber, reason } ]
+//  }
+//
+//  A format we do not recognize -- or recognize but will not guess at, such
+//  as a reversed-column list -- yields zero entries and every data line in
+//  |skipped|. Callers are expected to check |format| and say something useful
+//  rather than treating an empty result as an empty file.
+//
+function parseAreaList(data, options = {}) {
+    if ('string' !== typeof data) {
+        throw Errors.Invalid('Area list data must be a string');
+    }
+
+    let format = options.format;
+    let stats;
+
+    if (format) {
+        stats = sniffAreaListFormat(data).stats;
+    } else {
+        ({ format, stats } = sniffAreaListFormat(data));
+    }
+
+    const entries = [];
+    const skipped = [];
+    const scan = scanLines(data);
+
+    if (!isParsableFormat(format)) {
+        scan.dataLines.forEach(line => {
+            skipped.push(Object.assign({ reason: SkipReasons.UnrecognizedFormat }, line));
+        });
+        return { format, stats, entries, skipped };
+    }
+
+    const lineParser = {
+        [AreaListFormat.NA]: parseNaLine,
+        [AreaListFormat.FileBone]: parseFileBoneLine,
+        [AreaListFormat.AreasBbs]: parseAreasBbsLine,
+    }[format];
+
+    scan.dataLines.forEach(line => lineParser(line, entries, skipped));
+
+    return { format, stats, entries, skipped };
+}
+
+function validateUplinks(uplinks) {
+    if (!Array.isArray(uplinks) || 0 === uplinks.length) {
+        return false;
+    }
+
+    const Address = require('./ftn_address.js');
+    return uplinks.every(ul => Address.fromString(ul) !== undefined);
+}
+
+//  Local area tag for a given FTN area tag; must match the FTN
+//  scanner/tosser's own case-insensitive comparison.
+function localAreaTagFor(ftnTag) {
+    return ftnTag.toLowerCase();
+}
+
+//
+//  Turn parsed entries into the two config fragments an imported area needs:
+//  the conference area record, and the FTN network area record.
+//
+//  |uplinks| is the fallback for entries that do not carry their own (only
+//  AREAS.BBS does). When |networkName| is not supplied no FTN records are
+//  produced -- the areas become purely local.
+//
+function buildAreaImportRecords(entries, { confTag, networkName, uplinks } = {}) {
+    const confAreas = {};
+    const ftnAreas = {};
+
+    entries.forEach(entry => {
+        const areaTag = entry.areaTag || localAreaTagFor(entry.ftnTag);
+
+        confAreas[areaTag] = {
+            name: entry.name,
+            desc: entry.name,
+        };
+
+        if (networkName) {
+            ftnAreas[areaTag] = {
+                network: networkName,
+                tag: entry.ftnTag,
+                uplinks: entry.uplinks || uplinks,
+            };
+        }
+    });
+
+    return {
+        messageConferences: {
+            [confTag]: { areas: confAreas },
+        },
+        messageNetworks: {
+            ftn: { areas: ftnAreas },
+        },
+    };
+}
+
+module.exports = {
+    AreaListFormat,
+    SkipReasons,
+    MaxAreaTagLength,
+
+    sniffAreaListFormat,
+    parseAreaList,
+    describeFormat,
+    isParsableFormat,
+    isValidAreaTag,
+
+    validateUplinks,
+    localAreaTagFor,
+    buildAreaImportRecords,
+};

--- a/core/area_import.js
+++ b/core/area_import.js
@@ -4,6 +4,9 @@
 //  ENiGMA½
 const Errors = require('./enig_error.js').Errors;
 
+//  deps
+const _ = require('lodash');
+
 //
 //  Shared parsing of FTN-style area/echo lists.
 //
@@ -74,8 +77,16 @@ const StrictAreaTagRe = /^[A-Z0-9][A-Z0-9_.-]*$/;
 
 //  A line is FILEBONE if it opens with the "Area" keyword
 const FileBoneDetectRe = /^Area\b/i;
+//
 //  ...and parses as: Area TAG <level> <flags> Description
-const FileBoneParseRe = /^Area\s+(\S+)\s+(\S+)\s+(\S+)\s+(.+)$/i;
+//
+//  The level is required to be numeric. It keeps an English sentence that
+//  happens to start with "Area" from parsing as an entry, and it is what the
+//  format actually specifies. Unlike the regex this replaces, the level may
+//  have more than one digit and the flags are not limited to "!" and "*&" --
+//  both occur in real FileGate and FILEBONE lists.
+//
+const FileBoneParseRe = /^Area\s+(\S+)\s+(\d+)\s+(\S+)\s+(.+)$/i;
 
 //  TAG Description
 const NaParseRe = /^(\S+)\s+(.+)$/;
@@ -96,6 +107,7 @@ const SkipReasons = {
     FileBoneLine: 'FILEBONE-style line in a plain area list',
     Unparsable: 'does not match the detected format',
     UnrecognizedFormat: 'file format not recognized',
+    UnusableRecord: 'does not produce a usable area or storage tag',
 };
 
 //  Accepting an entry: permissive, case-insensitive
@@ -420,6 +432,49 @@ function buildAreaImportRecords(entries, { confTag, networkName, uplinks } = {})
     };
 }
 
+//
+//  Turn parsed entries into file base area + storage tag records.
+//
+//  The area tag comes from the *description*, not the FTN tag, and the
+//  storage tag combines both. That is long standing `oputil fb import-areas`
+//  behaviour and is preserved exactly: changing it would orphan the storage
+//  directories of anyone who has already imported.
+//
+function buildFileAreaImportRecords(entries) {
+    const sanitizeFilename = require('sanitize-filename');
+
+    const result = { storageTags: {}, areas: {}, count: 0, skipped: [] };
+
+    entries.forEach(entry => {
+        const dir = entry.ftnTag.trim();
+        const name = entry.name.trim();
+        const safeName = sanitizeFilename(name);
+
+        const stPrefix = _.snakeCase(sanitizeFilename(safeName));
+        const storageTag = `${stPrefix}__${_.snakeCase(sanitizeFilename(dir))}`;
+        const areaTag = _.snakeCase(safeName);
+
+        if (!dir || !name || !storageTag || !areaTag) {
+            result.skipped.push({
+                lineNumber: entry.lineNumber,
+                text: `${entry.ftnTag} ${entry.name}`,
+                reason: SkipReasons.UnusableRecord,
+            });
+            return;
+        }
+
+        result.storageTags[storageTag] = dir;
+        result.areas[areaTag] = {
+            name: name,
+            desc: name,
+            storageTags: [storageTag],
+        };
+        result.count += 1;
+    });
+
+    return result;
+}
+
 module.exports = {
     AreaListFormat,
     SkipReasons,
@@ -434,4 +489,5 @@ module.exports = {
     validateUplinks,
     localAreaTagFor,
     buildAreaImportRecords,
+    buildFileAreaImportRecords,
 };

--- a/core/area_info_pack.js
+++ b/core/area_info_pack.js
@@ -1,0 +1,451 @@
+/* jslint node: true */
+'use strict';
+
+//  ENiGMA½
+const ConfigModule = require('./config.js');
+const Config = (...args) => ConfigModule.get(...args);
+const Log = () => require('./logger.js').log;
+const Errors = require('./enig_error.js').Errors;
+const StatLog = require('./stat_log.js');
+const SysProps = require('./system_property.js');
+const ArchiveUtil = require('./archive_util.js');
+const { AreaListFormat, parseAreaList, describeFormat } = require('./area_import.js');
+const autoAreaCreate = require('./auto_area_create.js');
+
+//  deps
+const fs = require('graceful-fs');
+const fse = require('fs-extra');
+const paths = require('path');
+const async = require('async');
+const temptmp = require('temptmp').createTrackedSession('ftn_info_pack');
+const _ = require('lodash');
+
+//
+//  Info pack ingest: metadata enrichment for automatically created areas.
+//
+//  Networks distribute an "info pack" -- an archive carrying the area list,
+//  nodelist and documentation -- through a file echo, so it arrives by TIC
+//  like any other file.  Rather than being triggered by that arrival, ingest
+//  *queries the file area*, the same way a FREQ resolves a TIC-fed nodelist.
+//  That means there is no path to configure, packs that landed before the
+//  feature existed still work, a pack placed by `oputil fb scan` or by hand
+//  works, and a missed trigger is picked up on the next pass.
+//
+//  What it does with the list is narrow on purpose.  A pack lists what the
+//  *network* carries, not what *we are linked to*: creating from it wholesale
+//  produces hundreds of permanently empty areas.  So by default it only
+//  replaces the placeholder name and description on areas we already carry,
+//  and creating unlinked areas is opt-in.  Enrichment-only also means nothing
+//  is ever created from untrusted input -- the worst a hostile pack achieves
+//  is wrong descriptions.
+//
+
+//  Only these ever come out of a pack
+const AllowedMemberExtensions = ['.na', '.txt'];
+const MaxMemberBytes = 1024 * 1024;
+const MaxTotalExtractedBytes = 4 * 1024 * 1024;
+const MaxMemberCount = 8;
+
+function log() {
+    //  logger.log is undefined until Log.init(); tests stub it
+    return Log() || { info() {}, warn() {}, error() {}, debug() {} };
+}
+
+//  "fsxnet*.zip" -> /^fsxnet.*\.zip$/i
+function globToRegExp(glob) {
+    const escaped = String(glob).replace(/[.+^${}()|[\]\\]/g, '\\$&');
+    return new RegExp(`^${escaped.replace(/\*/g, '.*').replace(/\?/g, '.')}$`, 'i');
+}
+
+function getInfoPackShaMap() {
+    const raw = StatLog.getSystemStat(SysProps.FtnInfoPackSha);
+    if (!raw) {
+        return {};
+    }
+    try {
+        const parsed = _.isString(raw) ? JSON.parse(raw) : raw;
+        return _.isObject(parsed) ? parsed : {};
+    } catch (e) {
+        return {};
+    }
+}
+
+function setInfoPackSha(networkName, sha) {
+    const map = getInfoPackShaMap();
+    map[networkName] = sha;
+    StatLog.setSystemStat(SysProps.FtnInfoPackSha, JSON.stringify(map));
+}
+
+//
+//  Newest file in |areaTag| whose name matches |match|.
+//
+function findInfoPackFile(areaTag, match, cb) {
+    const FileEntry = require('./file_entry.js');
+    const matchRe = match ? globToRegExp(match) : null;
+
+    FileEntry.findFiles(
+        { areaTag, sort: 'upload_timestamp', order: 'descending' },
+        (err, fileIds) => {
+            if (err || !fileIds || 0 === fileIds.length) {
+                return cb(null, null);
+            }
+
+            let index = 0;
+            const next = () => {
+                if (index >= fileIds.length) {
+                    return cb(null, null);
+                }
+
+                FileEntry.loadBasicEntry(fileIds[index++], {}, (loadErr, entry) => {
+                    if (loadErr) {
+                        return next();
+                    }
+
+                    if (matchRe && !matchRe.test(entry.fileName || '')) {
+                        return next();
+                    }
+
+                    let filePath;
+                    try {
+                        filePath = new FileEntry(entry).filePath;
+                    } catch (e) {
+                        return next();
+                    }
+
+                    fs.stat(filePath, statErr => {
+                        if (statErr) {
+                            return next();
+                        }
+                        return cb(null, {
+                            filePath,
+                            fileName: entry.fileName,
+                            fileSha256: entry.fileSha256,
+                        });
+                    });
+                });
+            };
+
+            next();
+        }
+    );
+}
+
+//
+//  Extract |wantedName| from |archivePath| and return its text.
+//
+//  An info pack arrives over FTN from a hub, so it is attacker adjacent and
+//  everything here is bounded.  The manifest decides what is asked for, but
+//  what actually lands on disk is what gets enforced: extractTo() silently
+//  downgrades to a full decompress when the configured archiver has no
+//  file-list extract verb, and listEntries() sizes are scraped from archiver
+//  stdout with a regex.  Neither can be trusted, so extraction goes into an
+//  empty temp directory and everything unwanted is deleted from it.
+//
+function extractAreaListFromPack(archivePath, wantedName, cb) {
+    const archUtil = ArchiveUtil.getInstance();
+    const wantedBase = paths.basename(String(wantedName)).toLowerCase();
+
+    if (!AllowedMemberExtensions.includes(paths.extname(wantedBase))) {
+        return cb(
+            Errors.Invalid(
+                `"${wantedName}" does not have an allowed extension (${AllowedMemberExtensions.join(
+                    ', '
+                )})`
+            )
+        );
+    }
+
+    const isSafeMemberName = name => {
+        if (!_.isString(name) || 0 === name.length) {
+            return false;
+        }
+        //  basename only: no paths from the archive are ever honoured
+        if (/[/\\]/.test(name) || name.includes('..')) {
+            return false;
+        }
+        return AllowedMemberExtensions.includes(paths.extname(name.toLowerCase()));
+    };
+
+    let tempDir;
+
+    async.waterfall(
+        [
+            callback => archUtil.detectType(archivePath, callback),
+            (archName, callback) => {
+                if (undefined === archName) {
+                    return callback(
+                        Errors.Invalid(`Unknown archive type: ${archivePath}`)
+                    );
+                }
+                archUtil.listEntries(archivePath, archName, (err, entries) =>
+                    callback(err, archName, entries || [])
+                );
+            },
+            (archName, entries, callback) => {
+                const wanted = entries
+                    .filter(
+                        e =>
+                            isSafeMemberName(e.fileName) &&
+                            paths.basename(e.fileName).toLowerCase() === wantedBase &&
+                            !(e.byteSize > MaxMemberBytes)
+                    )
+                    .slice(0, MaxMemberCount);
+
+                if (0 === wanted.length) {
+                    return callback(
+                        Errors.DoesNotExist(
+                            `"${wantedName}" is not in ${paths.basename(archivePath)}`
+                        )
+                    );
+                }
+
+                temptmp.mkdir({ prefix: 'eniginfopack-' }, (err, dir) => {
+                    if (err) {
+                        return callback(err);
+                    }
+                    tempDir = dir;
+                    archUtil.extractTo(
+                        archivePath,
+                        tempDir,
+                        archName,
+                        wanted.map(e => e.fileName),
+                        extractErr => callback(extractErr)
+                    );
+                });
+            },
+            callback => {
+                //
+                //  Enforce on what actually landed, not on what was asked for.
+                //
+                let totalBytes = 0;
+                let found;
+
+                fs.readdir(tempDir, (err, files) => {
+                    if (err) {
+                        return callback(err);
+                    }
+
+                    async.eachSeries(
+                        files,
+                        (fileName, nextFile) => {
+                            const fullPath = paths.join(tempDir, fileName);
+                            fs.lstat(fullPath, (statErr, stat) => {
+                                if (statErr) {
+                                    return nextFile(null);
+                                }
+
+                                const keep =
+                                    stat.isFile() &&
+                                    isSafeMemberName(fileName) &&
+                                    stat.size <= MaxMemberBytes &&
+                                    totalBytes + stat.size <= MaxTotalExtractedBytes &&
+                                    fileName.toLowerCase() === wantedBase;
+
+                                if (!keep) {
+                                    return fse.remove(fullPath, () => nextFile(null));
+                                }
+
+                                totalBytes += stat.size;
+                                found = fullPath;
+                                return nextFile(null);
+                            });
+                        },
+                        eachErr => callback(eachErr, found)
+                    );
+                });
+            },
+            (found, callback) => {
+                if (!found) {
+                    return callback(
+                        Errors.DoesNotExist(
+                            `"${wantedName}" was not produced by extraction`
+                        )
+                    );
+                }
+                fs.readFile(found, 'utf8', callback);
+            },
+        ],
+        (err, data) => {
+            if (tempDir) {
+                fse.remove(tempDir, () => {});
+            }
+            return cb(err, data);
+        }
+    );
+}
+
+//
+//  Ingest the info pack for one network, if there is a new one.
+//
+//  cb(err, { skipped, reason } | { enriched, created, format })
+//
+function ingestInfoPackForNetwork(networkName, cb) {
+    const autoConfig = autoAreaCreate.getAutoAreasConfig(networkName);
+    const infoPack = _.get(autoConfig, 'infoPack');
+
+    if (!infoPack || true !== infoPack.enabled) {
+        return cb(null, { skipped: true, reason: 'not enabled' });
+    }
+
+    if (!_.isString(infoPack.areaTag) || !_.isString(infoPack.areaFile)) {
+        return cb(
+            Errors.MissingConfig(
+                `autoAreas.infoPack for "${networkName}" needs both "areaTag" and "areaFile"`
+            )
+        );
+    }
+
+    async.waterfall(
+        [
+            callback =>
+                findInfoPackFile(infoPack.areaTag, infoPack.match, (err, found) =>
+                    callback(err, found)
+                ),
+            (found, callback) => {
+                if (!found) {
+                    return callback(null, null);
+                }
+
+                //
+                //  scanFile() populates fileSha256 during TIC import, so an
+                //  unchanged pack is free to detect and costs one query.
+                //
+                if (
+                    found.fileSha256 &&
+                    getInfoPackShaMap()[networkName] === found.fileSha256
+                ) {
+                    return callback(null, null);
+                }
+
+                return callback(null, found);
+            },
+            (found, callback) => {
+                if (!found) {
+                    return callback(null, null, null);
+                }
+
+                extractAreaListFromPack(
+                    found.filePath,
+                    infoPack.areaFile,
+                    (err, data) => {
+                        if (err) {
+                            return callback(err);
+                        }
+                        return callback(null, found, data);
+                    }
+                );
+            },
+            (found, data, callback) => {
+                if (!found) {
+                    return callback(null, { skipped: true, reason: 'unchanged' });
+                }
+
+                const parsed = parseAreaList(data);
+
+                //
+                //  Degrade to "no enrichment available" rather than guessing.
+                //  Two of eight networks surveyed ship no machine readable
+                //  list at all -- one uses reversed columns, one embeds its
+                //  areas in English prose.
+                //
+                if (AreaListFormat.NA !== parsed.format || 0 === parsed.entries.length) {
+                    log().warn(
+                        {
+                            networkName,
+                            pack: found.fileName,
+                            areaFile: infoPack.areaFile,
+                            format: parsed.format,
+                        },
+                        `Info pack area list is a ${describeFormat(
+                            parsed.format
+                        )}; no descriptions were taken from it`
+                    );
+
+                    //  still record the sha: re-reading it will not help
+                    if (found.fileSha256) {
+                        setInfoPackSha(networkName, found.fileSha256);
+                    }
+                    return callback(null, {
+                        skipped: true,
+                        reason: 'unusable area list',
+                        format: parsed.format,
+                    });
+                }
+
+                autoAreaCreate.applyInfoPackEntries(
+                    networkName,
+                    parsed.entries,
+                    { createUnlinked: true === infoPack.createUnlinked },
+                    (err, result) => {
+                        if (err) {
+                            return callback(err);
+                        }
+
+                        if (found.fileSha256) {
+                            setInfoPackSha(networkName, found.fileSha256);
+                        }
+
+                        log().info(
+                            {
+                                networkName,
+                                pack: found.fileName,
+                                entries: parsed.entries.length,
+                                enriched: result.enriched.length,
+                                created: result.created.length,
+                            },
+                            `Info pack ingested for "${networkName}"`
+                        );
+
+                        return callback(null, Object.assign({ skipped: false }, result));
+                    }
+                );
+            },
+        ],
+        cb
+    );
+}
+
+function infoPackNetworkNames() {
+    return Object.keys(_.get(Config(), 'messageNetworks.ftn.networks', {})).filter(
+        networkName => {
+            const cfg = autoAreaCreate.getAutoAreasConfig(networkName);
+            return cfg && true === _.get(cfg, 'infoPack.enabled');
+        }
+    );
+}
+
+function ingestInfoPacks(cb) {
+    const networkNames = infoPackNetworkNames();
+    if (0 === networkNames.length) {
+        return cb(null);
+    }
+
+    async.eachSeries(
+        networkNames,
+        (networkName, nextNetwork) => {
+            ingestInfoPackForNetwork(networkName, err => {
+                if (err) {
+                    log().warn(
+                        { networkName, error: err.message },
+                        'Info pack ingest failed'
+                    );
+                }
+                return nextNetwork(null);
+            });
+        },
+        () => cb(null)
+    );
+}
+
+module.exports = {
+    AllowedMemberExtensions,
+    MaxMemberBytes,
+    MaxTotalExtractedBytes,
+
+    globToRegExp,
+    findInfoPackFile,
+    extractAreaListFromPack,
+    ingestInfoPackForNetwork,
+    infoPackNetworkNames,
+    ingestInfoPacks,
+};

--- a/core/areafix_reply.js
+++ b/core/areafix_reply.js
@@ -1,0 +1,207 @@
+/* jslint node: true */
+'use strict';
+
+//
+//  Parsing of inbound AreaFix (conference manager) replies.
+//
+//  Pure: no config, no I/O.  See docs/_docs/messageareas/ftn.md for how this
+//  is wired up.
+//
+//  The point of this module is *not* to extract descriptions.  A confirmation
+//  line and a %LIST entry are structurally identical --
+//
+//      FSX_GEN ........................... added             <- confirmation
+//      FSX_GEN ........................... General chatter   <- %LIST entry
+//
+//  -- so no regex can tell them apart, and a parser that returned free text
+//  would eventually set an area's description to "added".  The protection is
+//  the return type: this yields a status enum and nothing else.  A total
+//  mis-parse produces a wrong *status*, which is a log line, not a corrupted
+//  config.
+//
+//  Three implementations were read directly.  Their line *structure*
+//  converges on "[flags] TAG [fill] STATUS":
+//
+//      husky      areafix.c   " FSX_GEN ........................... added"
+//      SBBSecho   sbbsecho.c  "FSX_GEN added."
+//      CrashMail  areafix.c   "+FSX_GEN                       Attached"
+//
+//  Their *vocabulary* does not.  husky says "unlinked" where SBBSecho says
+//  "removed."; CrashMail says "Attached"/"Detached"/"Unknown area".  So the
+//  phrase list below is seeded data rather than a constant, and callers may
+//  extend it -- anything unseeded degrades to Unknown, which is reported to
+//  the operator with the raw line rather than acted on.
+//
+
+const AreaFixStatus = {
+    Added: 'added',
+    Removed: 'removed',
+    AlreadyLinked: 'already_linked',
+    NotLinked: 'not_linked',
+    NotFound: 'not_found',
+    NoAccess: 'no_access',
+    Forwarded: 'forwarded',
+    Rescanned: 'rescanned',
+    Unknown: 'unknown',
+};
+
+//
+//  Seeded from husky, SBBSecho and CrashMail II.  Keys are the normalized
+//  status text: lower case, internal whitespace collapsed, dot-fill and any
+//  trailing period removed.
+//
+const DefaultStatusPhrases = {
+    added: AreaFixStatus.Added,
+    created: AreaFixStatus.Added,
+    attached: AreaFixStatus.Added,
+    'attached as read-only': AreaFixStatus.Added,
+
+    removed: AreaFixStatus.Removed,
+    deleted: AreaFixStatus.Removed,
+    unlinked: AreaFixStatus.Removed,
+    detached: AreaFixStatus.Removed,
+    disconnected: AreaFixStatus.Removed,
+
+    'already linked': AreaFixStatus.AlreadyLinked,
+    'already connected': AreaFixStatus.AlreadyLinked,
+    'already attached': AreaFixStatus.AlreadyLinked,
+    'you are already attached to that area': AreaFixStatus.AlreadyLinked,
+
+    'not linked': AreaFixStatus.NotLinked,
+    'not connected': AreaFixStatus.NotLinked,
+    'not subscribed': AreaFixStatus.NotLinked,
+
+    'not found': AreaFixStatus.NotFound,
+    'unknown area': AreaFixStatus.NotFound,
+    'unknown echo': AreaFixStatus.NotFound,
+    'no such area': AreaFixStatus.NotFound,
+
+    'no access': AreaFixStatus.NoAccess,
+    'access denied': AreaFixStatus.NoAccess,
+
+    forwarded: AreaFixStatus.Forwarded,
+    'request forwarded': AreaFixStatus.Forwarded,
+};
+
+//
+//  Statuses that carry a variable tail and so cannot be matched exactly.
+//  SBBSecho reports "TAG rescanned and 123 messages exported."
+//
+const StatusPrefixes = [{ prefix: 'rescanned', status: AreaFixStatus.Rescanned }];
+
+//  Leading command/flag characters echoed back by some managers
+const LeadingFlagsRe = /^[-+=%*!~]+/;
+
+const LineRe = /^(\S+)\s+(.+)$/;
+
+function normalizeStatusText(text) {
+    return text
+        .replace(/^[.\s]+/, '') //  dot-fill (husky pads with dots)
+        .replace(/[.\s]+$/, '') //  trailing period (SBBSecho) and space
+        .replace(/\s+/g, ' ')
+        .toLowerCase();
+}
+
+//
+//  Tokenize one reply line into { tag, statusText } or null.
+//
+function tokenizeReplyLine(line) {
+    const text = line.replace(LeadingFlagsRe, '').trim();
+    if (0 === text.length) {
+        return null;
+    }
+
+    const m = LineRe.exec(text);
+    if (!m) {
+        return null;
+    }
+
+    const statusText = normalizeStatusText(m[2]);
+    if (0 === statusText.length) {
+        return null;
+    }
+
+    return { tag: m[1], statusText };
+}
+
+function statusForText(statusText, phrases) {
+    const exact = phrases[statusText];
+    if (exact) {
+        return exact;
+    }
+
+    const prefixed = StatusPrefixes.find(p => statusText.startsWith(p.prefix));
+    if (prefixed) {
+        return prefixed.status;
+    }
+
+    return AreaFixStatus.Unknown;
+}
+
+//
+//  Parse an AreaFix reply body.
+//
+//  options.tags          area tags we asked about.  REQUIRED.  Only lines
+//                        naming one of these are considered; a stray %LIST
+//                        entry for an area we never mentioned is discarded.
+//                        This is what makes it safe that husky appends its
+//                        full linked-areas list to the same netmail as the
+//                        confirmations when queryReports is on.
+//  options.extraPhrases  additional { normalizedText: AreaFixStatus } for a
+//                        manager whose vocabulary is not seeded above.
+//
+//  Returns { results: [ { tag, status, statusText, raw } ], unknownCount }
+//  with one entry per requested tag that was mentioned.  A tag mentioned more
+//  than once keeps the first recognized status.
+//
+function parseAreaFixReply(body, { tags, extraPhrases } = {}) {
+    const requested = new Set(Array.from(tags || []).map(t => String(t).toUpperCase()));
+
+    const phrases = Object.assign({}, DefaultStatusPhrases, extraPhrases || {});
+
+    const byTag = new Map();
+    let unknownCount = 0;
+
+    String(body || '')
+        .split(/\r\n|\n|\r/)
+        .forEach(line => {
+            const token = tokenizeReplyLine(line);
+            if (!token) {
+                return;
+            }
+
+            const upperTag = token.tag.toUpperCase();
+            if (!requested.has(upperTag)) {
+                return;
+            }
+
+            const status = statusForText(token.statusText, phrases);
+
+            const existing = byTag.get(upperTag);
+            if (existing && existing.status !== AreaFixStatus.Unknown) {
+                return; //  keep the first recognized status for a tag
+            }
+
+            if (status === AreaFixStatus.Unknown && !existing) {
+                unknownCount += 1;
+            } else if (status !== AreaFixStatus.Unknown && existing) {
+                unknownCount -= 1; //  upgraded from a previous Unknown
+            }
+
+            byTag.set(upperTag, {
+                tag: upperTag,
+                status,
+                statusText: token.statusText,
+                raw: line.trim(),
+            });
+        });
+
+    return { results: Array.from(byTag.values()), unknownCount };
+}
+
+module.exports = {
+    AreaFixStatus,
+    DefaultStatusPhrases,
+    tokenizeReplyLine,
+    parseAreaFixReply,
+};

--- a/core/auto_area_create.js
+++ b/core/auto_area_create.js
@@ -494,6 +494,31 @@ function commitGenerated(includeState, generated, changed, result, cb) {
 }
 
 //
+//  Everything that mutates the generated file runs one at a time.
+//
+//  All import triggers funnel through the tosser's `importing` flag, but the
+//  5 minute import watchdog force-completes a stuck cycle and lets the next
+//  one start while the first may still be running -- overlapping cycles are
+//  an acknowledged reality in that code. Two overlapping read-modify-writes
+//  here would have the later reader working from a copy that predates the
+//  earlier writer, and its write would drop whatever the other had just
+//  added. The next pass re-discovers it, since the scan is read-only and the
+//  mail is still there, but only if the packet has not been tossed in
+//  between. Serializing removes the window rather than relying on that.
+//
+//  One BBS instance per mail tree, so in-process is the whole story.
+//
+let generatedWriteChain = Promise.resolve();
+
+function serializeGeneratedWrite(fn) {
+    generatedWriteChain = generatedWriteChain.then(
+        () => new Promise(resolve => fn(resolve)),
+        () => new Promise(resolve => fn(resolve))
+    );
+    return generatedWriteChain;
+}
+
+//
 //  Create message areas for |ftnTags| on |networkName|.
 //
 //  cb(err, {
@@ -505,6 +530,15 @@ function commitGenerated(includeState, generated, changed, result, cb) {
 //  Creating nothing is a success with an empty |created|.
 //
 function createAreas(networkName, ftnTags, cb) {
+    serializeGeneratedWrite(done =>
+        _createAreas(networkName, ftnTags, (err, result) => {
+            cb(err, result);
+            return done();
+        })
+    );
+}
+
+function _createAreas(networkName, ftnTags, cb) {
     const ctx = prepareGeneratedWrite(networkName);
     if (ctx instanceof Error) {
         return cb(ctx);
@@ -543,7 +577,16 @@ function createAreas(networkName, ftnTags, cb) {
 //
 //  cb(err, { enriched: [areaTag], created, rejected, pruned })
 //
-function applyInfoPackEntries(networkName, entries, { createUnlinked } = {}, cb) {
+function applyInfoPackEntries(networkName, entries, options, cb) {
+    serializeGeneratedWrite(done =>
+        _applyInfoPackEntries(networkName, entries, options || {}, (err, result) => {
+            cb(err, result);
+            return done();
+        })
+    );
+}
+
+function _applyInfoPackEntries(networkName, entries, { createUnlinked } = {}, cb) {
     const ctx = prepareGeneratedWrite(networkName);
     if (ctx instanceof Error) {
         return cb(ctx);

--- a/core/auto_area_create.js
+++ b/core/auto_area_create.js
@@ -510,11 +510,64 @@ function commitGenerated(includeState, generated, changed, result, cb) {
 //
 let generatedWriteChain = Promise.resolve();
 
-function serializeGeneratedWrite(fn) {
-    generatedWriteChain = generatedWriteChain.then(
-        () => new Promise(resolve => fn(resolve)),
-        () => new Promise(resolve => fn(resolve))
-    );
+//
+//  Upper bound on one queued operation. Writing a small file and reloading
+//  config is a sub-second job; this only exists so a dropped callback cannot
+//  wedge the queue.
+//
+const DefaultGeneratedWriteTimeoutMs = 60 * 1000;
+
+//
+//  Run |fn| after any operation already queued, guaranteeing |cb| fires
+//  exactly once.
+//
+//  The bound is not optional. Because operations are chained, one that never
+//  settles would block every later one *permanently* -- worse than the
+//  overlap it exists to prevent. So a synchronous throw becomes an error, and
+//  a callback that never arrives becomes a timeout, either of which lets the
+//  queue move on. That mirrors guardedCall() in the FTN scanner/tosser, which
+//  bounds the import cycle around this for the same reason.
+//
+function serializeGeneratedWrite(label, fn, cb) {
+    let settled = false;
+    let timer;
+
+    const settle = (err, result) => {
+        if (settled) {
+            return;
+        }
+        settled = true;
+        clearTimeout(timer);
+        return cb(err, result);
+    };
+
+    const run = () =>
+        new Promise(resolve => {
+            const finish = (err, result) => {
+                settle(err, result);
+                return resolve();
+            };
+
+            const timeoutMs =
+                module.exports.GeneratedWriteTimeoutMs || DefaultGeneratedWriteTimeoutMs;
+
+            timer = setTimeout(() => {
+                finish(Errors.Timeout(`Timed out updating generated areas: ${label}`));
+            }, timeoutMs);
+
+            //  never hold the process open on our account
+            if (_.isFunction(timer.unref)) {
+                timer.unref();
+            }
+
+            try {
+                fn(finish);
+            } catch (e) {
+                finish(e);
+            }
+        });
+
+    generatedWriteChain = generatedWriteChain.then(run, run);
     return generatedWriteChain;
 }
 
@@ -530,11 +583,10 @@ function serializeGeneratedWrite(fn) {
 //  Creating nothing is a success with an empty |created|.
 //
 function createAreas(networkName, ftnTags, cb) {
-    serializeGeneratedWrite(done =>
-        _createAreas(networkName, ftnTags, (err, result) => {
-            cb(err, result);
-            return done();
-        })
+    serializeGeneratedWrite(
+        `create areas for "${networkName}"`,
+        done => _createAreas(networkName, ftnTags, done),
+        cb
     );
 }
 
@@ -578,11 +630,10 @@ function _createAreas(networkName, ftnTags, cb) {
 //  cb(err, { enriched: [areaTag], created, rejected, pruned })
 //
 function applyInfoPackEntries(networkName, entries, options, cb) {
-    serializeGeneratedWrite(done =>
-        _applyInfoPackEntries(networkName, entries, options || {}, (err, result) => {
-            cb(err, result);
-            return done();
-        })
+    serializeGeneratedWrite(
+        `apply info pack for "${networkName}"`,
+        done => _applyInfoPackEntries(networkName, entries, options || {}, done),
+        cb
     );
 }
 
@@ -660,6 +711,8 @@ function _applyInfoPackEntries(networkName, entries, { createUnlinked } = {}, cb
 
 module.exports = {
     GeneratedIncludeFileName,
+    //  overridable so tests do not have to wait a minute for the bound
+    GeneratedWriteTimeoutMs: DefaultGeneratedWriteTimeoutMs,
     DenyAllAcs,
     RejectReasons,
 

--- a/core/auto_area_create.js
+++ b/core/auto_area_create.js
@@ -24,7 +24,6 @@ const getMessageAreaByTag = areaTag =>
 const fs = require('graceful-fs');
 const paths = require('path');
 const hjson = require('hjson');
-const async = require('async');
 const _ = require('lodash');
 
 //
@@ -312,6 +311,189 @@ function checkCollision(ftnTag, areaTag, networkName, generated, config) {
 }
 
 //
+//  Validate everything a write depends on, once.  Returns an Error or a
+//  { autoConfig, confTag, includeState, ignore } context.
+//
+function prepareGeneratedWrite(networkName) {
+    const autoConfig = getAutoAreasConfig(networkName);
+    if (!autoConfig) {
+        return Errors.MissingConfig(
+            `No autoAreas configuration for network "${networkName}"`
+        );
+    }
+
+    const confTag = autoConfig.confTag;
+    if (!_.isString(confTag) || 0 === confTag.length) {
+        return Errors.MissingConfig(
+            `autoAreas for network "${networkName}" has no "confTag"`
+        );
+    }
+
+    //
+    //  The conference must already exist.  defaultsDeep would happily create
+    //  one from this file, but it would have areas and no name or desc.
+    //  Refuse rather than manufacture a broken conference.
+    //
+    if (!_.has(Config(), ['messageConferences', confTag])) {
+        return Errors.MissingConfig(
+            `autoAreas confTag "${confTag}" (network "${networkName}") is not a configured message conference`
+        );
+    }
+
+    const includeState = getGeneratedIncludeState();
+    if (!includeState.path) {
+        return Errors.UnexpectedState('Configuration base path is unknown');
+    }
+
+    if (!includeState.included) {
+        return Errors.MissingConfig(
+            `"${GeneratedIncludeFileName}" is not listed in the "includes" of ${ConfigModule.Config.getBasePath()}; ` +
+                'run "oputil.js mb auto-areas init"'
+        );
+    }
+
+    return {
+        autoConfig,
+        confTag,
+        includeState,
+        ignore: new Set(autoConfig.ignore.map(t => _.toUpper(String(t)))),
+    };
+}
+
+//
+//  The ignore list is the only way to un-create something, so it has to apply
+//  to what has already been generated, not just to new arrivals.
+//
+function pruneIgnored(generated, networkName, ignore, result) {
+    _.forEach(generatedAreasForNetwork(generated, networkName), (areaConf, areaTag) => {
+        if (ignore.has(_.toUpper(areaConf.tag || ''))) {
+            delete generated.messageNetworks.ftn.areas[areaTag];
+            _.forEach(generated.messageConferences, conf => {
+                if (conf.areas) {
+                    delete conf.areas[areaTag];
+                }
+            });
+            result.pruned.push(areaTag);
+        }
+    });
+}
+
+//
+//  Add areas for |ftnTags| that pass the ignore list, the collision guard and
+//  the total cap.  |names| optionally supplies a real name/desc per tag.
+//
+function addGeneratedAreas(generated, networkName, ctx, ftnTags, result, names) {
+    const config = Config();
+
+    //  Deterministic order so a maxAutoCreate cut is reproducible
+    const candidates = Array.from(
+        new Set(ftnTags.map(t => String(t).trim()).filter(t => t.length > 0))
+    ).sort();
+
+    let count = Object.keys(generatedAreasForNetwork(generated, networkName)).length;
+
+    candidates.forEach(ftnTag => {
+        const areaTag = localAreaTagFor(ftnTag);
+
+        if (ctx.ignore.has(_.toUpper(ftnTag))) {
+            result.rejected.push({ ftnTag, areaTag, reason: RejectReasons.Ignored });
+            return;
+        }
+
+        const collision = checkCollision(ftnTag, areaTag, networkName, generated, config);
+        if (collision) {
+            result.rejected.push({ ftnTag, areaTag, reason: collision });
+            return;
+        }
+
+        if (_.has(generated, ['messageNetworks', 'ftn', 'areas', areaTag])) {
+            //  already ours; nothing to do
+            return;
+        }
+
+        //
+        //  The cap is on the total, not the run: a per-run cap compounds, and
+        //  ten runs of 500 is 5000 areas.  The generated file is the durable
+        //  counter.
+        //
+        if (count >= ctx.autoConfig.maxAutoCreate) {
+            result.rejected.push({ ftnTag, areaTag, reason: RejectReasons.MaxReached });
+            return;
+        }
+
+        //
+        //  Without an info pack the tag is all we know, so it stands in for
+        //  the name and description. An info pack may replace those later,
+        //  and an operator's config.hjson beats both.
+        //
+        const name = (names && names[_.toUpper(ftnTag)]) || ftnTag;
+
+        _.set(generated, ['messageConferences', ctx.confTag, 'areas', areaTag], {
+            name,
+            desc: name,
+            acs: {
+                write: DenyAllAcs,
+            },
+        });
+
+        _.set(generated, ['messageNetworks', 'ftn', 'areas', areaTag], {
+            network: networkName,
+            tag: ftnTag,
+            //  deliberately no "uplinks": nothing is exported
+        });
+
+        result.created.push({ ftnTag, areaTag });
+        count += 1;
+    });
+}
+
+//
+//  Write |generated| if anything changed, reload, and prove the areas resolve.
+//
+function commitGenerated(includeState, generated, changed, result, cb) {
+    if (!changed) {
+        return cb(null);
+    }
+
+    writeGenerated(includeState.path, generated, writeErr => {
+        if (writeErr) {
+            return cb(writeErr);
+        }
+
+        //
+        //  Reload explicitly rather than waiting on ConfigChanged: that event
+        //  fires only on a *successful* reload, so on failure the stale config
+        //  stays live and an unguarded await never returns.
+        //
+        if (!_.isFunction(ConfigModule.reload)) {
+            return cb(Errors.UnexpectedState('Configuration reload is unavailable'));
+        }
+
+        ConfigModule.reload(err => {
+            if (err) {
+                return cb(err);
+            }
+
+            //  ...and prove the areas actually resolve now
+            const unresolved = (result.created || []).filter(
+                c => !getMessageAreaByTag(c.areaTag)
+            );
+            if (unresolved.length > 0) {
+                return cb(
+                    Errors.UnexpectedState(
+                        `Created areas did not resolve after reload: ${unresolved
+                            .map(u => u.areaTag)
+                            .join(', ')}`
+                    )
+                );
+            }
+
+            return cb(null);
+        });
+    });
+}
+
+//
 //  Create message areas for |ftnTags| on |networkName|.
 //
 //  cb(err, {
@@ -323,206 +505,114 @@ function checkCollision(ftnTag, areaTag, networkName, generated, config) {
 //  Creating nothing is a success with an empty |created|.
 //
 function createAreas(networkName, ftnTags, cb) {
-    const autoConfig = getAutoAreasConfig(networkName);
-    if (!autoConfig) {
-        return cb(
-            Errors.MissingConfig(
-                `No autoAreas configuration for network "${networkName}"`
-            )
-        );
+    const ctx = prepareGeneratedWrite(networkName);
+    if (ctx instanceof Error) {
+        return cb(ctx);
     }
 
-    const confTag = autoConfig.confTag;
-    if (!_.isString(confTag) || 0 === confTag.length) {
-        return cb(
-            Errors.MissingConfig(
-                `autoAreas for network "${networkName}" has no "confTag"`
-            )
-        );
-    }
+    const result = { created: [], rejected: [], pruned: [] };
 
-    //
-    //  The conference must already exist.  defaultsDeep would happily create
-    //  one from this file, but it would have areas and no name or desc.
-    //  Refuse rather than manufacture a broken conference.
-    //
-    if (!_.has(Config(), ['messageConferences', confTag])) {
-        return cb(
-            Errors.MissingConfig(
-                `autoAreas confTag "${confTag}" (network "${networkName}") is not a configured message conference`
-            )
-        );
-    }
-
-    const includeState = getGeneratedIncludeState();
-    if (!includeState.path) {
-        return cb(Errors.UnexpectedState('Configuration base path is unknown'));
-    }
-
-    if (!includeState.included) {
-        return cb(
-            Errors.MissingConfig(
-                `"${GeneratedIncludeFileName}" is not listed in the "includes" of ${ConfigModule.Config.getBasePath()}; ` +
-                    'run "oputil.js mb auto-areas init"'
-            )
-        );
-    }
-
-    const ignore = new Set(autoConfig.ignore.map(t => _.toUpper(String(t))));
-
-    let result;
-
-    async.waterfall(
-        [
-            callback => readGenerated(includeState.path, callback),
-            (generated, callback) => {
-                const config = Config();
-                result = { created: [], rejected: [], pruned: [] };
-
-                //
-                //  The ignore list is the only way to un-create something, so
-                //  it has to apply to what is already here, not just to new
-                //  arrivals.
-                //
-                _.forEach(
-                    generatedAreasForNetwork(generated, networkName),
-                    (areaConf, areaTag) => {
-                        if (ignore.has(_.toUpper(areaConf.tag || ''))) {
-                            delete generated.messageNetworks.ftn.areas[areaTag];
-                            _.forEach(generated.messageConferences, conf => {
-                                if (conf.areas) {
-                                    delete conf.areas[areaTag];
-                                }
-                            });
-                            result.pruned.push(areaTag);
-                        }
-                    }
-                );
-
-                //  Deterministic order so a maxAutoCreate cut is reproducible
-                const candidates = Array.from(
-                    new Set(ftnTags.map(t => String(t).trim()).filter(t => t.length > 0))
-                ).sort();
-
-                let count = Object.keys(
-                    generatedAreasForNetwork(generated, networkName)
-                ).length;
-
-                candidates.forEach(ftnTag => {
-                    const areaTag = localAreaTagFor(ftnTag);
-
-                    if (ignore.has(_.toUpper(ftnTag))) {
-                        result.rejected.push({
-                            ftnTag,
-                            areaTag,
-                            reason: RejectReasons.Ignored,
-                        });
-                        return;
-                    }
-
-                    const collision = checkCollision(
-                        ftnTag,
-                        areaTag,
-                        networkName,
-                        generated,
-                        config
-                    );
-                    if (collision) {
-                        result.rejected.push({ ftnTag, areaTag, reason: collision });
-                        return;
-                    }
-
-                    if (_.has(generated, ['messageNetworks', 'ftn', 'areas', areaTag])) {
-                        //  already ours; nothing to do
-                        return;
-                    }
-
-                    //
-                    //  The cap is on the total, not the run: a per-run cap
-                    //  compounds, and ten runs of 500 is 5000 areas.  The
-                    //  generated file is the durable counter.
-                    //
-                    if (count >= autoConfig.maxAutoCreate) {
-                        result.rejected.push({
-                            ftnTag,
-                            areaTag,
-                            reason: RejectReasons.MaxReached,
-                        });
-                        return;
-                    }
-
-                    _.set(generated, ['messageConferences', confTag, 'areas', areaTag], {
-                        //  Placeholder name/desc.  On-demand discovery knows the
-                        //  tag and nothing else; an info pack may replace these
-                        //  later, and an operator's config.hjson beats both.
-                        name: ftnTag,
-                        desc: ftnTag,
-                        acs: {
-                            write: DenyAllAcs,
-                        },
-                    });
-
-                    _.set(generated, ['messageNetworks', 'ftn', 'areas', areaTag], {
-                        network: networkName,
-                        tag: ftnTag,
-                        //  deliberately no "uplinks": nothing is exported
-                    });
-
-                    result.created.push({ ftnTag, areaTag });
-                    count += 1;
-                });
-
-                return callback(null, generated);
-            },
-            (generated, callback) => {
-                if (0 === result.created.length && 0 === result.pruned.length) {
-                    return callback(null, false);
-                }
-                writeGenerated(includeState.path, generated, err => callback(err, true));
-            },
-            (didWrite, callback) => {
-                if (!didWrite) {
-                    return callback(null);
-                }
-
-                //
-                //  Reload explicitly rather than waiting on ConfigChanged: the
-                //  event fires only on a successful reload, so on failure the
-                //  stale config stays live and an await never returns.
-                //
-                if (!_.isFunction(ConfigModule.reload)) {
-                    return callback(
-                        Errors.UnexpectedState('Configuration reload is unavailable')
-                    );
-                }
-
-                ConfigModule.reload(err => {
-                    if (err) {
-                        return callback(err);
-                    }
-
-                    //  ...and prove the areas actually resolve now
-                    const unresolved = result.created.filter(
-                        c => !getMessageAreaByTag(c.areaTag)
-                    );
-                    if (unresolved.length > 0) {
-                        return callback(
-                            Errors.UnexpectedState(
-                                `Created areas did not resolve after reload: ${unresolved
-                                    .map(u => u.areaTag)
-                                    .join(', ')}`
-                            )
-                        );
-                    }
-
-                    return callback(null);
-                });
-            },
-        ],
-        err => {
+    readGenerated(ctx.includeState.path, (err, generated) => {
+        if (err) {
             return cb(err, result);
         }
-    );
+
+        pruneIgnored(generated, networkName, ctx.ignore, result);
+        addGeneratedAreas(generated, networkName, ctx, ftnTags, result);
+
+        const changed = result.created.length > 0 || result.pruned.length > 0;
+        commitGenerated(ctx.includeState, generated, changed, result, commitErr =>
+            cb(commitErr, result)
+        );
+    });
+}
+
+//
+//  Apply an info pack's area list.
+//
+//  The pack owns exactly two fields -- name and desc -- and only for areas we
+//  generated ourselves. An area an operator defined in config.hjson is left
+//  alone: config.hjson wins over the include anyway, so writing there would
+//  be pointless, and it would risk a second copy of the area in a different
+//  conference. getMessageAreaByTag() stops at the first conference carrying a
+//  tag, so a duplicate resolves by object key order rather than intent.
+//
+//  A pack lists what the *network* carries, not what *we* are linked to, so
+//  creating from it is opt-in: createUnlinked otherwise produces hundreds of
+//  permanently empty areas.
+//
+//  cb(err, { enriched: [areaTag], created, rejected, pruned })
+//
+function applyInfoPackEntries(networkName, entries, { createUnlinked } = {}, cb) {
+    const ctx = prepareGeneratedWrite(networkName);
+    if (ctx instanceof Error) {
+        return cb(ctx);
+    }
+
+    const result = { enriched: [], created: [], rejected: [], pruned: [] };
+
+    const byTag = {};
+    entries.forEach(e => {
+        if (_.isString(e.ftnTag) && _.isString(e.name) && e.name.length > 0) {
+            byTag[_.toUpper(e.ftnTag)] = e.name;
+        }
+    });
+
+    readGenerated(ctx.includeState.path, (err, generated) => {
+        if (err) {
+            return cb(err, result);
+        }
+
+        pruneIgnored(generated, networkName, ctx.ignore, result);
+
+        if (createUnlinked) {
+            addGeneratedAreas(
+                generated,
+                networkName,
+                ctx,
+                Object.keys(byTag),
+                result,
+                byTag
+            );
+        }
+
+        _.forEach(
+            generatedAreasForNetwork(generated, networkName),
+            (areaConf, areaTag) => {
+                const name = byTag[_.toUpper(areaConf.tag || '')];
+                if (!name) {
+                    return;
+                }
+
+                //  find the conference this area was generated into
+                const confTag = _.findKey(
+                    generated.messageConferences,
+                    conf => conf && conf.areas && conf.areas[areaTag]
+                );
+                if (!confTag) {
+                    return;
+                }
+
+                const area = generated.messageConferences[confTag].areas[areaTag];
+                if (area.name === name && area.desc === name) {
+                    return; //  already says this
+                }
+
+                area.name = name;
+                area.desc = name;
+                result.enriched.push(areaTag);
+            }
+        );
+
+        const changed =
+            result.created.length > 0 ||
+            result.pruned.length > 0 ||
+            result.enriched.length > 0;
+
+        commitGenerated(ctx.includeState, generated, changed, result, commitErr =>
+            cb(commitErr, result)
+        );
+    });
 }
 
 module.exports = {
@@ -532,6 +622,7 @@ module.exports = {
 
     getAutoAreasConfig,
     onDemandNetworkNames,
+    applyInfoPackEntries,
     anyAutoAreasEnabled,
     getGeneratedIncludePath,
     getGeneratedIncludeState,

--- a/core/auto_area_create.js
+++ b/core/auto_area_create.js
@@ -1,0 +1,545 @@
+/* jslint node: true */
+'use strict';
+
+//  ENiGMA½
+const ConfigModule = require('./config.js');
+//  Look up configModule.get on each call rather than capturing it at load
+//  time: it is replaced when the Config bootstrapper runs (and by tests
+//  swapping in fixture configs), and a load-time capture freezes whichever
+//  getter happened to be installed first.  Same reasoning as message_area.js.
+const Config = (...args) => ConfigModule.get(...args);
+const Errors = require('./enig_error.js').Errors;
+const { WellKnownAreaTags } = require('./message_const.js');
+const { isValidAreaTag, localAreaTagFor } = require('./area_import.js');
+
+//
+//  message_area.js captures dbs.message at module load, so it must not be
+//  pulled in before initializeDatabases() has run.  Requiring it lazily keeps
+//  this module safe to load from anywhere, including oputil's early paths.
+//
+const getMessageAreaByTag = areaTag =>
+    require('./message_area.js').getMessageAreaByTag(areaTag);
+
+//  deps
+const fs = require('graceful-fs');
+const paths = require('path');
+const hjson = require('hjson');
+const async = require('async');
+const _ = require('lodash');
+
+//
+//  Automatic message area creation.
+//
+//  Areas discovered from inbound EchoMail are written to a *generated* hjson
+//  file that config.hjson pulls in via `includes`.  That placement is what
+//  makes the feature safe to re-run: includes are merged with
+//
+//      _.defaultsDeep(config, includedConfig)     config_loader.js
+//
+//  which fills only keys config.hjson does not already have.  config.hjson
+//  therefore always wins, so this file can be rewritten wholesale on every
+//  pass without ever clobbering something an operator set by hand.
+//
+//  Consequences of that same merge, all load bearing:
+//
+//  * config_default.js is merged *before* includes, so a generated value can
+//    never override a default.  Nothing here restates a defaulted key.
+//  * Arrays merge by index rather than being replaced, and the customizer
+//    that fixes array semantics for the defaults<->user merge does not apply
+//    to includes.  Nothing here emits an array an operator might partially
+//    override -- notably `uplinks`, which stays out entirely.
+//  * A referenced-but-missing include fails the *entire* config load, so the
+//    board will not start.  Writes are staged to a temp file, parsed back,
+//    and only then renamed into place.
+//
+
+const GeneratedIncludeFileName = 'auto-areas.hjson';
+
+const GeneratedFileHeader = `//
+//  ENiGMA½ automatic message areas
+//
+//  GENERATED FILE -- do not edit.  It is rewritten whenever automatic area
+//  creation runs, and anything you add here will be lost.
+//
+//  Areas here are created read-only: they carry no "uplinks" (nothing is
+//  exported) and an "acs.write" of ID0, which no user satisfies, so nothing
+//  can be posted into them either.  Without both, a local post would vanish
+//  into an area that looks live but goes nowhere.
+//
+//  To adopt an area, define it in config.hjson -- that file wins over this
+//  one -- adding "uplinks" and your own "acs".  To make it go away entirely,
+//  add its FTN tag to the network's autoAreas.ignore list; it is removed
+//  from here on the next pass.  Removing an area does not delete its
+//  messages: they stay in the database keyed by area tag, invisible, and
+//  reappear if the tag is ever created again.
+//
+`;
+
+//  ACS that no user can satisfy: user IDs start at 1.
+const DenyAllAcs = 'ID0';
+
+const DefaultMaxAutoCreate = 500;
+
+const RejectReasons = {
+    Ignored: 'in the network ignore list',
+    InvalidTag: 'not a usable area tag',
+    WellKnown: 'would collide with a built-in system area',
+    ExistingArea: 'an area with that tag already exists',
+    ExistingFtnArea: 'an FTN area with that tag is already configured',
+    OtherNetwork: 'already generated for a different network',
+    MaxReached: 'maximum automatically created areas reached',
+};
+
+function getFtnNetworks() {
+    return _.get(Config(), 'messageNetworks.ftn.networks', {});
+}
+
+//
+//  Per-network autoAreas config, or null.  Following the design, there is no
+//  parent `enabled` flag: the feature is on for a network iff one of its
+//  sources is on.  Two flags that must agree is a configuration bug waiting
+//  to happen.
+//
+function getAutoAreasConfig(networkName) {
+    const autoAreas = _.get(getFtnNetworks(), [networkName, 'autoAreas']);
+    if (!_.isObject(autoAreas)) {
+        return null;
+    }
+
+    const onDemand = _.get(autoAreas, 'onDemand', {});
+    const infoPack = _.get(autoAreas, 'infoPack', {});
+
+    if (true !== onDemand.enabled && true !== infoPack.enabled) {
+        return null;
+    }
+
+    return Object.assign({}, autoAreas, {
+        networkName,
+        confTag: autoAreas.confTag,
+        ignore: Array.isArray(autoAreas.ignore) ? autoAreas.ignore : [],
+        maxAutoCreate: _.isNumber(autoAreas.maxAutoCreate)
+            ? autoAreas.maxAutoCreate
+            : DefaultMaxAutoCreate,
+        onDemand,
+        infoPack,
+    });
+}
+
+//  Networks that want areas created when unknown EchoMail arrives
+function onDemandNetworkNames() {
+    return Object.keys(getFtnNetworks()).filter(networkName => {
+        const cfg = getAutoAreasConfig(networkName);
+        return cfg && true === cfg.onDemand.enabled;
+    });
+}
+
+function anyAutoAreasEnabled() {
+    return Object.keys(getFtnNetworks()).some(n => getAutoAreasConfig(n) !== null);
+}
+
+function getGeneratedIncludePath() {
+    const basePath = ConfigModule.Config.getBasePath();
+    if (!basePath) {
+        return undefined;
+    }
+    return paths.join(paths.dirname(basePath), GeneratedIncludeFileName);
+}
+
+//
+//  The generated file has to exist *and* be listed in config.hjson's
+//  `includes` before it does anything, and it must exist before it is
+//  referenced or the board will not boot.  `oputil.js mb auto-areas init`
+//  does both in the right order; this reports what is actually in place.
+//
+function getGeneratedIncludeState() {
+    const path = getGeneratedIncludePath();
+    const state = { path, exists: false, included: false };
+
+    if (!path) {
+        return state;
+    }
+
+    state.exists = fs.existsSync(path);
+
+    const includes = _.get(Config(), 'includes');
+    if (Array.isArray(includes)) {
+        state.included = includes.some(
+            inc => paths.basename(inc) === GeneratedIncludeFileName
+        );
+    }
+
+    return state;
+}
+
+function emptyGenerated() {
+    return {
+        messageConferences: {},
+        messageNetworks: { ftn: { areas: {} } },
+    };
+}
+
+function readGenerated(path, cb) {
+    fs.readFile(path, 'utf8', (err, data) => {
+        if (err) {
+            //  A missing file is fine -- nothing has been generated yet.
+            if ('ENOENT' === err.code) {
+                return cb(null, emptyGenerated());
+            }
+            return cb(err);
+        }
+
+        let parsed;
+        try {
+            parsed = hjson.parse(data);
+        } catch (e) {
+            //
+            //  Refuse to overwrite something we cannot read.  If the board is
+            //  running, this file parsed at boot, so whatever is here now was
+            //  changed underneath us and is the operator's to sort out.
+            //
+            return cb(
+                Errors.Invalid(`Cannot parse generated area file "${path}": ${e.message}`)
+            );
+        }
+
+        return cb(null, _.defaultsDeep(parsed || {}, emptyGenerated()));
+    });
+}
+
+//  Areas in the generated file belonging to |networkName|
+function generatedAreasForNetwork(generated, networkName) {
+    return _.pickBy(
+        _.get(generated, 'messageNetworks.ftn.areas', {}),
+        areaConf => _.get(areaConf, 'network') === networkName
+    );
+}
+
+//
+//  Write the generated file atomically: stage to a temp file in the same
+//  directory, parse it back to prove it loads, then rename over the original.
+//  A truncated or unparsable include here stops the board from starting.
+//
+function writeGenerated(path, generated, cb) {
+    let body;
+    try {
+        body =
+            GeneratedFileHeader +
+            hjson.stringify(generated, {
+                emitRootBraces: true,
+                bracesSameLine: true,
+                space: 4,
+                quotes: 'min',
+                eol: '\n',
+            }) +
+            '\n';
+    } catch (e) {
+        return cb(Errors.UnexpectedState(`Failed generating area config: ${e.message}`));
+    }
+
+    //  prove it round-trips before anything can see it
+    try {
+        hjson.parse(body);
+    } catch (e) {
+        return cb(
+            Errors.UnexpectedState(
+                `Generated area config does not parse; refusing to write: ${e.message}`
+            )
+        );
+    }
+
+    const tempPath = `${path}.${process.pid}.tmp`;
+    fs.writeFile(tempPath, body, 'utf8', err => {
+        if (err) {
+            return cb(err);
+        }
+
+        fs.rename(tempPath, path, renameErr => {
+            if (renameErr) {
+                fs.unlink(tempPath, () => {});
+                return cb(renameErr);
+            }
+            return cb(null);
+        });
+    });
+}
+
+//
+//  Would creating |ftnTag| for |networkName| collide with something?
+//
+//  Collisions are refused, never merged.  An FTN tag lower cases straight
+//  onto a local area tag, and PRIVATE_MAIL -> private_mail would alias the
+//  built-in private mail area -- an echo landing in everyone's mailbox.
+//
+function checkCollision(ftnTag, areaTag, networkName, generated, config) {
+    if (!isValidAreaTag(ftnTag)) {
+        return RejectReasons.InvalidTag;
+    }
+
+    if (Object.values(WellKnownAreaTags).includes(areaTag)) {
+        return RejectReasons.WellKnown;
+    }
+
+    const generatedFtnAreas = _.get(generated, 'messageNetworks.ftn.areas', {});
+    const alreadyGenerated = generatedFtnAreas[areaTag];
+    if (alreadyGenerated) {
+        //
+        //  Ours already, for this network and tag: re-running is a no-op
+        //  rather than a collision.  This matters because import cycles can
+        //  overlap -- the 5 minute import watchdog force-completes a cycle
+        //  and lets the next one start while the first may still be running.
+        //
+        if (
+            alreadyGenerated.network === networkName &&
+            _.toUpper(alreadyGenerated.tag) === _.toUpper(ftnTag)
+        ) {
+            return null;
+        }
+        return RejectReasons.OtherNetwork;
+    }
+
+    //  Any conference, not just ours: getMessageAreaByTag() stops at the
+    //  first conference carrying the tag, so a duplicate elsewhere would
+    //  silently win or lose by object key order.
+    if (getMessageAreaByTag(areaTag)) {
+        return RejectReasons.ExistingArea;
+    }
+
+    if (_.has(config, ['messageNetworks', 'ftn', 'areas', areaTag])) {
+        return RejectReasons.ExistingFtnArea;
+    }
+
+    return null;
+}
+
+//
+//  Create message areas for |ftnTags| on |networkName|.
+//
+//  cb(err, {
+//      created:  [ { ftnTag, areaTag } ],
+//      rejected: [ { ftnTag, areaTag, reason } ],
+//      pruned:   [ areaTag ],
+//  })
+//
+//  Creating nothing is a success with an empty |created|.
+//
+function createAreas(networkName, ftnTags, cb) {
+    const autoConfig = getAutoAreasConfig(networkName);
+    if (!autoConfig) {
+        return cb(
+            Errors.MissingConfig(
+                `No autoAreas configuration for network "${networkName}"`
+            )
+        );
+    }
+
+    const confTag = autoConfig.confTag;
+    if (!_.isString(confTag) || 0 === confTag.length) {
+        return cb(
+            Errors.MissingConfig(
+                `autoAreas for network "${networkName}" has no "confTag"`
+            )
+        );
+    }
+
+    //
+    //  The conference must already exist.  defaultsDeep would happily create
+    //  one from this file, but it would have areas and no name or desc.
+    //  Refuse rather than manufacture a broken conference.
+    //
+    if (!_.has(Config(), ['messageConferences', confTag])) {
+        return cb(
+            Errors.MissingConfig(
+                `autoAreas confTag "${confTag}" (network "${networkName}") is not a configured message conference`
+            )
+        );
+    }
+
+    const includeState = getGeneratedIncludeState();
+    if (!includeState.path) {
+        return cb(Errors.UnexpectedState('Configuration base path is unknown'));
+    }
+
+    if (!includeState.included) {
+        return cb(
+            Errors.MissingConfig(
+                `"${GeneratedIncludeFileName}" is not listed in the "includes" of ${ConfigModule.Config.getBasePath()}; ` +
+                    'run "oputil.js mb auto-areas init"'
+            )
+        );
+    }
+
+    const ignore = new Set(autoConfig.ignore.map(t => _.toUpper(String(t))));
+
+    let result;
+
+    async.waterfall(
+        [
+            callback => readGenerated(includeState.path, callback),
+            (generated, callback) => {
+                const config = Config();
+                result = { created: [], rejected: [], pruned: [] };
+
+                //
+                //  The ignore list is the only way to un-create something, so
+                //  it has to apply to what is already here, not just to new
+                //  arrivals.
+                //
+                _.forEach(
+                    generatedAreasForNetwork(generated, networkName),
+                    (areaConf, areaTag) => {
+                        if (ignore.has(_.toUpper(areaConf.tag || ''))) {
+                            delete generated.messageNetworks.ftn.areas[areaTag];
+                            _.forEach(generated.messageConferences, conf => {
+                                if (conf.areas) {
+                                    delete conf.areas[areaTag];
+                                }
+                            });
+                            result.pruned.push(areaTag);
+                        }
+                    }
+                );
+
+                //  Deterministic order so a maxAutoCreate cut is reproducible
+                const candidates = Array.from(
+                    new Set(ftnTags.map(t => String(t).trim()).filter(t => t.length > 0))
+                ).sort();
+
+                let count = Object.keys(
+                    generatedAreasForNetwork(generated, networkName)
+                ).length;
+
+                candidates.forEach(ftnTag => {
+                    const areaTag = localAreaTagFor(ftnTag);
+
+                    if (ignore.has(_.toUpper(ftnTag))) {
+                        result.rejected.push({
+                            ftnTag,
+                            areaTag,
+                            reason: RejectReasons.Ignored,
+                        });
+                        return;
+                    }
+
+                    const collision = checkCollision(
+                        ftnTag,
+                        areaTag,
+                        networkName,
+                        generated,
+                        config
+                    );
+                    if (collision) {
+                        result.rejected.push({ ftnTag, areaTag, reason: collision });
+                        return;
+                    }
+
+                    if (_.has(generated, ['messageNetworks', 'ftn', 'areas', areaTag])) {
+                        //  already ours; nothing to do
+                        return;
+                    }
+
+                    //
+                    //  The cap is on the total, not the run: a per-run cap
+                    //  compounds, and ten runs of 500 is 5000 areas.  The
+                    //  generated file is the durable counter.
+                    //
+                    if (count >= autoConfig.maxAutoCreate) {
+                        result.rejected.push({
+                            ftnTag,
+                            areaTag,
+                            reason: RejectReasons.MaxReached,
+                        });
+                        return;
+                    }
+
+                    _.set(generated, ['messageConferences', confTag, 'areas', areaTag], {
+                        //  Placeholder name/desc.  On-demand discovery knows the
+                        //  tag and nothing else; an info pack may replace these
+                        //  later, and an operator's config.hjson beats both.
+                        name: ftnTag,
+                        desc: ftnTag,
+                        acs: {
+                            write: DenyAllAcs,
+                        },
+                    });
+
+                    _.set(generated, ['messageNetworks', 'ftn', 'areas', areaTag], {
+                        network: networkName,
+                        tag: ftnTag,
+                        //  deliberately no "uplinks": nothing is exported
+                    });
+
+                    result.created.push({ ftnTag, areaTag });
+                    count += 1;
+                });
+
+                return callback(null, generated);
+            },
+            (generated, callback) => {
+                if (0 === result.created.length && 0 === result.pruned.length) {
+                    return callback(null, false);
+                }
+                writeGenerated(includeState.path, generated, err => callback(err, true));
+            },
+            (didWrite, callback) => {
+                if (!didWrite) {
+                    return callback(null);
+                }
+
+                //
+                //  Reload explicitly rather than waiting on ConfigChanged: the
+                //  event fires only on a successful reload, so on failure the
+                //  stale config stays live and an await never returns.
+                //
+                if (!_.isFunction(ConfigModule.reload)) {
+                    return callback(
+                        Errors.UnexpectedState('Configuration reload is unavailable')
+                    );
+                }
+
+                ConfigModule.reload(err => {
+                    if (err) {
+                        return callback(err);
+                    }
+
+                    //  ...and prove the areas actually resolve now
+                    const unresolved = result.created.filter(
+                        c => !getMessageAreaByTag(c.areaTag)
+                    );
+                    if (unresolved.length > 0) {
+                        return callback(
+                            Errors.UnexpectedState(
+                                `Created areas did not resolve after reload: ${unresolved
+                                    .map(u => u.areaTag)
+                                    .join(', ')}`
+                            )
+                        );
+                    }
+
+                    return callback(null);
+                });
+            },
+        ],
+        err => {
+            return cb(err, result);
+        }
+    );
+}
+
+module.exports = {
+    GeneratedIncludeFileName,
+    DenyAllAcs,
+    RejectReasons,
+
+    getAutoAreasConfig,
+    onDemandNetworkNames,
+    anyAutoAreasEnabled,
+    getGeneratedIncludePath,
+    getGeneratedIncludeState,
+    createAreas,
+
+    //  exported for tests and for oputil
+    readGenerated,
+    writeGenerated,
+    emptyGenerated,
+    generatedAreasForNetwork,
+};

--- a/core/auto_area_create.js
+++ b/core/auto_area_create.js
@@ -311,6 +311,123 @@ function checkCollision(ftnTag, areaTag, networkName, generated, config) {
 }
 
 //
+//  Add |fileName| to the "includes" array of a config.hjson, editing the text
+//  in place rather than re-serializing.
+//
+//  writeConfig() round-trips through hjson, which preserves comments but
+//  normalizes whitespace: column alignment is lost, comment spacing collapses,
+//  and inline arrays are expanded. That is a fine trade when rewriting whole
+//  sections, as import-areas does. It is a bad one for appending a single
+//  line to a hand-maintained config, so this touches only the bytes it has to.
+//
+//  Returns the new text, or null if it could not be done safely -- in which
+//  case the caller tells the operator what to add by hand.
+//
+function addIncludeEntry(configText, fileName) {
+    let before;
+    try {
+        before = hjson.parse(configText);
+    } catch (e) {
+        return null;
+    }
+
+    const insert = (() => {
+        const existing = /^([ \t]*)includes[ \t]*:[ \t]*\[/m.exec(configText);
+
+        //  no "includes" yet: add one before the closing brace of the document
+        if (!existing) {
+            const close = configText.lastIndexOf('}');
+            if (close < 0) {
+                return null;
+            }
+            return (
+                configText.slice(0, close) +
+                `    includes: [\n        ${fileName}\n    ]\n` +
+                configText.slice(close)
+            );
+        }
+
+        //
+        //  One already exists, so append to the *end* of it. Includes are
+        //  merged in order and the earliest wins, so the generated file has to
+        //  come last: an include the operator wrote should beat it, the same
+        //  way config.hjson does.
+        //
+        const indent = existing[1];
+        const open = existing.index + existing[0].length;
+
+        let depth = 1;
+        let quote = null;
+        let close = -1;
+
+        for (let i = open; i < configText.length; ++i) {
+            const ch = configText.charAt(i);
+
+            if (quote) {
+                if (ch === quote && '\\' !== configText.charAt(i - 1)) {
+                    quote = null;
+                }
+                continue;
+            }
+
+            if ('"' === ch || "'" === ch) {
+                quote = ch;
+            } else if ('[' === ch) {
+                depth += 1;
+            } else if (']' === ch) {
+                depth -= 1;
+                if (0 === depth) {
+                    close = i;
+                    break;
+                }
+            }
+        }
+
+        if (close < 0) {
+            return null;
+        }
+
+        return (
+            configText.slice(0, close).replace(/\s+$/, '') +
+            `\n${indent}    ${fileName}\n${indent}` +
+            configText.slice(close)
+        );
+    })();
+
+    if (!insert) {
+        return null;
+    }
+
+    //
+    //  Prove the edit did exactly what was intended and nothing else: the
+    //  result must parse, must now include the file, and must be otherwise
+    //  identical to what was there before.
+    //
+    let after;
+    try {
+        after = hjson.parse(insert);
+    } catch (e) {
+        return null;
+    }
+
+    const includes = after.includes;
+    if (!Array.isArray(includes) || !includes.includes(fileName)) {
+        return null;
+    }
+
+    if (!_.isEqual(_.omit(before, 'includes'), _.omit(after, 'includes'))) {
+        return null;
+    }
+
+    const priorIncludes = Array.isArray(before.includes) ? before.includes : [];
+    if (!_.isEqual(includes, priorIncludes.concat([fileName]))) {
+        return null;
+    }
+
+    return insert;
+}
+
+//
 //  Validate everything a write depends on, once.  Returns an Error or a
 //  { autoConfig, confTag, includeState, ignore } context.
 //
@@ -727,6 +844,7 @@ module.exports = {
     //  exported for tests and for oputil
     readGenerated,
     writeGenerated,
+    addIncludeEntry,
     emptyGenerated,
     generatedAreasForNetwork,
 };

--- a/core/bbs.js
+++ b/core/bbs.js
@@ -114,9 +114,32 @@ function main() {
                         console.error(`Configuration error: ${err.message}`); //  eslint-disable-line no-console
 
                         if ('ENOENT' === err.code) {
-                            console.error(
-                                "\nConfiguration file does not exist: '{configFile}'\n\nIf this is a new installation please run './oputil.js config new' from the enigma-bbs directory"
-                            );
+                            //
+                            //  err.configPath names the file that was actually
+                            //  missing, which is not necessarily config.hjson:
+                            //  a file listed in "includes" that is not there
+                            //  fails the whole load in exactly the same way,
+                            //  and telling the operator to run "config new"
+                            //  would be actively wrong advice for that.
+                            //
+                            const missingPath = err.configPath || resolvePath(configFile);
+                            const isBaseConfig =
+                                paths.basename(missingPath).toLowerCase() ===
+                                'config.hjson';
+
+                            if (isBaseConfig) {
+                                console.error(
+                                    `\nConfiguration file does not exist: '${missingPath}'` +
+                                        "\n\nIf this is a new installation please run './oputil.js config new' from the enigma-bbs directory"
+                                );
+                            } else {
+                                console.error(
+                                    `\nA file listed in "includes" does not exist: '${missingPath}'` +
+                                        `\n\nCreate it, or remove it from "includes" in ${resolvePath(
+                                            configFile
+                                        )}.`
+                                );
+                            }
                         }
 
                         if (err.hint) {

--- a/core/config.js
+++ b/core/config.js
@@ -57,9 +57,17 @@ exports.Config = class Config extends ConfigLoader {
             //  late bind an exported get method to the global Config
             //  instance we just created
             exports.get = systemConfigInstance.get.bind(systemConfigInstance);
+            exports.reload = systemConfigInstance.reload.bind(systemConfigInstance);
 
             return cb(null);
         });
+    }
+
+    //  Path to config.hjson as loaded; undefined until create() has run.
+    //  Anything generating a config include needs this to know where to
+    //  write it.
+    static getBasePath() {
+        return systemConfigInstance ? systemConfigInstance.baseConfigPath : undefined;
     }
 
     static getDefaultPath() {

--- a/core/config_loader.js
+++ b/core/config_loader.js
@@ -49,6 +49,34 @@ module.exports = class ConfigLoader {
         return this._reload(baseConfigPath, cb);
     }
 
+    //
+    //  Reload from disk right now, bypassing the file watcher and its debounce.
+    //
+    //  For a caller that has just written a config include and needs the new
+    //  values live before it can continue, waiting on the ConfigChanged event
+    //  is not safe: that event is emitted only on a *successful* reload, so a
+    //  bad include leaves the previous config in place, emits nothing, and an
+    //  unguarded await never returns.  Here the error comes straight back.
+    //
+    reload(cb) {
+        //
+        //  Read from disk, not from ConfigCache.  Without this, a caller that
+        //  has just written an include gets the *previous* parsed copy back:
+        //  the cache is only refreshed by the file watcher, which arrives
+        //  later and on its own schedule.  An explicit reload has to mean
+        //  what it says.
+        //
+        this._forceReCache = true;
+        return this._reload(this.baseConfigPath, err => {
+            this._forceReCache = false;
+
+            if (_.isFunction(this.onReload)) {
+                this.onReload(err);
+            }
+            return cb(err);
+        });
+    }
+
     //  Returns the current effective config.  When theme.js finalises a merged
     //  theme it writes back to this.current directly; get() surfaces that value.
     get() {
@@ -229,6 +257,8 @@ module.exports = class ConfigLoader {
             filePath,
             hotReload: this.hotReload,
             keepWsc: this.keepWsc,
+            //  set for the duration of an explicit reload(); see above
+            forceReCache: true === this._forceReCache,
             callback: this._configFileChanged.bind(this),
         };
 

--- a/core/oputil/oputil_file_base.js
+++ b/core/oputil/oputil_file_base.js
@@ -15,6 +15,12 @@ const {
     writeConfig,
 } = require('./oputil_common.js');
 const Errors = require('../enig_error.js').Errors;
+const {
+    AreaListFormat,
+    parseAreaList,
+    describeFormat,
+    buildFileAreaImportRecords,
+} = require('../area_import.js');
 
 const async = require('async');
 const fs = require('graceful-fs');
@@ -23,7 +29,6 @@ const _ = require('lodash');
 const moment = require('moment');
 const inq = require('inquirer');
 const { glob } = require('glob');
-const sanatizeFilename = require('sanitize-filename');
 const hjson = require('hjson');
 const { mkdirs } = require('fs-extra');
 
@@ -1056,38 +1061,63 @@ function importFileAreas() {
                         return callback(err);
                     }
 
-                    const importInfo = {
-                        storageTags: {},
-                        areas: {},
-                        count: 0,
-                    };
+                    //
+                    //  The format is worked out from the file's content, not
+                    //  its extension. FILEBONE / FileGate "RAID" is the common
+                    //  shape, but some networks ship their file echo list as a
+                    //  plain "TAG  Description" list -- the same layout their
+                    //  *message* list uses -- and nothing in the name says
+                    //  which you have.
+                    //
+                    const parsed = parseAreaList(importData);
 
-                    const re = /Area\s+([^\s]+)\s+[0-9]\s+(?:!|\*&)\s+([^\r\n]+)/gm;
-                    let m;
-                    while ((m = re.exec(importData))) {
-                        const dir = m[1].trim();
-                        const name = m[2].trim();
-                        const safeName = sanatizeFilename(name);
-
-                        const stPrefix = _.snakeCase(sanatizeFilename(safeName));
-                        const storageTag = `${stPrefix}__${_.snakeCase(
-                            sanatizeFilename(dir)
-                        )}`;
-                        const areaTag = _.snakeCase(safeName);
-
-                        if (!dir || !name || !storageTag || !areaTag) {
-                            console.info(`Skipping entry: ${m[0]}`);
-                            continue;
-                        }
-
-                        importInfo.storageTags[storageTag] = dir;
-                        importInfo.areas[areaTag] = {
-                            name: name,
-                            desc: name,
-                            storageTags: [storageTag],
-                        };
-                        ++importInfo.count;
+                    if (
+                        ![AreaListFormat.FileBone, AreaListFormat.NA].includes(
+                            parsed.format
+                        )
+                    ) {
+                        return callback(
+                            Errors.Invalid(
+                                `Nothing to import from "${paths.basename(
+                                    importPath
+                                )}": ${describeFormat(parsed.format)} ` +
+                                    `(${parsed.stats.dataLines} data line(s), ` +
+                                    `${parsed.stats.commentLines} comment line(s))`
+                            )
+                        );
                     }
+
+                    if (AreaListFormat.NA === parsed.format) {
+                        //
+                        //  A plain "TAG  Description" list is exactly the shape
+                        //  a *message* echo list uses, and several networks
+                        //  ship both with a .na extension. Nothing in the
+                        //  content can tell them apart, so say so and let the
+                        //  operator decide at the confirmation prompt below.
+                        //
+                        console.info('');
+                        console.info(
+                            `NOTE: "${paths.basename(
+                                importPath
+                            )}" is a plain "TAG  Description" list, which is also`
+                        );
+                        console.info(
+                            '      how message echo lists are written. Check the areas below'
+                        );
+                        console.info(
+                            '      before proceeding -- this may not be a file echo list.'
+                        );
+                        console.info('');
+                    }
+
+                    const importInfo = buildFileAreaImportRecords(parsed.entries);
+
+                    const skipped = parsed.skipped.concat(importInfo.skipped);
+                    skipped.forEach(sk => {
+                        console.info(
+                            `Skipping line ${sk.lineNumber} (${sk.reason}): ${sk.text}`
+                        );
+                    });
 
                     if (0 === importInfo.count) {
                         return callback(new Error('Nothing to import'));

--- a/core/oputil/oputil_help.js
+++ b/core/oputil/oputil_help.js
@@ -212,6 +212,11 @@ Actions:
 
   import-areas PATH           Import areas using FidoNet *.NA or AREAS.BBS file
 
+  auto-areas init             Prepare automatic message area creation: creates
+                              auto-areas.hjson and adds it to "includes" in
+                              config.hjson. Safe to re-run. The feature itself
+                              stays off until configured per network.
+
   qwk-dump PATH               Dumps a QWK packet to stdout.
   qwk-export [AREA_TAGS] PATH Exports one or more configured message area to a QWK
                               packet in the directory specified by PATH. The QWK

--- a/core/oputil/oputil_help.js
+++ b/core/oputil/oputil_help.js
@@ -179,7 +179,8 @@ remove arguments:
 import-areas arguments:
   --type TYPE                  Sets import areas type
 
-  Valid types are are "zxx" or "na".
+  Valid types are are "zxx" or "na". This selects which file extensions are
+  accepted; the format itself is determined from the file's content.
 
   --create-dirs                Also create backing storage directories
 `,

--- a/core/oputil/oputil_message_base.js
+++ b/core/oputil/oputil_message_base.js
@@ -486,6 +486,7 @@ function autoAreas() {
         GeneratedIncludeFileName,
         emptyGenerated,
         writeGenerated,
+        addIncludeEntry,
     } = require('../auto_area_create.js');
 
     const configPath = getConfigPath();
@@ -508,22 +509,18 @@ function autoAreas() {
             },
             function loadConfigHjson(callback) {
                 fs.readFile(configPath, 'utf8', (err, confData) => {
-                    if (err) {
-                        return callback(err);
-                    }
-
-                    let config;
-                    try {
-                        config = hjson.parse(confData, { keepWsc: true });
-                    } catch (e) {
-                        return callback(e);
-                    }
-                    return callback(null, config);
+                    return callback(err, confData);
                 });
             },
-            function addInclude(config, callback) {
-                const includes = Array.isArray(config.includes) ? config.includes : [];
+            function addInclude(confData, callback) {
+                let config;
+                try {
+                    config = hjson.parse(confData);
+                } catch (e) {
+                    return callback(e);
+                }
 
+                const includes = Array.isArray(config.includes) ? config.includes : [];
                 if (
                     includes.some(inc => paths.basename(inc) === GeneratedIncludeFileName)
                 ) {
@@ -533,13 +530,28 @@ function autoAreas() {
                     return callback(null);
                 }
 
-                includes.push(GeneratedIncludeFileName);
-                config.includes = includes;
+                const updated = addIncludeEntry(confData, GeneratedIncludeFileName);
+                if (!updated) {
+                    //
+                    //	Refuse rather than fall back to a full rewrite: this is
+                    //	somebody's live configuration and a one line addition is
+                    //	not worth reformatting it.
+                    //
+                    console.info('');
+                    console.info(`Could not safely add the include to ${configPath}.`);
+                    console.info('Please add it by hand:');
+                    console.info('');
+                    console.info('    includes: [');
+                    console.info(`        ${GeneratedIncludeFileName}`);
+                    console.info('    ]');
+                    console.info('');
+                    return callback(Errors.General('Could not update configuration'));
+                }
 
-                if (!writeConfig(config, configPath)) {
-                    return callback(
-                        Errors.UnexpectedState('Failed writing configuration')
-                    );
+                try {
+                    fs.writeFileSync(configPath, updated, 'utf8');
+                } catch (e) {
+                    return callback(e);
                 }
 
                 console.info(

--- a/core/oputil/oputil_message_base.js
+++ b/core/oputil/oputil_message_base.js
@@ -469,6 +469,103 @@ function importAreas() {
     );
 }
 
+//
+//	oputil.js mb auto-areas init
+//
+//	Bootstraps automatic area creation.  The order matters: a referenced but
+//	missing include fails the entire config load, so the generated file has to
+//	exist before config.hjson points at it or the board will not start.
+//
+function autoAreas() {
+    const action = argv._[2];
+    if ('init' !== action) {
+        return printUsageAndSetExitCode(getHelpFor('MessageBase'), ExitCodes.ERROR);
+    }
+
+    const {
+        GeneratedIncludeFileName,
+        emptyGenerated,
+        writeGenerated,
+    } = require('../auto_area_create.js');
+
+    const configPath = getConfigPath();
+    const generatedPath = paths.join(paths.dirname(configPath), GeneratedIncludeFileName);
+
+    async.waterfall(
+        [
+            function createGeneratedFile(callback) {
+                if (fs.existsSync(generatedPath)) {
+                    console.info(`Already present: ${generatedPath}`);
+                    return callback(null);
+                }
+
+                writeGenerated(generatedPath, emptyGenerated(), err => {
+                    if (!err) {
+                        console.info(`Created: ${generatedPath}`);
+                    }
+                    return callback(err);
+                });
+            },
+            function loadConfigHjson(callback) {
+                fs.readFile(configPath, 'utf8', (err, confData) => {
+                    if (err) {
+                        return callback(err);
+                    }
+
+                    let config;
+                    try {
+                        config = hjson.parse(confData, { keepWsc: true });
+                    } catch (e) {
+                        return callback(e);
+                    }
+                    return callback(null, config);
+                });
+            },
+            function addInclude(config, callback) {
+                const includes = Array.isArray(config.includes) ? config.includes : [];
+
+                if (
+                    includes.some(inc => paths.basename(inc) === GeneratedIncludeFileName)
+                ) {
+                    console.info(
+                        `Already included from ${configPath}: ${GeneratedIncludeFileName}`
+                    );
+                    return callback(null);
+                }
+
+                includes.push(GeneratedIncludeFileName);
+                config.includes = includes;
+
+                if (!writeConfig(config, configPath)) {
+                    return callback(
+                        Errors.UnexpectedState('Failed writing configuration')
+                    );
+                }
+
+                console.info(
+                    `Added to "includes" in ${configPath}: ${GeneratedIncludeFileName}`
+                );
+                return callback(null);
+            },
+        ],
+        err => {
+            if (err) {
+                process.exitCode = ExitCodes.ERROR;
+                return console.error(err.reason ? err.reason : err.message);
+            }
+
+            console.info('');
+            console.info(
+                'Automatic area creation can now be configured per FTN network under'
+            );
+            console.info(
+                'messageNetworks.ftn.networks.<network>.autoAreas -- it stays off until you do.'
+            );
+            console.info('See the Message Networks documentation for details.');
+        }
+    );
+}
+
 function dumpQWKPacket() {
     const packetPath = argv._[argv._.length - 1];
     if (argv._.length < 3 || !packetPath || 0 === packetPath.length) {
@@ -848,6 +945,7 @@ function handleMessageBaseCommand() {
         {
             areafix: areaFix,
             'import-areas': importAreas,
+            'auto-areas': autoAreas,
             'qwk-dump': dumpQWKPacket,
             'qwk-export': exportQWKPacket,
             'list-confs': listConferences,

--- a/core/oputil/oputil_message_base.js
+++ b/core/oputil/oputil_message_base.js
@@ -15,6 +15,14 @@ const {
 const getHelpFor = require('./oputil_help.js').getHelpFor;
 const Address = require('../ftn_address.js');
 const Errors = require('../enig_error.js').Errors;
+const {
+    AreaListFormat,
+    parseAreaList,
+    describeFormat,
+    validateUplinks,
+    localAreaTagFor,
+    buildAreaImportRecords,
+} = require('../area_import.js');
 
 //	deps
 const async = require('async');
@@ -142,15 +150,6 @@ function areaFix() {
     );
 }
 
-function validateUplinks(uplinks) {
-    const ftnAddress = require('../../core/ftn_address.js');
-    const valid = uplinks.every(ul => {
-        const addr = ftnAddress.fromString(ul);
-        return addr;
-    });
-    return valid;
-}
-
 function getMsgAreaImportType(path) {
     if (argv.type) {
         return argv.type.toLowerCase();
@@ -179,6 +178,7 @@ function importAreas() {
     }
 
     let importEntries;
+    let importSkipped = [];
 
     async.waterfall(
         [
@@ -188,10 +188,43 @@ function importAreas() {
                         return callback(err);
                     }
 
-                    importEntries = getImportEntries(importType, importData);
-                    if (0 === importEntries.length) {
-                        return callback(Errors.Invalid('Invalid or empty import file'));
+                    //
+                    //  AREAS.BBS cannot be told apart from a plain area list by
+                    //  shape, so it is only ever used when asked for explicitly.
+                    //  Everything else is sniffed from content: the extension
+                    //  does not indicate the format -- several networks ship a
+                    //  FILEBONE file echo list named "*.na".
+                    //
+                    const parsed = parseAreaList(
+                        importData,
+                        'bbs' === importType ? { format: AreaListFormat.AreasBbs } : {}
+                    );
+
+                    if (AreaListFormat.FileBone === parsed.format) {
+                        return callback(
+                            Errors.Invalid(
+                                `"${paths.basename(importPath)}" is a ${describeFormat(
+                                    parsed.format
+                                )}, not a message area list.\n` +
+                                    'File echo lists are imported with "oputil.js fb import-areas".'
+                            )
+                        );
                     }
+
+                    if (0 === parsed.entries.length) {
+                        return callback(
+                            Errors.Invalid(
+                                `Nothing to import from "${paths.basename(
+                                    importPath
+                                )}": ${describeFormat(parsed.format)} ` +
+                                    `(${parsed.stats.dataLines} data line(s), ` +
+                                    `${parsed.stats.commentLines} comment line(s))`
+                            )
+                        );
+                    }
+
+                    importEntries = parsed.entries;
+                    importSkipped = parsed.skipped;
 
                     //	We should have enough to validate uplinks
                     if ('bbs' === importType) {
@@ -295,7 +328,7 @@ function importAreas() {
                         uplinks = uplinks || answers.uplinks;
 
                         importEntries.forEach(ie => {
-                            ie.areaTag = ie.ftnTag.toLowerCase();
+                            ie.areaTag = localAreaTagFor(ie.ftnTag);
                         });
 
                         return callback(null);
@@ -338,6 +371,17 @@ function importAreas() {
                 importEntries.forEach(ie => {
                     console.info(`  ${ie.ftnTag} - ${ie.name}`);
                 });
+
+                if (importSkipped.length > 0) {
+                    console.info('');
+                    console.info(
+                        `${importSkipped.length} line(s) skipped and NOT imported:`
+                    );
+                    importSkipped.forEach(sk => {
+                        console.info(`  line ${sk.lineNumber}: ${sk.reason}`);
+                        console.info(`    ${sk.text}`);
+                    });
+                }
 
                 if (networkName) {
                     console.info('');
@@ -386,29 +430,18 @@ function importAreas() {
                 });
             },
             function performImport(config, callback) {
-                const confAreas = { messageConferences: {} };
-                confAreas.messageConferences[confTag] = { areas: {} };
-
-                const msgNetworks = { messageNetworks: { ftn: { areas: {} } } };
-
-                importEntries.forEach(ie => {
-                    const specificUplinks = ie.uplinks || uplinks; //	AREAS.BBS has specific uplinks per area
-
-                    confAreas.messageConferences[confTag].areas[ie.areaTag] = {
-                        name: ie.name,
-                        desc: ie.name,
-                    };
-
-                    if (networkName) {
-                        msgNetworks.messageNetworks.ftn.areas[ie.areaTag] = {
-                            network: networkName,
-                            tag: ie.ftnTag,
-                            uplinks: specificUplinks,
-                        };
-                    }
+                //	AREAS.BBS carries per-area uplinks; everything else uses |uplinks|
+                const records = buildAreaImportRecords(importEntries, {
+                    confTag,
+                    networkName,
+                    uplinks,
                 });
 
-                const newConfig = _.defaultsDeep(config, confAreas, msgNetworks);
+                const newConfig = _.defaultsDeep(
+                    config,
+                    { messageConferences: records.messageConferences },
+                    { messageNetworks: records.messageNetworks }
+                );
                 const configPath = getConfigPath();
 
                 if (!writeConfig(newConfig, configPath)) {
@@ -434,54 +467,6 @@ function importAreas() {
             }
         }
     );
-}
-
-function getImportEntries(importType, importData) {
-    let importEntries = [];
-
-    if ('na' === importType) {
-        //
-        //	parse out
-        //	TAG		DESC
-        //
-        const re = /^([^\s]+)\s+([^\r\n]+)/gm;
-        let m;
-
-        while ((m = re.exec(importData))) {
-            importEntries.push({
-                ftnTag: m[1].trim(),
-                name: m[2].trim(),
-            });
-        }
-    } else if ('bbs' === importType) {
-        //
-        //	Various formats for AREAS.BBS seem to exist. We want to support as much as possible.
-        //
-        //	SBBS http://www.synchro.net/docs/sbbsecho.html#AREAS.BBS
-        //	CODE	TAG		UPLINKS
-        //
-        //	VADV https://www.vadvbbs.com/products/vadv/support/docs/docs_vfido.php#AREAS.BBS
-        //	TAG		UPLINKS
-        //
-        //	Misc
-        //	PATH|OTHER	TAG		UPLINKS
-        //
-        //	Assume the second item is TAG and 1:n UPLINKS (space and/or comma sep) after (at the end)
-        //
-        const re = /^[^\s]+\s+([^\s]+)\s+([^\n]+)$/gm;
-        let m;
-        while ((m = re.exec(importData))) {
-            const tag = m[1].trim();
-
-            importEntries.push({
-                ftnTag: tag,
-                name: `Area: ${tag}`,
-                uplinks: m[2].trim().split(/[\s,]+/),
-            });
-        }
-    }
-
-    return importEntries;
 }
 
 function dumpQWKPacket() {

--- a/core/scanner_tossers/ftn_bso.js
+++ b/core/scanner_tossers/ftn_bso.js
@@ -3792,6 +3792,26 @@ FTNMessageScanTossModule.prototype.maybeRequestAreaFixRescan = function (
                 `Queued AreaFix rescan request for ${result.created.length} area(s)`
             );
 
+            //
+            //  Queued is not sent. NetMail needs a route to reach an uplink,
+            //  and without one the export fails with the request still sitting
+            //  in the message base -- which reads as "we asked and got no
+            //  answer" rather than "we never asked". Check the same way the
+            //  export will, and say so now.
+            //
+            self.getNetMailRouteInfoFromAddress(uplink, routeErr => {
+                if (routeErr) {
+                    Log.warn(
+                        {
+                            networkName,
+                            uplink: uplink.toString(),
+                            error: routeErr.message,
+                        },
+                        'AreaFix rescan request is queued but cannot be routed; it will not be sent until "scannerTossers.ftn_bso.netMail.routes" covers this uplink'
+                    );
+                }
+            });
+
             self.recordPendingAreaFixRequests(
                 uplink.toString(),
                 networkName,

--- a/core/scanner_tossers/ftn_bso.js
+++ b/core/scanner_tossers/ftn_bso.js
@@ -3774,7 +3774,15 @@ FTNMessageScanTossModule.prototype.maybeRequestAreaFixRescan = function (
             message.setLocalFromUserId(User.RootUserID);
         }
 
-        message.persist(persistErr => {
+        //
+        //  persistMessage() rather than message.persist(): the latter does not
+        //  record the message with the message network modules, which is what
+        //  drives "@immediate" export. A system scheduling export as
+        //  "@immediate" alone would otherwise queue this request and never
+        //  send it.
+        //
+        const { persistMessage } = require('../message_area.js');
+        persistMessage(message, persistErr => {
             if (persistErr) {
                 Log.warn(
                     { networkName, error: persistErr.message },

--- a/core/scanner_tossers/ftn_bso.js
+++ b/core/scanner_tossers/ftn_bso.js
@@ -39,6 +39,7 @@ const {
     validateOutboundConfig,
 } = require('../bso_util.js');
 const autoAreaCreate = require('../auto_area_create.js');
+const areaInfoPack = require('../area_info_pack.js');
 const { AreaFixStatus, parseAreaFixReply } = require('../areafix_reply.js');
 
 //  deps
@@ -4012,23 +4013,33 @@ FTNMessageScanTossModule.prototype.performImport = function (cb) {
             //  skipped exactly as they were before.
             //
             self.maybeAutoCreateAreas(() => {
-                async.each(
-                    ['inbound', 'secInbound'],
-                    (inboundType, nextDir) => {
-                        const importDir = self.moduleConfig.paths[inboundType];
-                        self.importFromDirectory(inboundType, importDir, err => {
-                            if (err) {
-                                Log.trace(
-                                    { importDir, error: err.message },
-                                    'Cannot perform FTN import for directory'
-                                );
-                            }
+                //
+                //  ...and pick up any new info pack, so areas created above
+                //  get their real names in the same cycle.  This queries the
+                //  file area rather than reacting to a TIC arrival, so a pack
+                //  that landed before the feature was enabled still counts and
+                //  a missed trigger is picked up next pass.  An unchanged pack
+                //  costs one file-area query.
+                //
+                areaInfoPack.ingestInfoPacks(() => {
+                    async.each(
+                        ['inbound', 'secInbound'],
+                        (inboundType, nextDir) => {
+                            const importDir = self.moduleConfig.paths[inboundType];
+                            self.importFromDirectory(inboundType, importDir, err => {
+                                if (err) {
+                                    Log.trace(
+                                        { importDir, error: err.message },
+                                        'Cannot perform FTN import for directory'
+                                    );
+                                }
 
-                            return nextDir(null);
-                        });
-                    },
-                    done
-                );
+                                return nextDir(null);
+                            });
+                        },
+                        done
+                    );
+                });
             });
         },
         cb

--- a/core/scanner_tossers/ftn_bso.js
+++ b/core/scanner_tossers/ftn_bso.js
@@ -3,7 +3,13 @@
 
 //  ENiGMA½
 const MessageScanTossModule = require('../msg_scan_toss_module.js').MessageScanTossModule;
-const Config = require('../config.js').get;
+const configModule = require('../config.js');
+//  Look up configModule.get on each call rather than capturing it at load
+//  time. It is rebound when the Config bootstrapper runs, and swapped by
+//  tests; a load-time capture freezes whichever getter happened to be
+//  installed when this module was first required. Same reasoning as
+//  message_area.js.
+const Config = (...args) => configModule.get(...args);
 const Events = require('../events.js');
 const ftnMailPacket = require('../ftn_mail_packet.js');
 const ftnUtil = require('../ftn_util.js');
@@ -32,6 +38,8 @@ const {
     legacyOutboundDirName,
     validateOutboundConfig,
 } = require('../bso_util.js');
+const autoAreaCreate = require('../auto_area_create.js');
+const { AreaFixStatus, parseAreaFixReply } = require('../areafix_reply.js');
 
 //  deps
 const moment = require('moment');
@@ -1711,6 +1719,27 @@ function FTNMessageScanTossModule() {
                         return callback(err);
                     });
                 },
+                function maybeAreaFixReply(callback) {
+                    //
+                    //  A NetMail from an uplink's AreaFix robot answering a
+                    //  request we sent.  Never fatal to the import: this is
+                    //  reporting, and a failure here must not reject mail
+                    //  that has already been stored.
+                    //
+                    if (Message.WellKnownAreaTags.Private !== config.localAreaTag) {
+                        return callback(null);
+                    }
+
+                    try {
+                        return self.handleAreaFixReply(message, () => callback(null));
+                    } catch (e) {
+                        Log.warn(
+                            { error: e.message },
+                            'Failed handling possible AreaFix reply'
+                        );
+                        return callback(null);
+                    }
+                },
             ],
             err => {
                 cb(err);
@@ -1977,6 +2006,200 @@ function FTNMessageScanTossModule() {
         });
     };
 
+    //
+    //  ── Automatic area creation: pass 1 ──────────────────────────────────
+    //
+    //  Pass 1 finds FTN area tags in inbound mail that we have no local area
+    //  for, so pass 2 can import messages that would otherwise be skipped and
+    //  lost (see the unknown-area branch of importMessagesFromPacketFile).
+    //
+    //  It has to be new, genuinely read-only code.  The import path disposes
+    //  of its input as it goes: every tossed .pkt is archived and then
+    //  unlinked, and bundles are extracted, tossed and unlinked one at a time
+    //  so that a large backlog drains monotonically.  Running the real import
+    //  as pass 1 would destroy the mail before pass 2 could see it.  The cost
+    //  for bundles is a second archive extraction, paid only when the feature
+    //  is switched on.
+    //
+    this.collectUnknownAreaTagsFromPacket = function (packetPath, cb) {
+        let networkName;
+        const unknown = new Set();
+
+        new ftnMailPacket.Packet({ keepTearAndOrigin: false }).read(
+            packetPath,
+            (entryType, entryData, next) => {
+                if ('header' === entryType) {
+                    networkName = self.getNetworkNameByAddress(entryData.destAddress);
+                    if (!_.isString(networkName)) {
+                        //  not addressed to us; the import rejects it too
+                        return next(Errors.Invalid('Packet is not addressed to us'));
+                    }
+
+                    //
+                    //  Apply the same packet password check the import
+                    //  applies.  A packet whose messages will be rejected must
+                    //  not be able to create areas on its way past.
+                    //
+                    const originAddr = new Address(entryData.origAddress);
+                    const nodeConfig = _.find(
+                        self.moduleConfig.nodes,
+                        (node, addrWildcard) => originAddr.isPatternMatch(addrWildcard)
+                    );
+                    if (nodeConfig && nodeConfig.packetPassword) {
+                        const expected = nodeConfig.packetPassword.toUpperCase();
+                        const actual = (entryData.password || '').toUpperCase();
+                        if (expected !== actual) {
+                            return next(Errors.AccessDenied('Packet password mismatch'));
+                        }
+                    }
+
+                    return next(null);
+                }
+
+                if ('message' === entryType) {
+                    const ftnAreaTag = _.get(entryData, 'meta.FtnProperty.ftn_area');
+                    if (ftnAreaTag && !self.getLocalAreaTagByFtnAreaTag(ftnAreaTag)) {
+                        unknown.add(ftnAreaTag.toUpperCase());
+                    }
+                }
+
+                return next(null);
+            },
+            err => {
+                if (err) {
+                    Log.debug(
+                        { path: packetPath, error: err.message },
+                        'Unknown area scan skipped packet'
+                    );
+                    return cb(null, null);
+                }
+                return cb(null, { networkName, ftnTags: Array.from(unknown) });
+            }
+        );
+    };
+
+    this.collectUnknownAreaTagsFromPacketDir = function (dir, collected, cb) {
+        fs.readdir(dir, (err, files) => {
+            if (err) {
+                return cb(null);
+            }
+
+            const packetFiles = files.filter(
+                f => '.pkt' === paths.extname(f).toLowerCase()
+            );
+
+            async.eachSeries(
+                packetFiles,
+                (packetFile, nextFile) => {
+                    self.collectUnknownAreaTagsFromPacket(
+                        paths.join(dir, packetFile),
+                        (scanErr, info) => {
+                            if (info && info.ftnTags.length > 0) {
+                                const set =
+                                    collected[info.networkName] ||
+                                    (collected[info.networkName] = new Set());
+                                info.ftnTags.forEach(t => set.add(t));
+                            }
+                            return nextFile(null);
+                        }
+                    );
+                },
+                () => cb(null)
+            );
+        });
+    };
+
+    //  Remove everything the scan extracted; the source bundles are untouched
+    this.emptyScanTempDir = function (cb) {
+        if (!_.isString(self.scanTempDir)) {
+            return cb(null);
+        }
+
+        fs.readdir(self.scanTempDir, (err, files) => {
+            if (err) {
+                return cb(null);
+            }
+            async.each(
+                files,
+                (f, next) =>
+                    fse.remove(paths.join(self.scanTempDir, f), () => next(null)),
+                () => cb(null)
+            );
+        });
+    };
+
+    this.collectUnknownAreaTagsFromDirectory = function (importDir, collected, cb) {
+        async.series(
+            [
+                callback =>
+                    self.collectUnknownAreaTagsFromPacketDir(
+                        importDir,
+                        collected,
+                        callback
+                    ),
+                callback => {
+                    if (!_.isString(self.scanTempDir)) {
+                        return callback(null);
+                    }
+
+                    fs.readdir(importDir, (err, files) => {
+                        if (err) {
+                            return callback(null);
+                        }
+
+                        const bundleRegExp = /\.(su|mo|tu|we|th|fr|sa)[0-9a-z]/i;
+                        const bundles = files.filter(f =>
+                            bundleRegExp.test(paths.extname(f))
+                        );
+
+                        async.eachSeries(
+                            bundles,
+                            (file, nextFile) => {
+                                const fullPath = paths.join(importDir, file);
+                                self.archUtil.detectType(fullPath, (err, archName) => {
+                                    if (undefined === archName) {
+                                        return nextFile(null);
+                                    }
+
+                                    self.archUtil.extractTo(
+                                        fullPath,
+                                        self.scanTempDir,
+                                        archName,
+                                        extractErr => {
+                                            if (extractErr) {
+                                                Log.debug(
+                                                    {
+                                                        path: fullPath,
+                                                        error: extractErr.message,
+                                                    },
+                                                    'Unknown area scan could not extract bundle'
+                                                );
+                                                return self.emptyScanTempDir(() =>
+                                                    nextFile(null)
+                                                );
+                                            }
+
+                                            self.collectUnknownAreaTagsFromPacketDir(
+                                                self.scanTempDir,
+                                                collected,
+                                                () =>
+                                                    self.emptyScanTempDir(() =>
+                                                        nextFile(null)
+                                                    )
+                                            );
+                                        }
+                                    );
+                                });
+                            },
+                            () => callback(null)
+                        );
+                    });
+                },
+            ],
+            () => cb(null)
+        );
+    };
+
     this.importPacketFilesFromDirectory = function (importDir, password, cb) {
         async.waterfall(
             [
@@ -2218,8 +2441,19 @@ function FTNMessageScanTossModule() {
 
             temptmp.mkdir({ prefix: 'enigftnimport-' }, (err, tempDir) => {
                 self.importTempDir = tempDir;
+                if (err) {
+                    return cb(err);
+                }
 
-                cb(err);
+                //  Kept separate from importTempDir: the read-only area scan
+                //  extracts bundles here and deletes what it extracted, while
+                //  the import path unlinks packets out of its own directory as
+                //  it tosses them.  Sharing one would have each removing the
+                //  other's work.
+                temptmp.mkdir({ prefix: 'enigftnareascan-' }, (err, tempDir) => {
+                    self.scanTempDir = tempDir;
+                    cb(err);
+                });
             });
         });
     };
@@ -2987,6 +3221,9 @@ FTNMessageScanTossModule.prototype.startup = function (cb) {
             this.moduleConfig = config.scannerTossers.ftn_bso;
         }
 
+        //  so a fixed auto-areas include is noticed rather than staying quiet
+        this._autoAreaIncludeWarned = false;
+
         //  ...and re-check what the new config says about the outbound spool:
         //  a reload can introduce a bad defaultNetwork, or move the default
         //  network and leave mail behind in the previous directory.
@@ -3273,6 +3510,490 @@ function sweepOrphanBsyFiles(dirs) {
 const IMPORT_WATCHDOG_MS = 5 * 60 * 1000;
 const EXPORT_WATCHDOG_MS = 10 * 60 * 1000;
 
+//
+//  ── Automatic area creation ──────────────────────────────────────────────
+//
+//  Two-pass toss.  At the unknown-area branch of the import a message is
+//  skipped and the packet then disposed of, so "skipped" means lost.  Rather
+//  than create inline -- which would mean writing config, reloading and
+//  re-resolving inside the packet loop, with everything already iterated past
+//  still lost -- the inbound directories are scanned read-only first, the
+//  areas created, and the import then run normally.
+//
+FTNMessageScanTossModule.prototype.maybeAutoCreateAreas = function (cb) {
+    const self = this;
+
+    const networkNames = autoAreaCreate.onDemandNetworkNames();
+    if (0 === networkNames.length) {
+        return cb(null); //  feature off: no scan, no cost
+    }
+
+    const includeState = autoAreaCreate.getGeneratedIncludeState();
+    if (!includeState.included) {
+        //
+        //  Warn once rather than every cycle.  The flag is cleared on
+        //  ConfigChanged so fixing it is noticed.
+        //
+        if (!self._autoAreaIncludeWarned) {
+            self._autoAreaIncludeWarned = true;
+            Log.warn(
+                {
+                    networks: networkNames,
+                    expected: includeState.path,
+                },
+                `Automatic area creation is enabled but "${autoAreaCreate.GeneratedIncludeFileName}" is not included from config.hjson; run "oputil.js mb auto-areas init"`
+            );
+        }
+        return cb(null);
+    }
+
+    const collected = {};
+
+    async.eachSeries(
+        ['inbound', 'secInbound'],
+        (inboundType, nextDir) => {
+            const importDir = self.moduleConfig.paths[inboundType];
+            if (!_.isString(importDir)) {
+                return nextDir(null);
+            }
+            self.collectUnknownAreaTagsFromDirectory(importDir, collected, () =>
+                nextDir(null)
+            );
+        },
+        () => {
+            const wanted = networkNames.filter(
+                n => collected[n] && collected[n].size > 0
+            );
+            if (0 === wanted.length) {
+                return cb(null);
+            }
+
+            async.eachSeries(
+                wanted,
+                (networkName, nextNetwork) => {
+                    const ftnTags = Array.from(collected[networkName]);
+
+                    autoAreaCreate.createAreas(networkName, ftnTags, (err, result) => {
+                        if (err) {
+                            Log.error(
+                                { networkName, error: err.message },
+                                'Automatic message area creation failed'
+                            );
+                            return nextNetwork(null);
+                        }
+
+                        self.reportAutoCreatedAreas(networkName, result, () =>
+                            nextNetwork(null)
+                        );
+                    });
+                },
+                () => cb(null)
+            );
+        }
+    );
+};
+
+//  Log what happened, tell the operator once per batch, and optionally ask
+//  the uplink to rescan.
+FTNMessageScanTossModule.prototype.reportAutoCreatedAreas = function (
+    networkName,
+    result,
+    cb
+) {
+    const self = this;
+
+    if (result.pruned.length > 0) {
+        Log.info(
+            { networkName, areaTags: result.pruned },
+            `Removed ${result.pruned.length} automatically created area(s) now in the ignore list`
+        );
+    }
+
+    result.rejected.forEach(r => {
+        Log.warn(
+            { networkName, ftnTag: r.ftnTag, areaTag: r.areaTag, reason: r.reason },
+            `Refused to automatically create "${r.ftnTag}": ${r.reason}`
+        );
+    });
+
+    if (0 === result.created.length) {
+        return cb(null);
+    }
+
+    Log.info(
+        { networkName, areas: result.created.map(c => c.areaTag) },
+        `Automatically created ${result.created.length} message area(s) for "${networkName}"`
+    );
+
+    async.series(
+        [
+            callback => self.notifyOpOfAutoCreatedAreas(networkName, result, callback),
+            callback => self.maybeRequestAreaFixRescan(networkName, result, callback),
+        ],
+        () => cb(null)
+    );
+};
+
+//  One netmail to the operator per batch, not per area: a first pull that
+//  creates 300 areas should be one message.
+FTNMessageScanTossModule.prototype.notifyOpOfAutoCreatedAreas = function (
+    networkName,
+    result,
+    cb
+) {
+    const lines = [
+        `${result.created.length} message area(s) were automatically created for the`,
+        `"${networkName}" network after EchoMail arrived for area tags that were not`,
+        'configured:',
+        '',
+    ];
+
+    result.created.forEach(c => {
+        lines.push(`  ${c.ftnTag}  ->  ${c.areaTag}`);
+    });
+
+    lines.push('');
+    lines.push(
+        'These areas are read-only: they have no uplinks, so nothing is exported,'
+    );
+    lines.push(
+        'and they carry a write-deny ACS so nothing can be posted into them either.'
+    );
+    lines.push('');
+    lines.push(
+        `They are defined in ${autoAreaCreate.GeneratedIncludeFileName}. To adopt one,`
+    );
+    lines.push(
+        'define it in config.hjson with your own uplinks and acs -- config.hjson wins'
+    );
+    lines.push('over the generated file. To make one go away, add its FTN tag to the');
+    lines.push(`"autoAreas.ignore" list for "${networkName}".`);
+
+    if (result.rejected.length > 0) {
+        lines.push('');
+        lines.push('The following were NOT created:');
+        result.rejected.forEach(r => {
+            lines.push(`  ${r.ftnTag}: ${r.reason}`);
+        });
+    }
+
+    const message = new Message({
+        toUserName: StatLog.getSystemStat(SysProps.SysOpUsername) || 'SysOp',
+        fromUserName: 'ENiGMA½',
+        subject: `${result.created.length} message area(s) automatically created`,
+        message: lines.join('\r\n'),
+        areaTag: Message.WellKnownAreaTags.Private,
+    });
+    message.setLocalToUserId(User.RootUserID);
+
+    message.persist(err => {
+        if (err) {
+            Log.warn(
+                { error: err.message },
+                'Failed to notify the operator of automatically created areas'
+            );
+        }
+        return cb(null);
+    });
+};
+
+//
+//  ── AreaFix rescan ───────────────────────────────────────────────────────
+//
+//  Off by default, and the command has no default form.
+//
+//  FSC-0057's own "=TAG R=n" is spec correct but not portable: Mystic (what
+//  the fsxNet hubs run) and CrashMail II implement '=', while husky and
+//  SBBSecho do not.  Against husky, "=TAG, R=n" falls through to a subscribe
+//  of a garbage tag and, on a hub with forwardRequests, may be sent upstream
+//  as a *new area* request.  There is no safe universal syntax, so the
+//  operator states the one their uplink speaks or no request is sent.
+//
+FTNMessageScanTossModule.prototype.maybeRequestAreaFixRescan = function (
+    networkName,
+    result,
+    cb
+) {
+    const self = this;
+
+    const autoConfig = autoAreaCreate.getAutoAreasConfig(networkName);
+    const onDemand = _.get(autoConfig, 'onDemand', {});
+
+    if (true !== onDemand.rescan) {
+        return cb(null);
+    }
+
+    const uplink = Address.fromString(onDemand.rescanUplink || '');
+    if (!uplink) {
+        Log.warn(
+            { networkName, rescanUplink: onDemand.rescanUplink },
+            'autoAreas rescan is enabled but "rescanUplink" is missing or not a valid FTN address'
+        );
+        return cb(null);
+    }
+
+    const commandTemplate = onDemand.rescanCommand;
+    if (!_.isString(commandTemplate) || 0 === commandTemplate.length) {
+        Log.warn(
+            { networkName },
+            'autoAreas rescan is enabled but "rescanCommand" is not set; AreaFix rescan syntax differs per uplink and has no safe default'
+        );
+        return cb(null);
+    }
+
+    const days = _.isNumber(onDemand.rescanDays) ? onDemand.rescanDays : 0;
+
+    const body =
+        result.created
+            .map(c =>
+                commandTemplate
+                    .replace(/%TAG%/g, c.ftnTag)
+                    .replace(/%DAYS%/g, String(days))
+            )
+            .join('\r\n') + '\r\n';
+
+    const toUserName = onDemand.rescanTo || 'AreaFix';
+
+    User.getUserName(User.RootUserID, (err, fromName) => {
+        const message = new Message({
+            toUserName,
+            fromUserName: fromName || 'SysOp',
+            subject: onDemand.rescanPassword || '',
+            message: body,
+            areaTag: Message.WellKnownAreaTags.Private,
+            meta: {
+                System: {
+                    [Message.SystemMetaNames.RemoteToUser]: uplink.toString(),
+                    [Message.SystemMetaNames.ExternalFlavor]: Message.AddressFlavor.FTN,
+                },
+            },
+        });
+
+        if (!err) {
+            message.setLocalFromUserId(User.RootUserID);
+        }
+
+        message.persist(persistErr => {
+            if (persistErr) {
+                Log.warn(
+                    { networkName, error: persistErr.message },
+                    'Failed to queue AreaFix rescan request'
+                );
+                return cb(null);
+            }
+
+            Log.info(
+                {
+                    networkName,
+                    uplink: uplink.toString(),
+                    areas: result.created.map(c => c.ftnTag),
+                },
+                `Queued AreaFix rescan request for ${result.created.length} area(s)`
+            );
+
+            self.recordPendingAreaFixRequests(
+                uplink.toString(),
+                networkName,
+                toUserName,
+                result.created.map(c => c.ftnTag)
+            );
+
+            return cb(null);
+        });
+    });
+};
+
+//
+//  ── AreaFix replies ──────────────────────────────────────────────────────
+//
+//  Only replies correlated to a request we actually sent are read, and only
+//  lines naming a tag we asked about are considered.  Nothing parsed here can
+//  reach config.hjson: the parser's return type is a status, so the worst a
+//  mis-parse produces is a wrong log line.
+//
+const AreaFixPendingMaxAgeDays = 14;
+
+FTNMessageScanTossModule.prototype.getPendingAreaFixRequests = function () {
+    const raw = StatLog.getSystemStat(SysProps.FtnAreaFixPending);
+    if (!raw) {
+        return {};
+    }
+
+    let pending;
+    try {
+        pending = _.isString(raw) ? JSON.parse(raw) : raw;
+    } catch (e) {
+        Log.warn({ error: e.message }, 'Could not parse pending AreaFix requests');
+        return {};
+    }
+
+    if (!_.isObject(pending)) {
+        return {};
+    }
+
+    //  drop anything too old to still be an answer to us
+    const cutoff = moment().subtract(AreaFixPendingMaxAgeDays, 'days');
+    _.forEach(pending, (entry, address) => {
+        _.forEach(_.get(entry, 'tags', {}), (info, tag) => {
+            if (!info.timestamp || moment(info.timestamp).isBefore(cutoff)) {
+                delete entry.tags[tag];
+            }
+        });
+        if (0 === Object.keys(_.get(entry, 'tags', {})).length) {
+            delete pending[address];
+        }
+    });
+
+    return pending;
+};
+
+FTNMessageScanTossModule.prototype.setPendingAreaFixRequests = function (pending) {
+    StatLog.setSystemStat(SysProps.FtnAreaFixPending, JSON.stringify(pending));
+};
+
+FTNMessageScanTossModule.prototype.recordPendingAreaFixRequests = function (
+    address,
+    networkName,
+    toUserName,
+    ftnTags
+) {
+    const pending = this.getPendingAreaFixRequests();
+    const entry = pending[address] || (pending[address] = { tags: {} });
+
+    entry.network = networkName;
+    entry.toUserName = toUserName;
+    entry.tags = entry.tags || {};
+
+    const timestamp = moment().toISOString();
+    ftnTags.forEach(tag => {
+        entry.tags[tag.toUpperCase()] = { action: 'rescan', timestamp };
+    });
+
+    this.setPendingAreaFixRequests(pending);
+};
+
+//  Robot usernames these replies arrive from; also reserved in config_default
+const AreaFixRobotNames = [
+    'areafix',
+    'areamgr',
+    'allfix',
+    'filefix',
+    'filemgr',
+    'echomail',
+];
+
+FTNMessageScanTossModule.prototype.handleAreaFixReply = function (message, cb) {
+    const self = this;
+
+    const remoteFrom = _.get(message, [
+        'meta',
+        'System',
+        Message.SystemMetaNames.RemoteFromUser,
+    ]);
+    if (!remoteFrom) {
+        return cb(null);
+    }
+
+    const pending = self.getPendingAreaFixRequests();
+    const entry = pending[remoteFrom];
+    const tags = Object.keys(_.get(entry, 'tags', {}));
+    if (0 === tags.length) {
+        return cb(null);
+    }
+
+    //  ...and from the robot we addressed, not just from that system
+    const expectedNames = new Set(
+        AreaFixRobotNames.concat([String(entry.toUserName || '').toLowerCase()])
+    );
+    const fromName = String(message.fromUserName || '').toLowerCase();
+    if (!expectedNames.has(fromName)) {
+        return cb(null);
+    }
+
+    const { results, unknownCount } = parseAreaFixReply(message.message, {
+        tags,
+        extraPhrases: _.get(Config(), 'messageNetworks.ftn.areaFixStatusPhrases'),
+    });
+
+    if (0 === results.length) {
+        Log.info(
+            { uplink: remoteFrom, pending: tags },
+            'AreaFix reply received but nothing in it matched the areas we asked about; read the NetMail'
+        );
+        return cb(null);
+    }
+
+    results.forEach(r => {
+        const logInfo = {
+            uplink: remoteFrom,
+            network: entry.network,
+            areaTag: r.tag,
+            status: r.status,
+            raw: r.raw,
+        };
+        if (AreaFixStatus.Unknown === r.status) {
+            Log.warn(logInfo, `AreaFix reply for "${r.tag}" was not understood`);
+        } else {
+            Log.info(logInfo, `AreaFix reply for "${r.tag}": ${r.status}`);
+        }
+    });
+
+    //  answered tags stop being pending regardless of the answer
+    results.forEach(r => delete entry.tags[r.tag]);
+    if (0 === Object.keys(entry.tags).length) {
+        delete pending[remoteFrom];
+    }
+    self.setPendingAreaFixRequests(pending);
+
+    return self.notifyOpOfAreaFixReply(remoteFrom, entry, results, unknownCount, cb);
+};
+
+FTNMessageScanTossModule.prototype.notifyOpOfAreaFixReply = function (
+    address,
+    entry,
+    results,
+    unknownCount,
+    cb
+) {
+    const lines = [`The AreaFix robot at ${address} answered a request we sent:`, ''];
+
+    results.forEach(r => {
+        lines.push(`  ${r.tag}: ${r.status}`);
+        if (AreaFixStatus.Unknown === r.status) {
+            lines.push(`    (not understood) ${r.raw}`);
+        }
+    });
+
+    if (unknownCount > 0) {
+        lines.push('');
+        lines.push(
+            `${unknownCount} line(s) were not understood. AreaFix reply wording differs`
+        );
+        lines.push(
+            'between tossers; the raw NetMail from the robot has the full answer.'
+        );
+    }
+
+    const message = new Message({
+        toUserName: StatLog.getSystemStat(SysProps.SysOpUsername) || 'SysOp',
+        fromUserName: 'ENiGMA½',
+        subject: `AreaFix reply from ${address}`,
+        message: lines.join('\r\n'),
+        areaTag: Message.WellKnownAreaTags.Private,
+    });
+    message.setLocalToUserId(User.RootUserID);
+
+    message.persist(err => {
+        if (err) {
+            Log.warn(
+                { error: err.message },
+                'Failed to notify the operator of an AreaFix reply'
+            );
+        }
+        return cb(null);
+    });
+};
+
 FTNMessageScanTossModule.prototype.performImport = function (cb) {
     if (!this.hasValidConfiguration()) {
         return cb(Errors.MissingConfig('Invalid or missing configuration'));
@@ -3284,23 +4005,31 @@ FTNMessageScanTossModule.prototype.performImport = function (cb) {
         IMPORT_WATCHDOG_MS,
         'FTN import',
         done => {
-            async.each(
-                ['inbound', 'secInbound'],
-                (inboundType, nextDir) => {
-                    const importDir = self.moduleConfig.paths[inboundType];
-                    self.importFromDirectory(inboundType, importDir, err => {
-                        if (err) {
-                            Log.trace(
-                                { importDir, error: err.message },
-                                'Cannot perform FTN import for directory'
-                            );
-                        }
+            //
+            //  Pass 1: create areas for unknown FTN tags so pass 2 can import
+            //  their mail instead of skipping it.  A failure here is never
+            //  allowed to stop the import; the worst case is the messages are
+            //  skipped exactly as they were before.
+            //
+            self.maybeAutoCreateAreas(() => {
+                async.each(
+                    ['inbound', 'secInbound'],
+                    (inboundType, nextDir) => {
+                        const importDir = self.moduleConfig.paths[inboundType];
+                        self.importFromDirectory(inboundType, importDir, err => {
+                            if (err) {
+                                Log.trace(
+                                    { importDir, error: err.message },
+                                    'Cannot perform FTN import for directory'
+                                );
+                            }
 
-                        return nextDir(null);
-                    });
-                },
-                done
-            );
+                            return nextDir(null);
+                        });
+                    },
+                    done
+                );
+            });
         },
         cb
     );

--- a/core/system_property.js
+++ b/core/system_property.js
@@ -26,6 +26,10 @@ module.exports = {
     MessageTotalCount: 'message_post_total_count', //  total non-private messages on the system; non-persistent
     MessagesToday: 'message_post_today', //  non-private messages posted/imported today; non-persistent
 
+    //  JSON: { "<uplink FTN address>": { network, toUserName, tags: { TAG: { action, timestamp } } } }
+    //  AreaFix requests we have sent and are waiting on a reply for
+    FtnAreaFixPending: 'ftn_areafix_pending',
+
     SysOpUsername: 'sysop_username', //  non-persistent
     SysOpRealName: 'sysop_real_name', //  non-persistent
     SysOpLocation: 'sysop_location', //  non-persistent

--- a/core/system_property.js
+++ b/core/system_property.js
@@ -30,6 +30,9 @@ module.exports = {
     //  AreaFix requests we have sent and are waiting on a reply for
     FtnAreaFixPending: 'ftn_areafix_pending',
 
+    //  JSON: { "<network>": "<sha256>" } -- last info pack ingested per network
+    FtnInfoPackSha: 'ftn_info_pack_sha',
+
     SysOpUsername: 'sysop_username', //  non-persistent
     SysOpRealName: 'sysop_real_name', //  non-persistent
     SysOpLocation: 'sysop_location', //  non-persistent

--- a/docs/_docs/admin/oputil.md
+++ b/docs/_docs/admin/oputil.md
@@ -201,7 +201,8 @@ remove arguments:
 import-areas arguments:
   --type TYPE                  Sets import areas type
 
-  Valid types are are "zxx" or "na".
+  Valid types are are "zxx" or "na". This selects which file extensions are
+  accepted; the format itself is determined from the file's content.
 
   --create-dirs                Also create backing storage directories
 
@@ -273,6 +274,12 @@ file_sha1: 558fab3b49a8ac302486e023a3c2a86bd4e4b948
 
 ### Importing FileGate RAID Style Areas
 Given a FileGate "RAID" style `FILEGATE.ZXX` file, one can import areas. This format also often comes in FTN-style info packs in the form of a `.NA` file i.e.: `FILEBONE.NA`.
+
+The format is determined from the file's **content**, so a `.na` file holding a FILEBONE list works regardless of what it is called. A handful of networks — ArakNet among them — instead ship their *file* echo list as a plain `TAG  Description` list, and those are now imported too rather than producing "Nothing to import".
+
+> :warning: A plain `TAG  Description` list is exactly the shape a **message** echo list uses, and nothing in the content distinguishes them. `import-areas` says so before the confirmation prompt; check the listed areas before answering yes, particularly with `--create-dirs`.
+
+A list in a format that cannot be recognised — including the reversed-column `Description … TAG` style one network ships — is refused with an explanation rather than partly imported.
 
 #### Example
 ```bash

--- a/docs/_docs/admin/oputil.md
+++ b/docs/_docs/admin/oputil.md
@@ -302,6 +302,11 @@ Actions:
 
   import-areas PATH           Import areas using FidoNet *.NA or AREAS.BBS file
 
+  auto-areas init             Prepare automatic message area creation: creates
+                              auto-areas.hjson and adds it to "includes" in
+                              config.hjson. Safe to re-run. The feature itself
+                              stays off until configured per network.
+
   qwk-dump PATH               Dumps a QWK packet to stdout.
   qwk-export [AREA_TAGS] PATH Exports one or more configured message area to a QWK
                               packet in the directory specified by PATH. The QWK
@@ -326,11 +331,14 @@ qwk-export arguments:
 | Action    | Description       | Examples                              |
 |-----------|-------------------|---------------------------------------|
 | `import-areas`    | Imports areas using a FidoNet style *.NA or AREAS.BBS formatted file. Optionally maps areas to FTN networks.  | `./oputil.js mb import-areas /some/path/l33tnet.na`   |
+| `auto-areas init` | One-time setup for [automatic area creation](../messageareas/ftn.md#automatic-area-creation) | `./oputil.js mb auto-areas init` |
 | `areafix` | Utility for sending AreaFix mails without logging into the system | |
 | `qwk-dump` | Dump a QWK packet to stdout | `./oputil.js mb qwk-dump /path/to/XIBALBA.QWK` |
 | `qwk-export` | Export messages to a QWK packet | `./oputil.js mb qwk-export /path/to/XIBALBA.QWK` |
 
 When using the `import-areas` action, you will be prompted for any missing additional arguments described in "import-areas args".
+
+The format of the supplied file is determined by its **content**, not its extension: several networks ship a FILEBONE *file* echo list named `*.na`, and at least one ships its list with the columns reversed. `import-areas` skips `;`, `%` and `#` comment lines, tells you which lines it could not use, and declines a file it does not recognise rather than importing nonsense. A FILEBONE list is recognised as such and pointed at [`fb import-areas`](#importing-filegate-raid-style-areas). `AREAS.BBS` cannot be told from a plain area list by shape, so it is only assumed when the file is named `.bbs` or `--type bbs` is given.
 
 ## FAT Disk Image Management
 The `fat` command lets you inspect and modify raw FAT disk images directly — no running ENiGMA instance or database required. Useful for preparing and maintaining FreeDOS images used by the `v86_door` module.

--- a/docs/_docs/messageareas/ftn.md
+++ b/docs/_docs/messageareas/ftn.md
@@ -102,5 +102,133 @@ Below is a more complete *example* illustrating some of the concepts above:
 
 > :information_source: Remember for a complete FTN experience, you'll probably also want to configure [FTN/BSO scanner/tosser](bso-import-export.md) settings.
 
+#### Automatic Area Creation
+EchoMail that arrives for an FTN area tag you have not configured is skipped and, because the packet is then removed, lost. ENiGMA½ can instead create those areas for you. **The feature is off unless you configure it**, and a system with no `autoAreas` block behaves exactly as it always has.
+
+##### Getting started
+Run this once:
+
+```bash
+./oputil.js mb auto-areas init
+```
+
+That creates `config/auto-areas.hjson` and adds it to `includes` in your `config.hjson`, **in that order** — a file listed in `includes` that does not exist stops the board from starting, so it must be created first. The command is safe to re-run.
+
+Automatically created areas are written to `auto-areas.hjson`, never to your `config.hjson`. Includes are merged such that **`config.hjson` always wins**, so that file can be rewritten on every pass without ever touching something you set by hand.
+
+##### Configuration
+Configured per network under `messageNetworks.ftn.networks.<network>.autoAreas`:
+
+```hjson
+{
+  messageNetworks: {
+    ftn: {
+      networks: {
+        fsxnet: {
+          defaultZone: 21
+          localAddress: "21:1/121"
+
+          autoAreas: {
+            //  conference new areas are placed in; must already exist
+            confTag: fsxnet
+
+            //  never create these, and remove them if already created
+            ignore: [ "FSX_BOT", "SOME.AREA" ]
+
+            //  cap on the TOTAL number ever created for this network
+            maxAutoCreate: 500
+
+            onDemand: {
+              //  create areas when EchoMail arrives for an unknown tag
+              enabled: true
+            }
+
+            infoPack: {
+              //  take real names and descriptions from the network info pack
+              enabled: true
+
+              //  file area the pack is TIC'd into, and how to spot it there
+              areaTag: fsxnet_info
+              match: "fsxnet*.zip"
+
+              //  the area list INSIDE the pack. Name it exactly: fsxNet also
+              //  ships fsx_file.na, which is a FILEBONE file echo list
+              areaFile: fsxnet.na
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+There is no parent `enabled` flag: the feature is on for a network if either `onDemand.enabled` or `infoPack.enabled` is set. Two flags that have to agree is a configuration bug waiting to happen.
+
+| Config Item     | Required | Description |
+|-----------------|----------|-------------|
+| `confTag`       | :+1:     | Message conference created areas are placed in. Must already exist; creation is refused otherwise |
+| `ignore`        |          | FTN tags never to create. Also **removes** ones already created, so this is how you un-create something |
+| `maxAutoCreate` |          | Cap on the total number of areas ever created for this network. Defaults to `500`. This is a total, not a per-run limit |
+
+##### Created areas are read-only
+An area created this way carries no `uplinks`, so nothing is ever exported from it. That alone is not read-only — a local user could still post into an area that looks live and goes nowhere — so it also gets `acs: { write: ID0 }`, which no user satisfies.
+
+To adopt an area, define it in your `config.hjson` under the same conference and area tag with your own `uplinks` and `acs`. Your `config.hjson` wins over the generated file, so the two coexist.
+
+Some tags are refused outright rather than merged, and the operator is told why:
+
+* A tag that would lower case onto a built-in area, such as `PRIVATE_MAIL` → `private_mail`
+* A tag already used by an area in **any** conference, or already carried by another network
+
+##### The info pack
+Networks distribute an "info pack" — an archive with the area list, nodelist and documentation — through a file echo, so it arrives by TIC like any other file. ENiGMA½ does not wait to be told about it; it looks in the file area you name. A pack that landed before you turned the feature on is picked up just the same, as is one you dropped in by hand and scanned with `oputil fb scan`.
+
+Its job is narrow: replace the placeholder name and description on areas you **already carry**. A pack lists what the *network* carries, not what *you are linked to*, so creating from it wholesale would leave you with hundreds of permanently empty areas. Set `createUnlinked: true` if you want that anyway.
+
+> :information_source: `areaFile` is an exact name for a reason. Most networks ship *two* `.na` files — one message echo list and one **file** echo list — and the extension does not tell them apart. Pointing at the wrong one gets you nothing; ENiGMA½ recognises a FILEBONE list and declines to take descriptions from it rather than importing nonsense.
+
+Some networks ship no machine-readable list at all. If the file cannot be recognised, you get a warning saying what it looked like instead, and your areas keep their tag-based names.
+
+##### AreaFix rescan
+Optionally, an AreaFix request can be sent to your uplink after an area is created, asking it to send the backlog. This is **off by default and has no default command**, because there is no portable syntax:
+
+| Uplink software | Working per-area rescan |
+|---|---|
+| Mystic, CrashMail II | `=TAG R=n` |
+| husky, SBBSecho | `%RESCAN TAG R=n` |
+
+FSC-0057 specifies `=TAG R=n`, but husky and SBBSecho do not implement `=`: they read it as a request to *add* an area with a garbage tag, and a husky hub with `forwardRequests` may pass that upstream. So you state the form your uplink speaks, or nothing is sent:
+
+```hjson
+onDemand: {
+  enabled: true
+  rescan: true
+  rescanUplink: "21:1/100"
+  rescanPassword: "YOURPASS"
+  rescanDays: 30
+
+  //  %TAG% and %DAYS% are substituted
+  rescanCommand: "=%TAG% R=%DAYS%"
+}
+```
+
+Replies from the uplink's AreaFix robot are matched against requests actually sent — by address, robot name, and a 14 day window — and only lines naming an area asked about are read. You get a NetMail summarising what the uplink said. Reply wording differs between tossers; anything not recognised is reported with the raw line rather than acted on, and you can teach it more:
+
+```hjson
+messageNetworks: {
+  ftn: {
+    areaFixStatusPhrases: {
+      "linked ok": added
+    }
+  }
+}
+```
+
+##### Removing an area
+Add its FTN tag to `ignore`. It is dropped from `auto-areas.hjson` on the next pass.
+
+Its messages are **not** deleted — they stay in the database keyed by area tag, invisible, and reappear if the tag is ever created again. A later re-link and rescan will dupe-drop rather than re-import that history, since the MSGID duplicate check is system wide.
+
 #### FTN/BSO Scanner Tosser
 Please see the [FTN/BSO Scanner/Tosser](bso-import-export.md) documentation for information on this area.

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
         "lint:fix": "eslint . --fix",
         "build:acs": "peggy --format commonjs -o core/acs_parser.js misc/acs_parser.pegjs",
         "prepare": "husky",
-        "test": "mocha 'test/**/*.test.js' --recursive --timeout 5000 --require test/setup.js --exit"
+        "test": "mocha 'test/**/*.test.js' --recursive --timeout 5000 --require test/setup.js --exit && npm run test:live",
+        "test:live": "mocha 'test/live/*.live.js' --timeout 30000 --require test/setup.js --exit"
     },
     "repository": {
         "type": "git",

--- a/test/area_import.test.js
+++ b/test/area_import.test.js
@@ -1,0 +1,349 @@
+'use strict';
+
+const { strict: assert } = require('assert');
+const fs = require('fs');
+const paths = require('path');
+
+const {
+    AreaListFormat,
+    parseAreaList,
+    sniffAreaListFormat,
+    isValidAreaTag,
+    validateUplinks,
+    localAreaTagFor,
+    buildAreaImportRecords,
+} = require('../core/area_import.js');
+
+const FixtureDir = paths.join(__dirname, 'fixtures', 'area_lists');
+
+const readFixture = name => fs.readFileSync(paths.join(FixtureDir, name), 'utf8');
+
+// ─── Format sniffing over real network info packs ────────────────────────────
+//
+//  Expected values are measured against the committed fixtures; see
+//  test/fixtures/area_lists/README.md for provenance and what each one shows.
+//
+describe('area_import: real network area lists', () => {
+    const cases = [
+        //  file                     format                    entries
+        ['fsxnet-2025.na', AreaListFormat.NA, 13],
+        ['fsxnet-2018.na', AreaListFormat.NA, 2],
+        ['retronet-msg.na', AreaListFormat.NA, 18],
+        ['dorenet-msg.na', AreaListFormat.NA, 15],
+        ['agoranet.na', AreaListFormat.NA, 10],
+        ['araknet-msg.na', AreaListFormat.NA, 9],
+        ['zer0net-msg.na', AreaListFormat.NA, 9],
+        //  file echo list shipped as plain "TAG DESC" -- the opposite convention
+        ['araknet-file.na', AreaListFormat.NA, 3],
+        //  ".na" extension, FILEBONE content
+        ['fsxnet-file-2025.na', AreaListFormat.FileBone, 10],
+        ['fsxnet-file-2018.na', AreaListFormat.FileBone, 8],
+        ['agoranet-file.na', AreaListFormat.FileBone, 6],
+        ['zer0net-file.na', AreaListFormat.FileBone, 3],
+        //  reversed columns: recognized, deliberately not parsed
+        ['spooknet-baselist.txt', AreaListFormat.DescFirst, 0],
+    ];
+
+    cases.forEach(([fixture, expectFormat, expectCount]) => {
+        it(`${fixture} -> ${expectFormat} (${expectCount} entries)`, () => {
+            const result = parseAreaList(readFixture(fixture));
+            assert.equal(result.format, expectFormat);
+            assert.equal(result.entries.length, expectCount);
+        });
+    });
+
+    it('never emits a comment character as an area tag (#733)', () => {
+        //  Before the shared parser, a leading ';' or '%' line produced an
+        //  entry whose tag was the comment character itself.
+        fs.readdirSync(FixtureDir)
+            .filter(f => f !== 'README.md')
+            .forEach(f => {
+                const result = parseAreaList(readFixture(f));
+                result.entries.forEach(entry => {
+                    assert.ok(
+                        isValidAreaTag(entry.ftnTag),
+                        `${f}: bad tag "${entry.ftnTag}"`
+                    );
+                    assert.ok(
+                        ![';', '%', '#'].includes(entry.ftnTag),
+                        `${f}: comment char imported as an area tag`
+                    );
+                });
+            });
+    });
+
+    it('never emits "Area" as an area tag from a FILEBONE list (#733)', () => {
+        ['fsxnet-file-2025.na', 'fsxnet-file-2018.na', 'agoranet-file.na'].forEach(f => {
+            const result = parseAreaList(readFixture(f));
+            result.entries.forEach(entry => {
+                assert.notEqual(entry.ftnTag.toLowerCase(), 'area');
+            });
+        });
+    });
+});
+
+// ─── Comment handling ────────────────────────────────────────────────────────
+
+describe('area_import: comment stripping', () => {
+    it("strips ';' comments", () => {
+        const result = parseAreaList(
+            [
+                '; ==========================',
+                ';  FSXNet Echo List',
+                '; ==========================',
+                'FSX_GEN              General Chat',
+            ].join('\n')
+        );
+        assert.equal(result.format, AreaListFormat.NA);
+        assert.deepEqual(
+            result.entries.map(e => e.ftnTag),
+            ['FSX_GEN']
+        );
+        assert.equal(result.stats.commentLines, 3);
+    });
+
+    it("strips '%' comments -- fsxNet used these before switching to ';'", () => {
+        const result = parseAreaList(
+            ['% Agoranet Echo List', '%', 'AGN_GEN              General Chat'].join('\n')
+        );
+        assert.equal(result.format, AreaListFormat.NA);
+        assert.deepEqual(
+            result.entries.map(e => e.ftnTag),
+            ['AGN_GEN']
+        );
+        assert.equal(result.stats.commentLines, 2);
+    });
+
+    it("strips '#' comments", () => {
+        const result = parseAreaList('# a comment\nFSX_GEN  General Chat');
+        assert.deepEqual(
+            result.entries.map(e => e.ftnTag),
+            ['FSX_GEN']
+        );
+    });
+
+    it('treats an indented comment character as a comment', () => {
+        const result = parseAreaList('    ; indented\nFSX_GEN  General Chat');
+        assert.equal(result.entries.length, 1);
+        assert.equal(result.stats.commentLines, 1);
+    });
+
+    it('does not strip a comment character mid-line', () => {
+        const result = parseAreaList('FSX_GEN  Chat; and more');
+        assert.equal(result.entries[0].name, 'Chat; and more');
+    });
+});
+
+// ─── Whitespace / line ending tolerance ──────────────────────────────────────
+
+describe('area_import: separator and line ending tolerance', () => {
+    it('accepts tabs as separators', () => {
+        const result = parseAreaList('ARK_CYBER\t\t\t\t  Araknet: Cyber Culture');
+        assert.equal(result.entries[0].ftnTag, 'ARK_CYBER');
+        assert.equal(result.entries[0].name, 'Araknet: Cyber Culture');
+    });
+
+    it('accepts CRLF line endings and trailing whitespace', () => {
+        const result = parseAreaList('FSX_GEN  General Chat   \r\nFSX_BBS  BBS Dev\r\n');
+        assert.equal(result.entries.length, 2);
+        assert.equal(result.entries[0].name, 'General Chat');
+    });
+
+    it('accepts a missing final newline', () => {
+        const result = parseAreaList('FSX_GEN  General Chat\nFSX_BBS  BBS Dev');
+        assert.equal(result.entries.length, 2);
+        assert.equal(result.entries[1].ftnTag, 'FSX_BBS');
+    });
+
+    it('accepts bare CR line endings', () => {
+        const result = parseAreaList('FSX_GEN  General Chat\rFSX_BBS  BBS Dev');
+        assert.equal(result.entries.length, 2);
+    });
+
+    it('strips a leading BOM rather than corrupting the first tag', () => {
+        const result = parseAreaList('﻿FSX_GEN  General Chat');
+        assert.equal(result.entries[0].ftnTag, 'FSX_GEN');
+    });
+});
+
+// ─── Refuse to guess ─────────────────────────────────────────────────────────
+
+describe('area_import: refuses rather than guessing', () => {
+    it('reports reversed columns instead of importing 35 wrong entries', () => {
+        const result = parseAreaList(readFixture('spooknet-baselist.txt'));
+        assert.equal(result.format, AreaListFormat.DescFirst);
+        assert.equal(result.entries.length, 0);
+        //  every data line accounted for, none silently dropped
+        assert.equal(result.skipped.length, result.stats.dataLines);
+    });
+
+    it('rejects English prose as an unrecognized format', () => {
+        //  HappyNet ships its area list this way; there is nothing to parse
+        const result = parseAreaList(
+            [
+                'Welcome to the network! The following echos are carried by all',
+                'systems. Please ask your uplink to connect you to the ones you',
+                'would like to receive on your board.',
+            ].join('\n')
+        );
+        assert.equal(result.format, AreaListFormat.Unknown);
+        assert.equal(result.entries.length, 0);
+    });
+
+    it('returns unknown for a file that is only comments', () => {
+        const result = parseAreaList('; nothing here\n;\n');
+        assert.equal(result.format, AreaListFormat.Unknown);
+        assert.equal(result.entries.length, 0);
+    });
+
+    it('returns unknown for an empty file', () => {
+        const result = parseAreaList('');
+        assert.equal(result.format, AreaListFormat.Unknown);
+        assert.equal(result.entries.length, 0);
+    });
+
+    it('prefers a normal list when both columns look tag-shaped', () => {
+        //  all-upper-case descriptions must not read as reversed columns
+        const result = parseAreaList('FSX_GEN  GENERAL\nFSX_BBS  SUPPORT');
+        assert.equal(result.format, AreaListFormat.NA);
+        assert.deepEqual(
+            result.entries.map(e => e.ftnTag),
+            ['FSX_GEN', 'FSX_BBS']
+        );
+    });
+
+    it('skips a stray FILEBONE line inside an otherwise plain list', () => {
+        const result = parseAreaList(
+            [
+                'FSX_GEN  General Chat',
+                'FSX_BBS  BBS Dev',
+                'FSX_MYS  Mystic Support',
+                'Area FSX_NODE  0  !  Weekly Nodelist',
+            ].join('\n')
+        );
+        assert.equal(result.format, AreaListFormat.NA);
+        assert.deepEqual(
+            result.entries.map(e => e.ftnTag),
+            ['FSX_GEN', 'FSX_BBS', 'FSX_MYS']
+        );
+        assert.equal(result.skipped.length, 1);
+    });
+
+    it('skips a line with a tag but no description', () => {
+        const result = parseAreaList('FSX_GEN  General Chat\nFSX_BBS');
+        assert.equal(result.entries.length, 1);
+        assert.equal(result.skipped.length, 1);
+        assert.equal(result.skipped[0].lineNumber, 2);
+    });
+});
+
+// ─── AREAS.BBS ───────────────────────────────────────────────────────────────
+
+describe('area_import: AREAS.BBS', () => {
+    const parseBbs = data => parseAreaList(data, { format: AreaListFormat.AreasBbs });
+
+    it('takes the second token as the tag and the rest as uplinks', () => {
+        const result = parseBbs('/path/to/area  FSX_GEN  21:1/100 21:1/101');
+        assert.equal(result.entries.length, 1);
+        assert.equal(result.entries[0].ftnTag, 'FSX_GEN');
+        assert.deepEqual(result.entries[0].uplinks, ['21:1/100', '21:1/101']);
+        assert.equal(result.entries[0].name, 'Area: FSX_GEN');
+    });
+
+    it('accepts comma separated uplinks', () => {
+        const result = parseBbs('CODE FSX_GEN 21:1/100,21:1/101');
+        assert.deepEqual(result.entries[0].uplinks, ['21:1/100', '21:1/101']);
+    });
+
+    it('strips comments here too', () => {
+        const result = parseBbs('; AREAS.BBS\nCODE FSX_GEN 21:1/100');
+        assert.equal(result.entries.length, 1);
+    });
+
+    it('is never chosen by sniffing', () => {
+        //  cannot be told from a plain area list by shape; must be asked for
+        const { format } = sniffAreaListFormat('CODE FSX_GEN 21:1/100');
+        assert.notEqual(format, AreaListFormat.AreasBbs);
+    });
+});
+
+// ─── Tag validation ──────────────────────────────────────────────────────────
+
+describe('area_import: area tag validation', () => {
+    [
+        ['FSX_GEN', true],
+        ['DN-ADMI', true],
+        ['0N-BBS', true],
+        ['SOME.AREA', true],
+        ['netmail', true], //  lower case is accepted; tags compare case-insensitively
+        [';', false],
+        ['%', false],
+        ['Aliens,', false],
+        ['[ADMIN]', false],
+        ['--------', false],
+        ['has space', false],
+        ['', false],
+        ['A'.repeat(65), false],
+    ].forEach(([tag, expected]) => {
+        it(`${JSON.stringify(tag)} -> ${expected}`, () => {
+            assert.equal(isValidAreaTag(tag), expected);
+        });
+    });
+});
+
+// ─── Record building / uplink validation ─────────────────────────────────────
+
+describe('area_import: record builders', () => {
+    it('lower cases the FTN tag for the local area tag', () => {
+        assert.equal(localAreaTagFor('FSX_GEN'), 'fsx_gen');
+    });
+
+    it('builds conference and FTN network records', () => {
+        const entries = [{ ftnTag: 'FSX_GEN', name: 'General Chat' }];
+        const records = buildAreaImportRecords(entries, {
+            confTag: 'fsxnet',
+            networkName: 'fsxnet',
+            uplinks: ['21:1/100'],
+        });
+
+        assert.deepEqual(records.messageConferences.fsxnet.areas.fsx_gen, {
+            name: 'General Chat',
+            desc: 'General Chat',
+        });
+        assert.deepEqual(records.messageNetworks.ftn.areas.fsx_gen, {
+            network: 'fsxnet',
+            tag: 'FSX_GEN',
+            uplinks: ['21:1/100'],
+        });
+    });
+
+    it('prefers per-entry uplinks (AREAS.BBS) over the fallback', () => {
+        const entries = [
+            { ftnTag: 'FSX_GEN', name: 'General', uplinks: ['21:1/101'] },
+            { ftnTag: 'FSX_BBS', name: 'BBS' },
+        ];
+        const records = buildAreaImportRecords(entries, {
+            confTag: 'fsxnet',
+            networkName: 'fsxnet',
+            uplinks: ['21:1/100'],
+        });
+        assert.deepEqual(records.messageNetworks.ftn.areas.fsx_gen.uplinks, ['21:1/101']);
+        assert.deepEqual(records.messageNetworks.ftn.areas.fsx_bbs.uplinks, ['21:1/100']);
+    });
+
+    it('omits FTN network records when no network is given', () => {
+        const records = buildAreaImportRecords([{ ftnTag: 'LOCAL', name: 'Local' }], {
+            confTag: 'local',
+        });
+        assert.deepEqual(records.messageNetworks.ftn.areas, {});
+        assert.ok(records.messageConferences.local.areas.local);
+    });
+
+    it('validates uplinks as FTN addresses', () => {
+        assert.equal(validateUplinks(['21:1/100']), true);
+        assert.equal(validateUplinks(['21:1/100', '21:1/101.1']), true);
+        assert.equal(validateUplinks(['not-an-address']), false);
+        assert.equal(validateUplinks([]), false);
+        assert.equal(validateUplinks('21:1/100'), false);
+    });
+});

--- a/test/area_import.test.js
+++ b/test/area_import.test.js
@@ -12,6 +12,7 @@ const {
     validateUplinks,
     localAreaTagFor,
     buildAreaImportRecords,
+    buildFileAreaImportRecords,
 } = require('../core/area_import.js');
 
 const FixtureDir = paths.join(__dirname, 'fixtures', 'area_lists');
@@ -345,5 +346,83 @@ describe('area_import: record builders', () => {
         assert.equal(validateUplinks(['not-an-address']), false);
         assert.equal(validateUplinks([]), false);
         assert.equal(validateUplinks('21:1/100'), false);
+    });
+});
+
+// ─── File base area records ──────────────────────────────────────────────────
+
+describe('area_import: file base record builder', () => {
+    const build = fixture =>
+        buildFileAreaImportRecords(parseAreaList(readFixture(fixture)).entries);
+
+    it('builds the same records the FileGate/FILEBONE regex used to', () => {
+        //  Long standing oputil behaviour: the area tag comes from the
+        //  description and the storage tag combines description and FTN tag.
+        //  Changing either would orphan already-imported storage directories.
+        const records = build('fsxnet-file-2025.na');
+
+        assert.equal(records.count, 10);
+        assert.deepEqual(records.areas.weekly_nodelist_fsx_net, {
+            name: 'Weekly Nodelist (fsxNet)',
+            desc: 'Weekly Nodelist (fsxNet)',
+            storageTags: ['weekly_nodelist_fsx_net__fsx_node'],
+        });
+        assert.equal(records.storageTags.weekly_nodelist_fsx_net__fsx_node, 'FSX_NODE');
+    });
+
+    it('handles a file echo list shipped as a plain TAG/description list', () => {
+        //  ArakNet ships its FILE echoes this way -- the opposite convention
+        //  from the FILEBONE lists most networks use. This used to import
+        //  nothing at all.
+        const records = build('araknet-file.na');
+
+        assert.equal(records.count, 3);
+        assert.equal(
+            records.storageTags.araknet_infopack_sysop_access_only__ark_info,
+            'ARK_INFO'
+        );
+    });
+
+    it('produces nothing from a reversed-column list', () => {
+        const parsed = parseAreaList(readFixture('spooknet-baselist.txt'));
+        assert.equal(parsed.format, AreaListFormat.DescFirst);
+        assert.equal(buildFileAreaImportRecords(parsed.entries).count, 0);
+    });
+
+    it('skips an entry that cannot produce a usable tag', () => {
+        //  a description of only punctuation sanitizes away to nothing
+        const records = buildFileAreaImportRecords([
+            { ftnTag: 'FSX_NODE', name: '...', lineNumber: 1 },
+            { ftnTag: 'FSX_INFO', name: 'Infopack', lineNumber: 2 },
+        ]);
+        assert.equal(records.count, 1);
+        assert.equal(records.skipped.length, 1);
+        assert.ok(records.areas.infopack);
+    });
+
+    it('accepts a multi-digit level and flags beyond ! and *&', () => {
+        //  the regex this replaced allowed a single digit and only "!" / "*&"
+        const parsed = parseAreaList(
+            [
+                'Area FSX_NODE  10   !R    Weekly Nodelist',
+                'Area FSX_INFO  0    *&    Weekly Infopack',
+                'Area FSX_MYST  100  !     Mystic BBS Software',
+            ].join('\n')
+        );
+        assert.equal(parsed.format, AreaListFormat.FileBone);
+        assert.equal(buildFileAreaImportRecords(parsed.entries).count, 3);
+    });
+
+    it('does not treat an English sentence starting with "Area" as an entry', () => {
+        //  the numeric level requirement is what keeps prose out
+        const parsed = parseAreaList(
+            [
+                'Area 51 is a place',
+                'Area codes are not area tags',
+                'Area FSX_NODE 0 ! Weekly Nodelist',
+            ].join('\n')
+        );
+        assert.equal(parsed.entries.filter(e => e.ftnTag === 'FSX_NODE').length, 1);
+        assert.equal(parsed.entries.length, 1);
     });
 });

--- a/test/area_info_pack.test.js
+++ b/test/area_info_pack.test.js
@@ -1,0 +1,225 @@
+'use strict';
+
+//
+//  Bounded extraction of a network info pack.
+//
+//  A pack arrives over FTN from a hub, so it is attacker adjacent. The
+//  archiver itself is stubbed here: what is under test is the enforcement
+//  around it, and specifically that enforcement is applied to what actually
+//  lands on disk. ArchiveUtil.extractTo() silently downgrades a selective
+//  extraction to a full decompress when the configured archiver has no
+//  file-list verb, and listEntries() sizes come from a regex over archiver
+//  stdout -- so neither the requested file list nor the reported sizes can be
+//  taken as what happened.
+//
+
+const { strict: assert } = require('assert');
+const fs = require('fs');
+const paths = require('path');
+
+const ArchiveUtil = require('../core/archive_util.js');
+const {
+    globToRegExp,
+    extractAreaListFromPack,
+    MaxMemberBytes,
+} = require('../core/area_info_pack.js');
+
+const AREA_LIST = 'FSX_GEN              General Chat + More..\r\n';
+
+let savedGetInstance;
+
+//
+//  Stub archiver.  |produces| is what actually appears in the extraction
+//  directory, which is deliberately allowed to differ from |entries| (the
+//  manifest) and from the file list it was asked for.
+//
+function stubArchiver({ entries, produces, requestedSink }) {
+    ArchiveUtil.getInstance = () => ({
+        detectType: (path, cb) => cb(null, 'zip'),
+        listEntries: (path, archType, cb) => cb(null, entries),
+        extractTo: (archivePath, extractPath, archType, fileList, cb) => {
+            if (requestedSink) {
+                requestedSink.push(...fileList);
+            }
+            Object.entries(produces).forEach(([name, content]) => {
+                const full = paths.join(extractPath, name);
+                fs.mkdirSync(paths.dirname(full), { recursive: true });
+                fs.writeFileSync(full, content);
+            });
+            return cb(null);
+        },
+    });
+}
+
+function extract(wanted) {
+    return new Promise(resolve =>
+        extractAreaListFromPack('/fake/fsxnet.zip', wanted, (err, data) =>
+            resolve({ err, data })
+        )
+    );
+}
+
+describe('area_info_pack: file name matching', () => {
+    it('matches a glob against a pack file name', () => {
+        assert.ok(globToRegExp('fsxnet*.zip').test('fsxnet.zip'));
+        assert.ok(globToRegExp('fsxnet*.zip').test('FSXNET_2025.ZIP'));
+        assert.equal(globToRegExp('fsxnet*.zip').test('other.zip'), false);
+        assert.equal(globToRegExp('fsxnet*.zip').test('fsxnet.zip.bak'), false);
+    });
+
+    it('treats regex metacharacters in a glob as literals', () => {
+        assert.ok(globToRegExp('a.b.zip').test('a.b.zip'));
+        assert.equal(globToRegExp('a.b.zip').test('axbxzip'), false);
+    });
+
+    it('supports ? as a single character', () => {
+        assert.ok(globToRegExp('fsx?.na').test('fsxa.na'));
+        assert.equal(globToRegExp('fsx?.na').test('fsxab.na'), false);
+    });
+});
+
+describe('area_info_pack: bounded extraction', () => {
+    beforeEach(() => {
+        savedGetInstance = ArchiveUtil.getInstance;
+    });
+
+    afterEach(() => {
+        ArchiveUtil.getInstance = savedGetInstance;
+    });
+
+    it('extracts the named area list', async () => {
+        const requested = [];
+        stubArchiver({
+            entries: [
+                { fileName: 'fsxnet.na', byteSize: AREA_LIST.length },
+                { fileName: 'fsx_file.na', byteSize: 100 },
+                { fileName: 'nodelist.z21', byteSize: 100000 },
+            ],
+            produces: { 'fsxnet.na': AREA_LIST },
+            requestedSink: requested,
+        });
+
+        const { err, data } = await extract('fsxnet.na');
+        assert.ifError(err);
+        assert.equal(data, AREA_LIST);
+        //  only the one file was ever asked for
+        assert.deepEqual(requested, ['fsxnet.na']);
+    });
+
+    it('refuses an areaFile whose extension is not allowed', async () => {
+        stubArchiver({ entries: [], produces: {} });
+        const { err } = await extract('nodelist.z21');
+        assert.ok(err);
+        assert.match(err.message, /allowed extension/);
+    });
+
+    it('refuses when the named file is not in the manifest', async () => {
+        stubArchiver({
+            entries: [{ fileName: 'fsx_file.na', byteSize: 100 }],
+            produces: {},
+        });
+        const { err } = await extract('fsxnet.na');
+        assert.ok(err);
+        assert.match(err.message, /is not in/);
+    });
+
+    it('refuses a manifest entry larger than the per-member cap', async () => {
+        stubArchiver({
+            entries: [{ fileName: 'fsxnet.na', byteSize: MaxMemberBytes + 1 }],
+            produces: {},
+        });
+        const { err } = await extract('fsxnet.na');
+        assert.ok(err);
+        assert.match(err.message, /is not in/);
+    });
+
+    it('never asks for a member carrying a path', async () => {
+        const requested = [];
+        stubArchiver({
+            entries: [
+                { fileName: '../../etc/fsxnet.na', byteSize: 10 },
+                { fileName: 'sub/fsxnet.na', byteSize: 10 },
+            ],
+            produces: {},
+            requestedSink: requested,
+        });
+
+        const { err } = await extract('fsxnet.na');
+        assert.ok(err, 'nothing safe to extract');
+        assert.deepEqual(requested, []);
+    });
+
+    it('deletes everything a full decompress produced beyond what was wanted', async () => {
+        //
+        //  The "silent full decompress" case: the archiver ignored the file
+        //  list and unpacked the whole pack. Only the wanted file may survive,
+        //  and only its contents may be returned.
+        //
+        stubArchiver({
+            entries: [{ fileName: 'fsxnet.na', byteSize: AREA_LIST.length }],
+            produces: {
+                'fsxnet.na': AREA_LIST,
+                'fsx_file.na': 'Area FSX_NODE 0 ! Nodelist\r\n',
+                'readme.txt': 'hello',
+                'nodelist.z21': 'binary junk',
+                'evil.sh': '#!/bin/sh\nrm -rf /\n',
+            },
+        });
+
+        const { err, data } = await extract('fsxnet.na');
+        assert.ifError(err);
+        assert.equal(data, AREA_LIST);
+
+        //  temptmp cleans the directory up, but nothing unwanted may have
+        //  been read either -- the returned data is the wanted file alone
+        assert.equal(data.includes('FSX_NODE'), false);
+    });
+
+    it('refuses when extraction produced nothing usable', async () => {
+        stubArchiver({
+            entries: [{ fileName: 'fsxnet.na', byteSize: 10 }],
+            produces: { 'somethingelse.na': 'nope' },
+        });
+
+        const { err } = await extract('fsxnet.na');
+        assert.ok(err);
+        assert.match(err.message, /was not produced/);
+    });
+
+    it('refuses a produced file that exceeds the per-member cap', async () => {
+        stubArchiver({
+            entries: [{ fileName: 'fsxnet.na', byteSize: 10 }], //  manifest lied
+            produces: { 'fsxnet.na': 'x'.repeat(MaxMemberBytes + 1) },
+        });
+
+        const { err } = await extract('fsxnet.na');
+        assert.ok(err);
+        assert.match(err.message, /was not produced/);
+    });
+
+    it('ignores a produced directory with the wanted name', async () => {
+        ArchiveUtil.getInstance = () => ({
+            detectType: (path, cb) => cb(null, 'zip'),
+            listEntries: (path, archType, cb) =>
+                cb(null, [{ fileName: 'fsxnet.na', byteSize: 10 }]),
+            extractTo: (archivePath, extractPath, archType, fileList, cb) => {
+                fs.mkdirSync(paths.join(extractPath, 'fsxnet.na'));
+                return cb(null);
+            },
+        });
+
+        const { err } = await extract('fsxnet.na');
+        assert.ok(err);
+        assert.match(err.message, /was not produced/);
+    });
+
+    it('propagates an archive type it cannot identify', async () => {
+        ArchiveUtil.getInstance = () => ({
+            detectType: (path, cb) => cb(null, undefined),
+        });
+
+        const { err } = await extract('fsxnet.na');
+        assert.ok(err);
+        assert.match(err.message, /Unknown archive type/);
+    });
+});

--- a/test/areafix_reply.test.js
+++ b/test/areafix_reply.test.js
@@ -1,0 +1,217 @@
+'use strict';
+
+const { strict: assert } = require('assert');
+
+const {
+    AreaFixStatus,
+    tokenizeReplyLine,
+    parseAreaFixReply,
+} = require('../core/areafix_reply.js');
+
+const REQUESTED = ['FSX_GEN', 'FSX_BBS', 'FSX_MYS'];
+
+const parse = (body, extraPhrases) =>
+    parseAreaFixReply(body, { tags: REQUESTED, extraPhrases });
+
+const statusFor = (body, tag) => {
+    const found = parse(body).results.find(r => r.tag === tag);
+    return found && found.status;
+};
+
+// ─── Tokenizer ───────────────────────────────────────────────────────────────
+
+describe('areafix_reply: line tokenizer', () => {
+    it('handles husky dot-fill', () => {
+        assert.deepEqual(
+            tokenizeReplyLine(' FSX_GEN ........................... added'),
+            { tag: 'FSX_GEN', statusText: 'added' }
+        );
+    });
+
+    it('handles SBBSecho bare form with a trailing period', () => {
+        assert.deepEqual(tokenizeReplyLine('FSX_GEN added.'), {
+            tag: 'FSX_GEN',
+            statusText: 'added',
+        });
+    });
+
+    it('handles CrashMail column padding and an echoed command character', () => {
+        assert.deepEqual(tokenizeReplyLine('+FSX_GEN                       Attached'), {
+            tag: 'FSX_GEN',
+            statusText: 'attached',
+        });
+    });
+
+    it('strips the other command characters managers echo back', () => {
+        ['-', '=', '%', '*'].forEach(ch => {
+            assert.equal(tokenizeReplyLine(`${ch}FSX_GEN removed`).tag, 'FSX_GEN');
+        });
+    });
+
+    it('collapses internal whitespace in the status text', () => {
+        assert.equal(
+            tokenizeReplyLine('FSX_GEN   already    linked').statusText,
+            'already linked'
+        );
+    });
+
+    it('returns null for a line with nothing after the tag', () => {
+        assert.equal(tokenizeReplyLine('FSX_GEN'), null);
+        assert.equal(tokenizeReplyLine('   '), null);
+        assert.equal(tokenizeReplyLine(''), null);
+    });
+});
+
+// ─── Vocabulary ──────────────────────────────────────────────────────────────
+//
+//  Structure converges across husky, SBBSecho and CrashMail II; vocabulary
+//  does not. Each of these came from one of those implementations.
+//
+describe('areafix_reply: status vocabulary', () => {
+    const cases = [
+        //  husky
+        [' FSX_GEN ........................... added', AreaFixStatus.Added],
+        [' FSX_GEN ........................... unlinked', AreaFixStatus.Removed],
+        [
+            ' FSX_GEN ........................... already linked',
+            AreaFixStatus.AlreadyLinked,
+        ],
+        [' FSX_GEN ........................... not linked', AreaFixStatus.NotLinked],
+        //  SBBSecho
+        ['FSX_GEN added.', AreaFixStatus.Added],
+        ['FSX_GEN removed.', AreaFixStatus.Removed],
+        ['FSX_GEN not found.', AreaFixStatus.NotFound],
+        //  CrashMail II
+        ['+FSX_GEN                       Attached', AreaFixStatus.Added],
+        ['-FSX_GEN                       Detached', AreaFixStatus.Removed],
+        ['+FSX_GEN                       Unknown area', AreaFixStatus.NotFound],
+        [
+            '+FSX_GEN                       You are already attached to that area',
+            AreaFixStatus.AlreadyLinked,
+        ],
+        ['+FSX_GEN                       Attached as read-only', AreaFixStatus.Added],
+    ];
+
+    cases.forEach(([line, expected]) => {
+        it(`${JSON.stringify(line.trim())} -> ${expected}`, () => {
+            assert.equal(statusFor(line, 'FSX_GEN'), expected);
+        });
+    });
+
+    it("matches SBBSecho's rescan line by prefix, since it carries a count", () => {
+        assert.equal(
+            statusFor('FSX_GEN rescanned and 123 messages exported.', 'FSX_GEN'),
+            AreaFixStatus.Rescanned
+        );
+    });
+
+    it('reports an unseeded vocabulary as unknown rather than guessing', () => {
+        const { results, unknownCount } = parse('FSX_GEN wibbled sideways');
+        assert.equal(results[0].status, AreaFixStatus.Unknown);
+        assert.equal(results[0].raw, 'FSX_GEN wibbled sideways');
+        assert.equal(unknownCount, 1);
+    });
+
+    it('can be taught a manager-specific phrase without code changes', () => {
+        const { results } = parse('FSX_GEN wibbled sideways', {
+            'wibbled sideways': AreaFixStatus.Added,
+        });
+        assert.equal(results[0].status, AreaFixStatus.Added);
+    });
+});
+
+// ─── Correlation ─────────────────────────────────────────────────────────────
+
+describe('areafix_reply: only lines about areas we asked about', () => {
+    it('discards entries for areas we never mentioned', () => {
+        const { results } = parse(
+            [
+                'FSX_GEN added',
+                'SOME_OTHER added', //  not in our request
+            ].join('\r\n')
+        );
+        assert.deepEqual(
+            results.map(r => r.tag),
+            ['FSX_GEN']
+        );
+    });
+
+    it("ignores husky's appended %LIST block for unrelated areas", () => {
+        //  With queryReports on, husky appends the full linked-areas list to
+        //  the same netmail as the confirmations -- one message, both content
+        //  types, one subject. The tag-set intersection is what keeps that safe.
+        const body = [
+            'Areafix reply: node change request',
+            '',
+            ' FSX_GEN ........................... added',
+            '',
+            'Your linked areas:',
+            ' SOMENET_CHAT ...................... General chatter',
+            ' SOMENET_ADS ....................... Advertisements',
+        ].join('\r\n');
+
+        const { results } = parse(body);
+        assert.deepEqual(
+            results.map(r => r.tag),
+            ['FSX_GEN']
+        );
+        assert.equal(results[0].status, AreaFixStatus.Added);
+    });
+
+    it('cannot return free text -- a %LIST description becomes a status, never a desc', () => {
+        //  A confirmation and a %LIST entry are structurally identical, so a
+        //  description for an area we DID ask about is unavoidably parsed. It
+        //  must come back as Unknown, not as something assignable to desc.
+        const { results } = parse(' FSX_GEN ........................... General chatter');
+        assert.equal(results[0].status, AreaFixStatus.Unknown);
+        assert.equal(Object.keys(results[0]).includes('desc'), false);
+    });
+
+    it('keeps the first recognized status when a tag appears twice', () => {
+        const { results } = parse(
+            ['FSX_GEN added', 'FSX_GEN General chatter'].join('\r\n')
+        );
+        assert.equal(results.length, 1);
+        assert.equal(results[0].status, AreaFixStatus.Added);
+    });
+
+    it('upgrades an earlier unknown when a later line is recognized', () => {
+        const { results, unknownCount } = parse(
+            ['FSX_GEN General chatter', 'FSX_GEN added'].join('\r\n')
+        );
+        assert.equal(results[0].status, AreaFixStatus.Added);
+        assert.equal(unknownCount, 0);
+    });
+
+    it('returns nothing for an empty or unrelated body', () => {
+        assert.equal(parse('').results.length, 0);
+        assert.equal(parse('Thanks for your message!\r\n\r\n-- Bob').results.length, 0);
+    });
+
+    it('returns nothing when no tags were requested', () => {
+        assert.equal(parseAreaFixReply('FSX_GEN added', { tags: [] }).results.length, 0);
+    });
+
+    it('matches tags case-insensitively', () => {
+        const { results } = parseAreaFixReply('fsx_gen added', {
+            tags: ['FSX_GEN'],
+        });
+        assert.equal(results.length, 1);
+        assert.equal(results[0].tag, 'FSX_GEN');
+    });
+
+    it('handles a multi-area reply', () => {
+        const body = [
+            ' FSX_GEN ........................... added',
+            ' FSX_BBS ........................... already linked',
+            ' FSX_MYS ........................... not found',
+        ].join('\r\n');
+
+        const byTag = Object.fromEntries(parse(body).results.map(r => [r.tag, r.status]));
+        assert.deepEqual(byTag, {
+            FSX_GEN: AreaFixStatus.Added,
+            FSX_BBS: AreaFixStatus.AlreadyLinked,
+            FSX_MYS: AreaFixStatus.NotFound,
+        });
+    });
+});

--- a/test/auto_area_create.test.js
+++ b/test/auto_area_create.test.js
@@ -459,6 +459,42 @@ describe('auto_area_create', () => {
         });
     });
 
+    it('serializes overlapping writes instead of losing one of them', done => {
+        //
+        //  The import watchdog can force-complete a cycle and let the next one
+        //  start while the first is still running. Two unserialized
+        //  read-modify-writes would both read the empty file and the later
+        //  writer would drop what the earlier one added.
+        //
+        let finished = 0;
+        const check = () => {
+            if (2 !== ++finished) {
+                return;
+            }
+
+            const areas = configModule.get().messageConferences[CONF_TAG].areas;
+            assert.ok(areas.fsx_gen, 'first batch survived');
+            assert.ok(areas.fsx_bbs, 'second batch survived');
+
+            const generated = readGeneratedSync();
+            assert.deepEqual(Object.keys(generated.messageNetworks.ftn.areas).sort(), [
+                'fsx_bbs',
+                'fsx_gen',
+            ]);
+            done();
+        };
+
+        //  fired back to back, neither awaiting the other
+        autoAreaCreate.createAreas(NETWORK, ['FSX_GEN'], err => {
+            assert.ifError(err);
+            check();
+        });
+        autoAreaCreate.createAreas(NETWORK, ['FSX_BBS'], err => {
+            assert.ifError(err);
+            check();
+        });
+    });
+
     // ─── Info pack enrichment ────────────────────────────────────────────────
 
     it('replaces the placeholder name and desc on areas we generated', done => {

--- a/test/auto_area_create.test.js
+++ b/test/auto_area_create.test.js
@@ -1,0 +1,506 @@
+'use strict';
+
+//
+//  Automatic message area creation, end to end.
+//
+//  These tests drive the real ConfigLoader -- a temp config.hjson with a real
+//  `includes` entry -- rather than a mocked config, because the whole design
+//  rests on what the include merge actually does:
+//
+//      _.defaultsDeep(config, includedConfig)      config_loader.js
+//
+//  If that precedence were the other way around, a rewrite of the generated
+//  file would silently overwrite an operator's own description. So it is
+//  asserted here, against the repo's own lodash, rather than assumed.
+//
+
+const { strict: assert } = require('assert');
+const fs = require('fs');
+const os = require('os');
+const paths = require('path');
+const hjson = require('hjson');
+
+const configModule = require('../core/config.js');
+const autoAreaCreate = require('../core/auto_area_create.js');
+
+const NETWORK = 'fsxnet';
+const CONF_TAG = 'fsxnet';
+
+let tempDir;
+let savedGet;
+let savedReload;
+
+function writeBaseConfig(extra = {}) {
+    const config = Object.assign(
+        {
+            includes: [autoAreaCreate.GeneratedIncludeFileName],
+            messageConferences: {
+                [CONF_TAG]: {
+                    name: 'fsxNet',
+                    desc: 'fsxNet Echos',
+                    areas: {},
+                },
+            },
+            messageNetworks: {
+                ftn: {
+                    networks: {
+                        [NETWORK]: {
+                            localAddress: '21:1/121',
+                            autoAreas: {
+                                confTag: CONF_TAG,
+                                maxAutoCreate: 5,
+                                ignore: [],
+                                onDemand: { enabled: true },
+                            },
+                        },
+                    },
+                    areas: {},
+                },
+            },
+        },
+        extra
+    );
+
+    fs.writeFileSync(
+        paths.join(tempDir, 'config.hjson'),
+        hjson.stringify(config, { emitRootBraces: true, space: 4, eol: '\n' }),
+        'utf8'
+    );
+}
+
+function loadConfig(cb) {
+    configModule.Config.create(
+        paths.join(tempDir, 'config.hjson'),
+        { hotReload: false },
+        cb
+    );
+}
+
+function readGeneratedSync() {
+    return hjson.parse(
+        fs.readFileSync(
+            paths.join(tempDir, autoAreaCreate.GeneratedIncludeFileName),
+            'utf8'
+        )
+    );
+}
+
+describe('auto_area_create', () => {
+    before(() => {
+        savedGet = configModule.get;
+        savedReload = configModule.reload;
+    });
+
+    after(() => {
+        //  Config.create() rebinds these module-level exports; put back what
+        //  test/setup.js installed so later suites are unaffected.
+        configModule.get = savedGet;
+        configModule.reload = savedReload;
+    });
+
+    beforeEach(done => {
+        tempDir = fs.mkdtempSync(paths.join(os.tmpdir(), 'enig-autoarea-'));
+        //  the include must exist before it is referenced or the whole load fails
+        fs.writeFileSync(
+            paths.join(tempDir, autoAreaCreate.GeneratedIncludeFileName),
+            '{}\n',
+            'utf8'
+        );
+        writeBaseConfig();
+        loadConfig(done);
+    });
+
+    afterEach(() => {
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    // ─── Happy path ──────────────────────────────────────────────────────────
+
+    it('creates areas and makes them resolvable after reload', done => {
+        autoAreaCreate.createAreas(NETWORK, ['FSX_GEN', 'FSX_BBS'], (err, result) => {
+            assert.ifError(err);
+            assert.deepEqual(result.created.map(c => c.areaTag).sort(), [
+                'fsx_bbs',
+                'fsx_gen',
+            ]);
+            assert.equal(result.rejected.length, 0);
+
+            //  createAreas() reloads, so these must resolve through the merge
+            const { getMessageAreaByTag } = require('../core/message_area.js');
+            assert.ok(getMessageAreaByTag('fsx_gen'));
+            assert.equal(getMessageAreaByTag('fsx_gen').confTag, CONF_TAG);
+
+            const ftnArea = configModule.get().messageNetworks.ftn.areas.fsx_gen;
+            assert.equal(ftnArea.network, NETWORK);
+            assert.equal(ftnArea.tag, 'FSX_GEN');
+            done();
+        });
+    });
+
+    it('creates areas that do not export and cannot be posted into', done => {
+        autoAreaCreate.createAreas(NETWORK, ['FSX_GEN'], err => {
+            assert.ifError(err);
+
+            const config = configModule.get();
+            const ftnArea = config.messageNetworks.ftn.areas.fsx_gen;
+
+            //
+            //  No uplinks: isAreaConfigValid() requires an array, and both
+            //  export sites skip silently without one. Nothing goes out.
+            //
+            assert.equal(ftnArea.uplinks, undefined);
+
+            const FtnBso = require('../core/scanner_tossers/ftn_bso.js');
+            const inst = new FtnBso.getModule();
+            assert.equal(inst.isAreaConfigValid(Object.assign({}, ftnArea)), false);
+
+            //
+            //  ...but "does not export" is not "read-only": a local user could
+            //  still post into a black hole. The write-deny ACS is what closes
+            //  that, so check it the way ACS itself would.
+            //
+            const area = config.messageConferences[CONF_TAG].areas.fsx_gen;
+            assert.equal(area.acs.write, autoAreaCreate.DenyAllAcs);
+
+            const ACS = require('../core/acs.js');
+            const acs = new ACS({
+                client: { user: { userId: 1, groups: ['users', 'sysops'] } },
+                user: {
+                    userId: 1,
+                    groups: ['users', 'sysops'],
+                    properties: {},
+                    isRoot: () => true,
+                },
+            });
+            assert.equal(acs.hasMessageAreaWrite(area), false);
+            done();
+        });
+    });
+
+    // ─── Precedence: config.hjson wins over the generated include ────────────
+
+    it("an operator's own desc survives a regeneration", done => {
+        autoAreaCreate.createAreas(NETWORK, ['FSX_GEN'], err => {
+            assert.ifError(err);
+            assert.equal(
+                configModule.get().messageConferences[CONF_TAG].areas.fsx_gen.desc,
+                'FSX_GEN'
+            );
+
+            //  operator edits config.hjson to give it a real description
+            writeBaseConfig({
+                messageConferences: {
+                    [CONF_TAG]: {
+                        name: 'fsxNet',
+                        desc: 'fsxNet Echos',
+                        areas: {
+                            fsx_gen: { desc: 'General Chat, my words' },
+                        },
+                    },
+                },
+            });
+
+            configModule.reload(reloadErr => {
+                assert.ifError(reloadErr);
+
+                //  ...and a later pass rewrites the generated file wholesale
+                autoAreaCreate.createAreas(NETWORK, ['FSX_BBS'], err2 => {
+                    assert.ifError(err2);
+                    const areas = configModule.get().messageConferences[CONF_TAG].areas;
+                    assert.equal(areas.fsx_gen.desc, 'General Chat, my words');
+                    assert.ok(areas.fsx_bbs);
+                    done();
+                });
+            });
+        });
+    });
+
+    // ─── Collision guard ─────────────────────────────────────────────────────
+
+    it('refuses a tag that would alias the private mail area', done => {
+        autoAreaCreate.createAreas(NETWORK, ['PRIVATE_MAIL'], (err, result) => {
+            assert.ifError(err);
+            assert.equal(result.created.length, 0);
+            assert.equal(result.rejected.length, 1);
+            assert.equal(result.rejected[0].areaTag, 'private_mail');
+            assert.equal(
+                result.rejected[0].reason,
+                autoAreaCreate.RejectReasons.WellKnown
+            );
+
+            //  and nothing was written
+            assert.deepEqual(readGeneratedSync().messageNetworks?.ftn?.areas ?? {}, {});
+            done();
+        });
+    });
+
+    it('refuses a tag that would alias the local bulletin area', done => {
+        autoAreaCreate.createAreas(NETWORK, ['LOCAL_BULLETIN'], (err, result) => {
+            assert.ifError(err);
+            assert.equal(result.created.length, 0);
+            assert.equal(
+                result.rejected[0].reason,
+                autoAreaCreate.RejectReasons.WellKnown
+            );
+            done();
+        });
+    });
+
+    it('refuses a tag that collides with an existing area in another conference', done => {
+        writeBaseConfig({
+            messageConferences: {
+                [CONF_TAG]: { name: 'fsxNet', desc: 'fsxNet Echos', areas: {} },
+                local: {
+                    name: 'Local',
+                    desc: 'Local',
+                    areas: { fsx_gen: { name: 'Mine', desc: 'Mine' } },
+                },
+            },
+        });
+
+        configModule.reload(reloadErr => {
+            assert.ifError(reloadErr);
+            autoAreaCreate.createAreas(NETWORK, ['FSX_GEN'], (err, result) => {
+                assert.ifError(err);
+                assert.equal(result.created.length, 0);
+                assert.equal(
+                    result.rejected[0].reason,
+                    autoAreaCreate.RejectReasons.ExistingArea
+                );
+                done();
+            });
+        });
+    });
+
+    it('refuses a tag that is not a usable area tag', done => {
+        autoAreaCreate.createAreas(NETWORK, [';', 'has space'], (err, result) => {
+            assert.ifError(err);
+            assert.equal(result.created.length, 0);
+            assert.equal(result.rejected.length, 2);
+            result.rejected.forEach(r =>
+                assert.equal(r.reason, autoAreaCreate.RejectReasons.InvalidTag)
+            );
+            done();
+        });
+    });
+
+    // ─── Guardrails ──────────────────────────────────────────────────────────
+
+    it('caps the total number created, not the number per run', done => {
+        //  maxAutoCreate is 5 in the fixture config
+        autoAreaCreate.createAreas(
+            NETWORK,
+            ['A_ONE', 'A_TWO', 'A_THREE'],
+            (err, first) => {
+                assert.ifError(err);
+                assert.equal(first.created.length, 3);
+
+                autoAreaCreate.createAreas(
+                    NETWORK,
+                    ['B_ONE', 'B_TWO', 'B_THREE', 'B_FOUR'],
+                    (err2, second) => {
+                        assert.ifError(err2);
+                        //  2 remaining under the cap of 5, the rest refused
+                        assert.equal(second.created.length, 2);
+                        assert.equal(second.rejected.length, 2);
+                        second.rejected.forEach(r =>
+                            assert.equal(
+                                r.reason,
+                                autoAreaCreate.RejectReasons.MaxReached
+                            )
+                        );
+                        done();
+                    }
+                );
+            }
+        );
+    });
+
+    it('honours the ignore list for new tags and prunes ones already created', done => {
+        autoAreaCreate.createAreas(NETWORK, ['FSX_GEN', 'FSX_BBS'], err => {
+            assert.ifError(err);
+
+            writeBaseConfig({
+                messageNetworks: {
+                    ftn: {
+                        networks: {
+                            [NETWORK]: {
+                                localAddress: '21:1/121',
+                                autoAreas: {
+                                    confTag: CONF_TAG,
+                                    maxAutoCreate: 5,
+                                    ignore: ['FSX_GEN', 'FSX_TST'],
+                                    onDemand: { enabled: true },
+                                },
+                            },
+                        },
+                        areas: {},
+                    },
+                },
+            });
+
+            configModule.reload(reloadErr => {
+                assert.ifError(reloadErr);
+                autoAreaCreate.createAreas(
+                    NETWORK,
+                    ['FSX_TST', 'FSX_MYS'],
+                    (err2, result) => {
+                        assert.ifError(err2);
+                        assert.deepEqual(
+                            result.created.map(c => c.areaTag),
+                            ['fsx_mys']
+                        );
+                        assert.deepEqual(result.pruned, ['fsx_gen']);
+                        assert.equal(
+                            result.rejected[0].reason,
+                            autoAreaCreate.RejectReasons.Ignored
+                        );
+
+                        const generated = readGeneratedSync();
+                        assert.equal(
+                            generated.messageNetworks.ftn.areas.fsx_gen,
+                            undefined
+                        );
+                        assert.equal(
+                            generated.messageConferences[CONF_TAG].areas.fsx_gen,
+                            undefined
+                        );
+                        assert.ok(generated.messageNetworks.ftn.areas.fsx_bbs);
+                        done();
+                    }
+                );
+            });
+        });
+    });
+
+    it('is idempotent: re-running with the same tags creates nothing new', done => {
+        autoAreaCreate.createAreas(NETWORK, ['FSX_GEN'], err => {
+            assert.ifError(err);
+            autoAreaCreate.createAreas(NETWORK, ['FSX_GEN'], (err2, result) => {
+                assert.ifError(err2);
+                assert.equal(result.created.length, 0);
+                assert.equal(result.rejected.length, 0);
+                done();
+            });
+        });
+    });
+
+    // ─── Refusals that protect the boot ──────────────────────────────────────
+
+    it('refuses when the generated file is not included from config.hjson', done => {
+        writeBaseConfig({ includes: [] });
+        configModule.reload(reloadErr => {
+            assert.ifError(reloadErr);
+            autoAreaCreate.createAreas(NETWORK, ['FSX_GEN'], err => {
+                assert.ok(err);
+                assert.match(err.message, /includes/);
+                done();
+            });
+        });
+    });
+
+    it('refuses when the configured confTag is not a real conference', done => {
+        writeBaseConfig({
+            messageNetworks: {
+                ftn: {
+                    networks: {
+                        [NETWORK]: {
+                            localAddress: '21:1/121',
+                            autoAreas: {
+                                confTag: 'nope',
+                                onDemand: { enabled: true },
+                            },
+                        },
+                    },
+                    areas: {},
+                },
+            },
+        });
+
+        configModule.reload(reloadErr => {
+            assert.ifError(reloadErr);
+            autoAreaCreate.createAreas(NETWORK, ['FSX_GEN'], err => {
+                assert.ok(err);
+                assert.match(err.message, /not a configured message conference/);
+                done();
+            });
+        });
+    });
+
+    it('leaves an unparsable generated file alone rather than clobbering it', done => {
+        const generatedPath = paths.join(
+            tempDir,
+            autoAreaCreate.GeneratedIncludeFileName
+        );
+        fs.writeFileSync(generatedPath, '{ this is not: valid hjson ][', 'utf8');
+
+        autoAreaCreate.createAreas(NETWORK, ['FSX_GEN'], err => {
+            assert.ok(err);
+            assert.match(err.message, /Cannot parse/);
+            assert.equal(
+                fs.readFileSync(generatedPath, 'utf8'),
+                '{ this is not: valid hjson ]['
+            );
+            done();
+        });
+    });
+
+    it('writes a file that parses, and leaves no temp file behind', done => {
+        autoAreaCreate.createAreas(NETWORK, ['FSX_GEN'], err => {
+            assert.ifError(err);
+            //  hjson.parse would throw on a truncated write
+            const generated = readGeneratedSync();
+            assert.ok(generated.messageConferences[CONF_TAG].areas.fsx_gen);
+            assert.deepEqual(
+                fs.readdirSync(tempDir).filter(f => f.endsWith('.tmp')),
+                []
+            );
+            done();
+        });
+    });
+
+    // ─── Feature gating ──────────────────────────────────────────────────────
+
+    it('is off for a network with no autoAreas block', done => {
+        writeBaseConfig({
+            messageNetworks: {
+                ftn: {
+                    networks: { [NETWORK]: { localAddress: '21:1/121' } },
+                    areas: {},
+                },
+            },
+        });
+        configModule.reload(err => {
+            assert.ifError(err);
+            assert.deepEqual(autoAreaCreate.onDemandNetworkNames(), []);
+            assert.equal(autoAreaCreate.anyAutoAreasEnabled(), false);
+            assert.equal(autoAreaCreate.getAutoAreasConfig(NETWORK), null);
+            done();
+        });
+    });
+
+    it('is off when neither source is enabled', done => {
+        writeBaseConfig({
+            messageNetworks: {
+                ftn: {
+                    networks: {
+                        [NETWORK]: {
+                            localAddress: '21:1/121',
+                            autoAreas: {
+                                confTag: CONF_TAG,
+                                onDemand: { enabled: false },
+                                infoPack: { enabled: false },
+                            },
+                        },
+                    },
+                    areas: {},
+                },
+            },
+        });
+        configModule.reload(err => {
+            assert.ifError(err);
+            assert.deepEqual(autoAreaCreate.onDemandNetworkNames(), []);
+            done();
+        });
+    });
+});

--- a/test/auto_area_create.test.js
+++ b/test/auto_area_create.test.js
@@ -459,6 +459,139 @@ describe('auto_area_create', () => {
         });
     });
 
+    // ─── Info pack enrichment ────────────────────────────────────────────────
+
+    it('replaces the placeholder name and desc on areas we generated', done => {
+        autoAreaCreate.createAreas(NETWORK, ['FSX_GEN', 'FSX_BBS'], err => {
+            assert.ifError(err);
+
+            const entries = [
+                { ftnTag: 'FSX_GEN', name: 'General Chat + More..' },
+                { ftnTag: 'FSX_BBS', name: 'BBS Support/Dev' },
+                { ftnTag: 'FSX_MYS', name: 'Mystic BBS Support/Dev' },
+            ];
+
+            autoAreaCreate.applyInfoPackEntries(NETWORK, entries, {}, (err2, result) => {
+                assert.ifError(err2);
+                assert.deepEqual(result.enriched.sort(), ['fsx_bbs', 'fsx_gen']);
+
+                //  we are not linked to FSX_MYS, so it is not created
+                assert.equal(result.created.length, 0);
+
+                const areas = configModule.get().messageConferences[CONF_TAG].areas;
+                assert.equal(areas.fsx_gen.name, 'General Chat + More..');
+                assert.equal(areas.fsx_gen.desc, 'General Chat + More..');
+                assert.equal(areas.fsx_mys, undefined);
+
+                //  the write-deny ACS survives enrichment
+                assert.equal(areas.fsx_gen.acs.write, autoAreaCreate.DenyAllAcs);
+                done();
+            });
+        });
+    });
+
+    it('does not touch an area the operator defined in config.hjson', done => {
+        writeBaseConfig({
+            messageConferences: {
+                [CONF_TAG]: {
+                    name: 'fsxNet',
+                    desc: 'fsxNet Echos',
+                    areas: { fsx_gen: { name: 'Mine', desc: 'My words' } },
+                },
+            },
+        });
+
+        configModule.reload(reloadErr => {
+            assert.ifError(reloadErr);
+            autoAreaCreate.applyInfoPackEntries(
+                NETWORK,
+                [{ ftnTag: 'FSX_GEN', name: 'General Chat + More..' }],
+                {},
+                (err, result) => {
+                    assert.ifError(err);
+                    assert.equal(result.enriched.length, 0);
+                    assert.equal(
+                        configModule.get().messageConferences[CONF_TAG].areas.fsx_gen
+                            .desc,
+                        'My words'
+                    );
+                    done();
+                }
+            );
+        });
+    });
+
+    it('creates unlinked areas only when asked, with real names', done => {
+        const entries = [
+            { ftnTag: 'FSX_GEN', name: 'General Chat + More..' },
+            { ftnTag: 'FSX_BBS', name: 'BBS Support/Dev' },
+        ];
+
+        autoAreaCreate.applyInfoPackEntries(
+            NETWORK,
+            entries,
+            { createUnlinked: true },
+            (err, result) => {
+                assert.ifError(err);
+                assert.deepEqual(result.created.map(c => c.areaTag).sort(), [
+                    'fsx_bbs',
+                    'fsx_gen',
+                ]);
+
+                const areas = configModule.get().messageConferences[CONF_TAG].areas;
+                assert.equal(areas.fsx_gen.desc, 'General Chat + More..');
+                assert.equal(
+                    configModule.get().messageNetworks.ftn.areas.fsx_gen.uplinks,
+                    undefined
+                );
+                done();
+            }
+        );
+    });
+
+    it('applies the collision guard to createUnlinked as well', done => {
+        autoAreaCreate.applyInfoPackEntries(
+            NETWORK,
+            [{ ftnTag: 'PRIVATE_MAIL', name: 'Hostile' }],
+            { createUnlinked: true },
+            (err, result) => {
+                assert.ifError(err);
+                assert.equal(result.created.length, 0);
+                assert.equal(
+                    result.rejected[0].reason,
+                    autoAreaCreate.RejectReasons.WellKnown
+                );
+                done();
+            }
+        );
+    });
+
+    it('writes nothing when the pack says what we already say', done => {
+        autoAreaCreate.createAreas(NETWORK, ['FSX_GEN'], err => {
+            assert.ifError(err);
+            const before = fs.statSync(
+                paths.join(tempDir, autoAreaCreate.GeneratedIncludeFileName)
+            ).mtimeMs;
+
+            autoAreaCreate.applyInfoPackEntries(
+                NETWORK,
+                [{ ftnTag: 'FSX_GEN', name: 'FSX_GEN' }],
+                {},
+                (err2, result) => {
+                    assert.ifError(err2);
+                    assert.equal(result.enriched.length, 0);
+                    assert.equal(
+                        fs.statSync(
+                            paths.join(tempDir, autoAreaCreate.GeneratedIncludeFileName)
+                        ).mtimeMs,
+                        before
+                    );
+                    done();
+                }
+            );
+        });
+    });
+
     // ─── Feature gating ──────────────────────────────────────────────────────
 
     it('is off for a network with no autoAreas block', done => {

--- a/test/auto_area_create.test.js
+++ b/test/auto_area_create.test.js
@@ -495,6 +495,38 @@ describe('auto_area_create', () => {
         });
     });
 
+    it('a stuck operation times out instead of wedging the queue forever', done => {
+        //
+        //  Operations are chained, so one that never settles would block every
+        //  later one permanently -- worse than the overlap the chaining exists
+        //  to prevent. maybeAutoCreateAreas() also waits on this callback
+        //  inside the import watchdog.
+        //
+        const savedTimeout = autoAreaCreate.GeneratedWriteTimeoutMs;
+        const savedReload = configModule.reload;
+        autoAreaCreate.GeneratedWriteTimeoutMs = 50;
+
+        //  a config reload whose callback never arrives
+        configModule.reload = () => {};
+
+        autoAreaCreate.createAreas(NETWORK, ['FSX_GEN'], err => {
+            configModule.reload = savedReload;
+            assert.ok(err, 'expected a timeout, not a dropped callback');
+            assert.match(err.message, /Timed out/);
+
+            //  ...and the queue still works afterwards
+            autoAreaCreate.GeneratedWriteTimeoutMs = savedTimeout;
+            autoAreaCreate.createAreas(NETWORK, ['FSX_BBS'], (err2, result) => {
+                assert.ifError(err2);
+                assert.deepEqual(
+                    result.created.map(c => c.areaTag),
+                    ['fsx_bbs']
+                );
+                done();
+            });
+        });
+    });
+
     // ─── Info pack enrichment ────────────────────────────────────────────────
 
     it('replaces the placeholder name and desc on areas we generated', done => {

--- a/test/auto_area_create.test.js
+++ b/test/auto_area_create.test.js
@@ -85,6 +85,107 @@ function readGeneratedSync() {
     );
 }
 
+// ─── Wiring the include into config.hjson ────────────────────────────────────
+//
+//  writeConfig() round-trips through hjson, which preserves comments but
+//  normalizes whitespace: column alignment is lost, comment spacing collapses
+//  and inline arrays expand. Measured against a real 688 line config that is a
+//  seven hunk diff for what should be a one line addition, so the include is
+//  inserted textually and the result checked against the original parse.
+//
+describe('auto_area_create: addIncludeEntry()', () => {
+    const FILE = 'auto-areas.hjson';
+    const add = text => autoAreaCreate.addIncludeEntry(text, FILE);
+
+    it('adds an includes block to a config that has none', () => {
+        const before = '{\n    general: {\n        boardName: Test\n    }\n}\n';
+        const after = add(before);
+
+        assert.ok(after);
+        assert.deepEqual(hjson.parse(after).includes, [FILE]);
+        assert.equal(hjson.parse(after).general.boardName, 'Test');
+    });
+
+    it('appends LAST to an includes array that already exists', () => {
+        //
+        //  Order is load bearing: includes merge in order and the earliest
+        //  wins, so the generated file has to come last. An include the
+        //  operator wrote should beat it, the same way config.hjson does.
+        //
+        const before = '{\n    includes: [\n        other.hjson\n    ]\n}\n';
+        const after = add(before);
+
+        assert.ok(after);
+        assert.deepEqual(hjson.parse(after).includes, ['other.hjson', FILE]);
+    });
+
+    it('appends last to an inline includes array too', () => {
+        const after = add('{\n    includes: [ "a.hjson", "b.hjson" ]\n}\n');
+        assert.ok(after);
+        assert.deepEqual(hjson.parse(after).includes, ['a.hjson', 'b.hjson', FILE]);
+    });
+
+    it('is a no-op it refuses to repeat: the caller checks first', () => {
+        //  adding twice would produce a duplicate entry, so oputil checks for
+        //  an existing entry before calling this at all
+        const once = add('{\n    includes: []\n}\n');
+        const twice = add(once);
+        assert.deepEqual(hjson.parse(twice).includes, [FILE, FILE]);
+    });
+
+    it('handles an empty inline includes array', () => {
+        const after = add('{\n    includes: []\n}\n');
+        assert.ok(after);
+        assert.deepEqual(hjson.parse(after).includes, [FILE]);
+    });
+
+    it('changes nothing else in a config it does not understand the layout of', () => {
+        const before = [
+            '{',
+            '    //  a comment I care about',
+            '    general: {',
+            '        boardName: Test Board   //  aligned trailing comment',
+            '    }',
+            '',
+            '    /*  block',
+            '        comment */',
+            '    fileBase: {',
+            '        storageTags: {',
+            '            local_flat:    /some/path',
+            '            local_scene:   /some/other/path',
+            '        }',
+            '    }',
+            '    corsAllowedOrigins: ["*"]   //  inline array',
+            '}',
+            '',
+        ].join('\n');
+
+        const after = add(before);
+        assert.ok(after);
+
+        //  every original line survives byte for byte
+        before
+            .split('\n')
+            .filter(l => l.trim().length > 0 && l.trim() !== '}')
+            .forEach(line => {
+                assert.ok(
+                    after.includes(line),
+                    `line was reformatted: ${JSON.stringify(line)}`
+                );
+            });
+
+        assert.deepEqual(hjson.parse(after).corsAllowedOrigins, ['*']);
+    });
+
+    it('refuses a config it cannot parse rather than mangling it', () => {
+        assert.equal(add('{ this is not: valid hjson ]['), null);
+    });
+
+    it('refuses when there is no closing brace to insert before', () => {
+        assert.equal(add(''), null);
+    });
+});
+
 describe('auto_area_create', () => {
     before(() => {
         savedGet = configModule.get;

--- a/test/fixtures/area_lists/README.md
+++ b/test/fixtures/area_lists/README.md
@@ -1,0 +1,89 @@
+# FTN Area List Fixtures
+
+Real area/echo lists taken from FidoNet-style network info packs. These are the
+actual inputs `oputil.js mb import-areas` and `oputil.js fb import-areas` are
+handed by sysops, and they are messier than the parsers assume.
+
+Kept byte exact — `.gitattributes` marks this directory `-text` so the mix of
+CRLF and LF line endings survives, since that mix is part of what is being
+tested.
+
+## Provenance
+
+Freely distributed network info packs. Message and file echo lists only; the
+artwork, nodelists and documentation that ship alongside them are omitted.
+
+| Fixture | Network | Source |
+|---|---|---|
+| `fsxnet-2025.na`, `fsxnet-file-2025.na` | fsxNet | `fsxnet.nz/fsxnet.zip`, pulled 2026-08 |
+| `fsxnet-2018.na`, `fsxnet-file-2018.na` | fsxNet | 2018 pack, kept for the format drift below |
+| `agoranet.na`, `agoranet-file.na` | AgoraNet | info pack |
+| `araknet-msg.na`, `araknet-file.na` | ArakNet | info pack |
+| `dorenet-msg.na` | DoRENET | info pack |
+| `retronet-msg.na` | RetroNet | info pack |
+| `zer0net-msg.na`, `zer0net-file.na` | Zer0net | info pack |
+| `spooknet-baselist.txt` | SpookNet | info pack (ships no `.na` at all) |
+
+## What each one demonstrates
+
+Counts below are what the **current** parsers produce, measured, not predicted:
+
+- `NA` — `/^([^\s]+)\s+([^\r\n]+)/gm` from `getImportEntries()` in
+  `core/oputil/oputil_message_base.js`
+- `ZXX` — `/Area\s+([^\s]+)\s+[0-9]\s+(?:!|\*&)\s+([^\r\n]+)/gm` from
+  `importFileAreas()` in `core/oputil/oputil_file_base.js`
+
+| Fixture | NA good/junk | ZXX | Demonstrates |
+|---|---|---|---|
+| `fsxnet-2025.na` | 13 / 0 | 0 | The happy path: plain `TAG  Description` |
+| `retronet-msg.na` | 18 / 0 | 0 | Happy path, CRLF |
+| `dorenet-msg.na` | 15 / 0 | 0 | Happy path, tabs as separators |
+| `agoranet.na` | 10 / 0 | 0 | Happy path, mixed tabs and spaces |
+| `araknet-msg.na` | 9 / 0 | 0 | Tabs, trailing spaces before CRLF |
+| `zer0net-msg.na` | 9 / 0 | 0 | Happy path |
+| `fsxnet-2018.na` | 2 / 0 | 0 | **Format drift.** Same network, same filename, 2 areas in 2018 vs 13 in 2025 — a shipped `.na` is a point-in-time snapshot, not a stable list |
+| `fsxnet-file-2025.na` | 0 / 18 | 10 | **`.na` extension, FILEBONE content.** `;` comments |
+| `fsxnet-file-2018.na` | 0 / 16 | 8 | Same, but `%` comments — **the comment character changed over time** |
+| `agoranet-file.na` | 0 / 14 | 6 | Same trap, `%` comments |
+| `zer0net-file.na` | 0 / 3 | 3 | Same trap, no comment lines at all |
+| `araknet-file.na` | 3 / 0 | 0 | **File echoes in plain `TAG DESC`** — the opposite of the above |
+| `spooknet-baselist.txt` | 35 / 5 | 0 | **Reversed columns**, `Description … TAG`. The worst case — see below |
+
+## The three traps
+
+**1. The extension does not determine the format.** Six of the eight networks
+ship two `.na` files, one for message echoes and one for file echoes. Some file
+lists are FILEBONE (`Area TAG 0 ! Desc`), some are plain `TAG DESC`. Parsing a
+FILEBONE list with the message parser yields `Area` as the tag for every entry.
+Format has to be sniffed from content.
+
+**2. Comment lines are parsed as areas.** Neither parser skips comments. A
+leading `;` or `%` line produces an entry with that character as the area tag:
+
+```
+;  FSXNet Fileecho List        ->  ftnTag: ";"   name: "FSXNet Fileecho List"
+%  Agoranet Fileecho List      ->  ftnTag: "%"   name: "Agoranet Fileecho List"
+```
+
+Both characters appear in the wild, and which one a network uses has changed
+over time within a single network.
+
+**3. Silent nonsense is worse than obvious junk.** `spooknet-baselist.txt` puts
+the description first and the tag last. The message parser accepts 35 entries
+from it, and most pass a plausible-tag charset check:
+
+```
+tag="Aliens,"            desc="UFOs & EBEs                SN_ALIEN"
+tag="Counter-Terrorism"  desc="SN_TERROR"
+```
+
+Nothing here is malformed enough to reject on shape alone. A parser must be able
+to say "this file is not in a format I recognise" and refuse, rather than
+returning confident garbage.
+
+## Note
+
+Two of the eight networks surveyed ship no machine-readable area list at all —
+SpookNet uses the reversed-column `.txt` above, HappyNet embeds its list in
+English prose in a `.INF` file. Any design that assumes every network ships a
+parseable list is wrong.

--- a/test/fixtures/area_lists/agoranet-file.na
+++ b/test/fixtures/area_lists/agoranet-file.na
@@ -1,0 +1,18 @@
+% ========================================================================
+%  Agoranet Fileecho List                               December 3rd, 2011
+% ========================================================================
+%
+% ------------------------------------------------------------------------
+% File Echo                   Description
+% ------------------------------------------------------------------------
+%
+%
+Area AGN_NODE     0     !       AGN: Current Nodelist In ZIP Format
+Area AGN_DIFF     0     !       AGN: Current Nodediff in ZIP Format
+Area AGN_INFO     0     !       AGN: Information Pack
+Area AGN_MODS     0     !       AGN: BBS Mods
+Area AGN_GAME     0     !       AGN: InterBBS Games
+Area AGN_MISC     0     !       AGN: Miscellaneous
+%
+% End of Agoranet Fileecho List
+

--- a/test/fixtures/area_lists/agoranet.na
+++ b/test/fixtures/area_lists/agoranet.na
@@ -1,0 +1,10 @@
+AGN_GEN              General Chat
+AGN_ADS              BBS and Network Ads
+AGN_BBS              BBS Discussion
+AGN_ART              Art/Demo Scene
+AGN_DEV              Software Development
+AGN_NIX              Unix/Linux Related
+AGN_L46              League Scores & Recons
+AGN_HUB		     Agoranet Hub Stats
+AGN_TST              Testing Setups
+AGN_SYS              Sysops Only

--- a/test/fixtures/area_lists/araknet-file.na
+++ b/test/fixtures/area_lists/araknet-file.na
@@ -1,0 +1,3 @@
+ARK_INFO	   	  Araknet Infopack (sysop access only!)
+ARK_NODELIST  	  Araknet Nodelist (sysop access only!)
+ARK_MOD           BBS Mod releases

--- a/test/fixtures/area_lists/araknet-msg.na
+++ b/test/fixtures/area_lists/araknet-msg.na
@@ -1,0 +1,9 @@
+ARK_CYBER				  Araknet: Cyber Culture
+ARK_SCENE                 Araknet: Underground Scene
+ARK_CDEALS                Araknet: Cyber Deals 
+ARK_MOVIES				  Araknet: Movie Discussion
+ARK_STREAM                Araknet: Streaming Shows
+ARK_BBS                   Araknet: BBS Dev/Support
+ARK_DOORS                 Araknet: Door Dev/Support
+ARK_MODS                  Araknet: BBS Mod Dev/Support
+ARK_SYSOP				  Araknet: Test/Sysop Discussion

--- a/test/fixtures/area_lists/dorenet-msg.na
+++ b/test/fixtures/area_lists/dorenet-msg.na
@@ -1,0 +1,15 @@
+DN-ADMI             Manditory - Administrative (No users) Sysop-Co only private base test messages goes here too
+DN-ART              ansi/ascii art scene related
+DN-BBS              bbs news. anything bbs news related
+DN-CHAT             open chat
+DN-CODE             programming related
+DN-DOORS            bbs door/util related
+DN-HTML             html 101 web, css etc...
+DN-INET             bbs / internet & bbs echo net related
+DN-MODD             bbs modding
+DN-MYSTIC           official mystic bbs echo
+DN-MPL              MPL related
+DN-OS               misc operating systems 
+DN-ADDS	            BBS adds 
+DN-BBSES            Other bbs software support
+netmail		    netmail base (send test mail to your uplink)

--- a/test/fixtures/area_lists/fsxnet-2018.na
+++ b/test/fixtures/area_lists/fsxnet-2018.na
@@ -1,0 +1,3 @@
+FSX_GEN              Chat, Testing + More..
+FSX_MYS              Mystic BBS Discussions + Support
+

--- a/test/fixtures/area_lists/fsxnet-2025.na
+++ b/test/fixtures/area_lists/fsxnet-2025.na
@@ -1,0 +1,13 @@
+FSX_GEN              General Chat + More..
+FSX_BBS              BBS Support/Dev
+FSX_MYS              Mystic BBS Support/Dev
+FSX_RETRO            Retro Computing/Tech
+FSX_GAMING           Games/Gaming
+FSX_VIDEO            Movies/Music + More
+FSX_HAM              HAM + Radio Chat
+FSX_TST              fsxNet Test Arena
+FSX_NET              fsxNet Admin
+FSX_CRY              Cryptographics
+FSX_ADS              Ads + ANSI Art
+FSX_BOT              Automated roBOT Posts
+FSX_DAT              InterBBS Data

--- a/test/fixtures/area_lists/fsxnet-file-2018.na
+++ b/test/fixtures/area_lists/fsxnet-file-2018.na
@@ -1,0 +1,19 @@
+% ========================================================================
+%  FSXNet Fileecho List                                  July 9 2016
+% ========================================================================
+%
+% ------------------------------------------------------------------------
+% File Echo                   Description
+% ------------------------------------------------------------------------
+%
+%
+Area FSX_NODE     0     !       FSX: Current Nodelist
+Area FSX_INFO     0     !       FSX: Current Infopack
+Area FSX_MYST     0     !       FSX: Mystic BBS Software
+Area FSX_MUTL     0     !       FSX: Mystic BBS Utils, Mods etc.
+Area FSX_BBS      0     !       FSX: BBS Software (Current + Legacy)
+Area FSX_UTLS     0     !       FSX: BBS Utils, Tools, Networking etc.
+Area FSX_DOOR     0     !       FSX: BBS Doors, Games etc.
+Area FSX_ART      0     !       FSX: ANSI Art - Groups, Individuals etc.
+%
+% End of FSXNet Fileecho List

--- a/test/fixtures/area_lists/fsxnet-file-2025.na
+++ b/test/fixtures/area_lists/fsxnet-file-2025.na
@@ -1,0 +1,21 @@
+; ========================================================================
+;  FSXNet Fileecho List                                    
+; ========================================================================
+;
+; ------------------------------------------------------------------------
+; File Echo                   Description
+; ------------------------------------------------------------------------
+;
+;
+Area FSX_NODE  0     !      Weekly Nodelist (fsxNet)
+Area FSX_INFO  0     !      Weekly Infopack (fsxNet)
+Area FSX_MYST  0     !      Mystic BBS Software
+Area FSX_MUTL  0     !      Mystic BBS Utils, Mods etc.
+Area FSX_SOFT  0     !      BBS Software (Current + Legacy)
+Area FSX_UTLS  0     !      BBS Utils, Tools, Networking etc.
+Area FSX_DOOR  0     !      BBS Doors, Games etc.
+Area FSX_ARTS  0     !      ANSI Art - Groups, Individuals etc.
+Area FSX_IMGE  0     !      Image Files (Various)
+Area FSX_TEXT  0     !      Text Files (Various)
+;
+; End of FSXNet Fileecho List

--- a/test/fixtures/area_lists/retronet-msg.na
+++ b/test/fixtures/area_lists/retronet-msg.na
@@ -1,0 +1,18 @@
+RTN_COMMODORE       Commodore Computers/Software/Hardware
+RTN_AMIGA           Amiga Computers/Software/Hardware
+RTN_COL_ADAM        Coleco Adam Computer/Software/Hardware
+RTN_COLECO          Colecovision Console
+RTN_NINTENDO        Nintendo Consoles/Handhelds
+RTN_SEGA            Sega Consoles/Handhelds
+RTN_ATARIPC         Atari Computers/Software/Hardware
+RTN_ATARI           Atari Consoles/Handhelds
+RTN_BBSADS          BBS Advertisements
+RTN_GENERAL         RetroNet General Chat
+RTN_BUY_SELL        RetroNet Classifieds
+RTN_NEOGEO          Neo Geo Consoles/Handhelds
+RTN_TEST            RetroNet Test Echo
+RTN_PC_ALL          Any Retro PC Related Chat
+RTN_CONSOLES        Any Retro Gaming Console Related
+RTN_ADM             RetroNet Administration
+RTN_SUGGEST         Suggestions For RetroNet
+RTN_EMULATE         Emulating Retro Systems

--- a/test/fixtures/area_lists/spooknet-baselist.txt
+++ b/test/fixtures/area_lists/spooknet-baselist.txt
@@ -1,0 +1,46 @@
+[ADMIN] SpookNet Sysop Net Chat               SN_SYSOP
+Aliens, UFOs & EBEs                           SN_ALIEN
+Computer Security & Hacking                   SN_SECURITY
+Counter-Terrorism                             SN_TERROR
+Covert Communication                          SN_COVERT
+Cryptography & Steganography                  SN_CRYPTO
+Darknets, Network Underground                 SN_DARKNET
+Disease, Pandemics & Disasters                SN_DISASTER
+End Times & The Last Days                     SN_END_TIME
+Truth, Polygraphs, Serums                     SN_TRUTH
+Financial Crisis & Meltdown                   SN_FINANCIAL
+General Conspiracies                          SN_CONSPIRACY
+General Forensics                             SN_FORENSICS
+Intelligence & Espionage                      SN_INTEL
+Intelligence & The Law                        SN_LAW
+Interrogation & Torture                       SN_TORTURE
+Languages & Public Speaking                   SN_LANG
+Middle East Studies                           SN_MID_EAST
+Mind Control & Programming                    SN_MIND
+New World Order                               SN_NWO
+Paranormal Studies                            SN_PARANORMAL
+Predictive Studies                            SN_PREDICT
+Propaganda & Disinformation                   SN_DISINFO
+Politics & People                             SN_POLITICS
+Safe Houses & Sanctuarie                      SN_SAFE_HOUSE
+Secret Societies                              SN_SOCIETY
+Silencers of Information                      SN_SILENCE
+Spooks & Their Weapons                        SN_WEAPONS
+TSCM Bug Detection                            SN_TSCM
+Violent Extremist Religions                   SN_RELIGION
+Whistle Blowers                               SN_WHISTLE
+
+
+
+Filebone Aras:
+--------------
+--------------
+
+
+Private to Sysops                             SN_FSYSOP
+Infopacks                                     SN_FINFOPACK
+Intelligence                                  SN_FINTEL
+Computer Security                             SN_FSECURITY
+Conspiracy                                    SN_FCONSPIRACY
+Religion & Faith                              SN_RELIGION
+Miscellaneos                                  SN_FMISC

--- a/test/fixtures/area_lists/zer0net-file.na
+++ b/test/fixtures/area_lists/zer0net-file.na
@@ -1,0 +1,3 @@
+Area 0N-INFOP  0     !      Zer0net - Current Zer0net Infopack
+Area 0N-DMNIC  0     !      Zer0net - New Demonic Productionz Releases
+Area 0N-NODEL  0     !      Zer0net - Current Zer0net Node List

--- a/test/fixtures/area_lists/zer0net-msg.na
+++ b/test/fixtures/area_lists/zer0net-msg.na
@@ -1,0 +1,9 @@
+0N-BBS              Zer0net - The BBS scene! Art scene, modding, and BBS ads
+0N-CHAT             Zer0net - General chat, including news and announcements
+0N-CODE             Zer0net - Programming/scripting, demo scene, tracking
+0N-DPUB             Zer0net - Demonic Productions releases and discussion
+0N-ENTRT            Zer0net - Entertainment! Movies, TV, music, gaming
+0N-HPCAV            Zer0net - Hacking, phreaking, anarchy. All that phun stuff
+0N-RETRO            Zer0net - Retro computing, retro gaming, emulation
+0N-SYSOP            Zer0net - Restricted area for node SysOp chat and testing
+0N-WAREZ            Zer0net - Warez scene, cracking, file requests/sharing

--- a/test/ftn_areafix_rescan.test.js
+++ b/test/ftn_areafix_rescan.test.js
@@ -201,6 +201,47 @@ describe('FTN AreaFix rescan requests', () => {
         );
     });
 
+    it('persists through the message network layer so @immediate export fires', async () => {
+        //
+        //  A bare message.persist() stores the netmail but never records it
+        //  with the message network modules, and record() is what drives
+        //  "@immediate" export. A system scheduling export as "@immediate"
+        //  alone -- no time component -- would queue the request and never
+        //  send it. Caught on a live instance, where the outbound spool
+        //  stayed empty while the log said the request had been queued.
+        //
+        const messageArea = require('../core/message_area.js');
+        const savedPersistMessage = messageArea.persistMessage;
+
+        const recorded = [];
+        messageArea.persistMessage = (message, cb) => {
+            recorded.push(message);
+            return message.persist(cb);
+        };
+
+        try {
+            await request(
+                makeModule({
+                    rescan: true,
+                    rescanUplink: '21:1/100',
+                    rescanCommand: '=%TAG% R=%DAYS%',
+                })
+            );
+        } finally {
+            messageArea.persistMessage = savedPersistMessage;
+        }
+
+        assert.equal(recorded.length, 1, 'the rescan netmail must be recorded');
+        assert.equal(recorded[0].toUserName, 'AreaFix');
+
+        //  ...and it must still look like NetMail to the exporter: private,
+        //  with no local recipient, which is what isNetMailMessage() requires
+        assert.equal(
+            recorded[0].meta.System[Message.SystemMetaNames.LocalToUserID],
+            undefined
+        );
+    });
+
     it('records what it asked for so the reply can be correlated', async () => {
         const inst = makeModule({
             rescan: true,

--- a/test/ftn_areafix_rescan.test.js
+++ b/test/ftn_areafix_rescan.test.js
@@ -1,0 +1,395 @@
+'use strict';
+
+//
+//  AreaFix rescan requests and reply handling.
+//
+//  The load-bearing behaviour here is what does NOT happen. FSC-0057's
+//  "=TAG R=n" is spec correct and works against Mystic and CrashMail II, but
+//  husky and SBBSecho have no '=' case: the line falls through to a subscribe
+//  of a garbage tag, and a husky hub with forwardRequests may pass that
+//  upstream as a request for a new area. There is no portable syntax, so
+//  there is deliberately no default command and nothing is sent without one.
+//
+
+const { strict: assert } = require('assert');
+
+const configModule = require('../core/config.js');
+const { AreaFixStatus } = require('../core/areafix_reply.js');
+
+const FTN_BSO_PATH = require.resolve('../core/scanner_tossers/ftn_bso.js');
+
+//
+//  Resolved per test rather than at file load. Two other suites replace
+//  core/message.js and core/stat_log.js in the require cache while loading, so
+//  a reference captured here can end up pointing at a singleton the code under
+//  test no longer uses -- and stubbing it would have no effect.
+//
+let Message;
+let User;
+let StatLog;
+
+let restoreConfig;
+let savedPersist;
+let savedGetUserName;
+let savedGetSystemStat;
+let savedSetSystemStat;
+let persisted;
+let statStore;
+
+function installStubs() {
+    Message = require('../core/message.js');
+    User = require('../core/user.js');
+    StatLog = require('../core/stat_log.js');
+
+    persisted = [];
+    statStore = {};
+
+    savedPersist = Message.prototype.persist;
+    Message.prototype.persist = function (cb) {
+        persisted.push(this);
+        return cb(null);
+    };
+
+    savedGetUserName = User.getUserName;
+    User.getUserName = (userId, cb) => cb(null, 'SysOp');
+
+    savedGetSystemStat = StatLog.getSystemStat;
+    savedSetSystemStat = StatLog.setSystemStat;
+    StatLog.getSystemStat = name => statStore[name];
+    StatLog.setSystemStat = (name, value) => {
+        statStore[name] = value;
+    };
+}
+
+function removeStubs() {
+    Message.prototype.persist = savedPersist;
+    User.getUserName = savedGetUserName;
+    StatLog.getSystemStat = savedGetSystemStat;
+    StatLog.setSystemStat = savedSetSystemStat;
+
+    if (restoreConfig) {
+        restoreConfig();
+        restoreConfig = undefined;
+    }
+    delete require.cache[FTN_BSO_PATH];
+}
+
+function makeConfig(onDemand) {
+    return {
+        debug: { assertsEnabled: false },
+        scannerTossers: {
+            ftn_bso: { paths: { inbound: '/tmp', secInbound: '/tmp', outbound: '/tmp' } },
+        },
+        messageConferences: {
+            fsxnet: { name: 'fsxNet', desc: 'fsxNet', areas: {} },
+        },
+        messageNetworks: {
+            ftn: {
+                networks: {
+                    fsxnet: {
+                        localAddress: '21:1/121',
+                        autoAreas: {
+                            confTag: 'fsxnet',
+                            onDemand: Object.assign({ enabled: true }, onDemand),
+                        },
+                    },
+                },
+                areas: {},
+            },
+        },
+    };
+}
+
+function makeModule(onDemand) {
+    const prev = configModule._pushTestConfig(makeConfig(onDemand));
+    restoreConfig = () => configModule._popTestConfig(prev);
+
+    delete require.cache[FTN_BSO_PATH];
+    const { getModule } = require('../core/scanner_tossers/ftn_bso.js');
+    return new getModule();
+}
+
+const CREATED = {
+    created: [
+        { ftnTag: 'FSX_BBS', areaTag: 'fsx_bbs' },
+        { ftnTag: 'FSX_MYS', areaTag: 'fsx_mys' },
+    ],
+    rejected: [],
+    pruned: [],
+};
+
+describe('FTN AreaFix rescan requests', () => {
+    beforeEach(() => {
+        installStubs();
+    });
+
+    afterEach(() => {
+        removeStubs();
+    });
+
+    const request = inst =>
+        new Promise(resolve =>
+            inst.maybeRequestAreaFixRescan('fsxnet', CREATED, resolve)
+        );
+
+    it('sends nothing when rescan is not enabled', async () => {
+        await request(makeModule({}));
+        assert.equal(persisted.length, 0);
+    });
+
+    it('sends nothing when no rescanCommand is configured', async () => {
+        //  There is no safe default: the same line means different things to
+        //  different tossers, and to two of them it means "add this area".
+        await request(makeModule({ rescan: true, rescanUplink: '21:1/100' }));
+        assert.equal(persisted.length, 0);
+    });
+
+    it('sends nothing when the uplink address is missing or invalid', async () => {
+        await request(makeModule({ rescan: true, rescanCommand: '=%TAG% R=%DAYS%' }));
+        assert.equal(persisted.length, 0);
+
+        await request(
+            makeModule({
+                rescan: true,
+                rescanUplink: 'not-an-address',
+                rescanCommand: '=%TAG% R=%DAYS%',
+            })
+        );
+        assert.equal(persisted.length, 0);
+    });
+
+    it('sends one NetMail with a command per created area', async () => {
+        await request(
+            makeModule({
+                rescan: true,
+                rescanUplink: '21:1/100',
+                rescanPassword: 'SECRET',
+                rescanDays: 30,
+                rescanCommand: '=%TAG% R=%DAYS%',
+            })
+        );
+
+        assert.equal(persisted.length, 1);
+        const msg = persisted[0];
+
+        assert.equal(msg.areaTag, Message.WellKnownAreaTags.Private);
+        assert.equal(msg.toUserName, 'AreaFix');
+        assert.equal(msg.subject, 'SECRET'); //  AreaFix password goes in the subject
+        assert.equal(msg.meta.System[Message.SystemMetaNames.RemoteToUser], '21:1/100');
+        assert.equal(
+            msg.meta.System[Message.SystemMetaNames.ExternalFlavor],
+            Message.AddressFlavor.FTN
+        );
+
+        assert.equal(msg.message, '=FSX_BBS R=30\r\n=FSX_MYS R=30\r\n');
+    });
+
+    it('uses whatever syntax the uplink actually speaks', async () => {
+        //  the husky / SBBSecho form
+        await request(
+            makeModule({
+                rescan: true,
+                rescanUplink: '21:1/100',
+                rescanDays: 14,
+                rescanCommand: '%RESCAN %TAG% R=%DAYS%',
+            })
+        );
+
+        assert.equal(
+            persisted[0].message,
+            '%RESCAN FSX_BBS R=14\r\n%RESCAN FSX_MYS R=14\r\n'
+        );
+    });
+
+    it('records what it asked for so the reply can be correlated', async () => {
+        const inst = makeModule({
+            rescan: true,
+            rescanUplink: '21:1/100',
+            rescanCommand: '=%TAG% R=%DAYS%',
+        });
+        await request(inst);
+
+        const pending = inst.getPendingAreaFixRequests();
+        assert.deepEqual(Object.keys(pending), ['21:1/100']);
+        assert.deepEqual(Object.keys(pending['21:1/100'].tags).sort(), [
+            'FSX_BBS',
+            'FSX_MYS',
+        ]);
+        assert.equal(pending['21:1/100'].network, 'fsxnet');
+    });
+});
+
+describe('FTN AreaFix reply handling', () => {
+    let inst;
+
+    beforeEach(() => {
+        installStubs();
+
+        inst = makeModule({});
+        inst.recordPendingAreaFixRequests('21:1/100', 'fsxnet', 'AreaFix', [
+            'FSX_BBS',
+            'FSX_MYS',
+        ]);
+        persisted = [];
+    });
+
+    afterEach(() => {
+        removeStubs();
+    });
+
+    function reply({ from = '21:1/100', fromUserName = 'AreaFix', body }) {
+        const message = new Message({
+            toUserName: 'SysOp',
+            fromUserName,
+            subject: 'Areafix reply: node change request',
+            message: body,
+            areaTag: Message.WellKnownAreaTags.Private,
+        });
+        message.meta.System[Message.SystemMetaNames.RemoteFromUser] = from;
+        return new Promise(resolve => inst.handleAreaFixReply(message, resolve));
+    }
+
+    it('notifies the operator and clears what was answered', async () => {
+        await reply({
+            body: [
+                ' FSX_BBS ........................... added',
+                ' FSX_MYS ........................... not found',
+            ].join('\r\n'),
+        });
+
+        assert.equal(persisted.length, 1);
+        assert.match(persisted[0].subject, /AreaFix reply from 21:1\/100/);
+        assert.match(persisted[0].message, /FSX_BBS: added/);
+        assert.match(persisted[0].message, /FSX_MYS: not_found/);
+
+        //  both answered, so nothing is still pending for that uplink
+        assert.deepEqual(Object.keys(inst.getPendingAreaFixRequests()), []);
+    });
+
+    it('leaves unanswered areas pending', async () => {
+        await reply({ body: ' FSX_BBS ........................... added' });
+
+        const pending = inst.getPendingAreaFixRequests();
+        assert.deepEqual(Object.keys(pending['21:1/100'].tags), ['FSX_MYS']);
+    });
+
+    it('ignores a NetMail from a system we sent nothing to', async () => {
+        await reply({ from: '21:1/999', body: ' FSX_BBS ....... added' });
+        assert.equal(persisted.length, 0);
+        assert.deepEqual(Object.keys(inst.getPendingAreaFixRequests()), ['21:1/100']);
+    });
+
+    it('ignores a NetMail from a human at the uplink', async () => {
+        await reply({
+            fromUserName: 'Some Sysop',
+            body: 'I linked FSX_BBS added it for you',
+        });
+        assert.equal(persisted.length, 0);
+    });
+
+    it('reports wording it does not recognize rather than acting on it', async () => {
+        await reply({ body: 'FSX_BBS wibbled sideways' });
+
+        assert.equal(persisted.length, 1);
+        assert.match(persisted[0].message, new RegExp(AreaFixStatus.Unknown));
+        assert.match(persisted[0].message, /wibbled sideways/);
+    });
+
+    it('does nothing for a NetMail with no remote from address', async () => {
+        const message = new Message({
+            toUserName: 'SysOp',
+            fromUserName: 'AreaFix',
+            subject: 'hi',
+            message: 'FSX_BBS added',
+            areaTag: Message.WellKnownAreaTags.Private,
+        });
+        await new Promise(resolve => inst.handleAreaFixReply(message, resolve));
+        assert.equal(persisted.length, 0);
+    });
+
+    it('drops pending requests older than the correlation window', async () => {
+        const stale = JSON.parse(statStore.ftn_areafix_pending);
+        stale['21:1/100'].tags.FSX_BBS.timestamp = '2020-01-01T00:00:00.000Z';
+        stale['21:1/100'].tags.FSX_MYS.timestamp = '2020-01-01T00:00:00.000Z';
+        statStore.ftn_areafix_pending = JSON.stringify(stale);
+
+        assert.deepEqual(Object.keys(inst.getPendingAreaFixRequests()), []);
+
+        await reply({ body: ' FSX_BBS ....... added' });
+        assert.equal(persisted.length, 0);
+    });
+});
+
+describe('FTN automatic area creation: operator notification', () => {
+    let inst;
+
+    beforeEach(() => {
+        installStubs();
+
+        inst = makeModule({});
+    });
+
+    afterEach(() => {
+        removeStubs();
+    });
+
+    const report = result =>
+        new Promise(resolve => inst.reportAutoCreatedAreas('fsxnet', result, resolve));
+
+    it('sends one message per batch, not one per area', async () => {
+        await report({
+            created: Array.from({ length: 300 }, (_, i) => ({
+                ftnTag: `FSX_${i}`,
+                areaTag: `fsx_${i}`,
+            })),
+            rejected: [],
+            pruned: [],
+        });
+
+        assert.equal(persisted.length, 1);
+        assert.match(persisted[0].subject, /300 message area\(s\) automatically created/);
+        assert.match(persisted[0].message, /FSX_0\s+->\s+fsx_0/);
+        assert.match(persisted[0].message, /FSX_299\s+->\s+fsx_299/);
+    });
+
+    it('says what was refused and why', async () => {
+        await report({
+            created: [{ ftnTag: 'FSX_BBS', areaTag: 'fsx_bbs' }],
+            rejected: [
+                {
+                    ftnTag: 'PRIVATE_MAIL',
+                    areaTag: 'private_mail',
+                    reason: 'would collide with a built-in system area',
+                },
+            ],
+            pruned: [],
+        });
+
+        assert.equal(persisted.length, 1);
+        assert.match(
+            persisted[0].message,
+            /PRIVATE_MAIL: would collide with a built-in system area/
+        );
+    });
+
+    it('tells the operator these areas are read-only and how to adopt one', async () => {
+        await report({
+            created: [{ ftnTag: 'FSX_BBS', areaTag: 'fsx_bbs' }],
+            rejected: [],
+            pruned: [],
+        });
+
+        assert.match(persisted[0].message, /read-only/);
+        assert.match(persisted[0].message, /config\.hjson/);
+        assert.match(persisted[0].message, /autoAreas\.ignore/);
+    });
+
+    it('sends nothing when nothing was created', async () => {
+        await report({
+            created: [],
+            rejected: [{ ftnTag: 'X', areaTag: 'x', reason: 'nope' }],
+            pruned: ['old_area'],
+        });
+        assert.equal(persisted.length, 0);
+    });
+});

--- a/test/ftn_auto_area_scan.test.js
+++ b/test/ftn_auto_area_scan.test.js
@@ -1,0 +1,260 @@
+'use strict';
+
+//
+//  Pass 1 of the two-pass toss: the read-only scan that finds FTN area tags
+//  with no local area configured.
+//
+//  These build real .pkt files with the real packet writer and run them
+//  through the real scan, because the properties that matter here are exactly
+//  the ones a mock would paper over: that the scan reads without consuming,
+//  and that it refuses the same packets the import refuses.  A packet whose
+//  messages will be rejected must not be able to create areas on the way past.
+//
+
+const { strict: assert } = require('assert');
+const fs = require('fs');
+const os = require('os');
+const paths = require('path');
+
+const configModule = require('../core/config.js');
+const { Packet, PacketHeader } = require('../core/ftn_mail_packet.js');
+const Message = require('../core/message.js');
+
+const FTN_BSO_PATH = require.resolve('../core/scanner_tossers/ftn_bso.js');
+
+let tempDir;
+let restoreConfig;
+
+//  21:1/121 -- what the fixture network is addressed as
+const LOCAL_ZONE = 21;
+const LOCAL_NET = 1;
+const LOCAL_NODE = 121;
+
+function makeConfig({ packetPassword } = {}) {
+    const nodes = {};
+    if (packetPassword) {
+        nodes['21:1/100'] = { packetPassword };
+    }
+
+    return {
+        debug: { assertsEnabled: false },
+        scannerTossers: {
+            ftn_bso: {
+                paths: {
+                    inbound: paths.join(tempDir, 'in'),
+                    secInbound: paths.join(tempDir, 'secin'),
+                    outbound: paths.join(tempDir, 'out'),
+                },
+                nodes,
+            },
+        },
+        messageConferences: {
+            fsxnet: { name: 'fsxNet', desc: 'fsxNet', areas: {} },
+        },
+        messageNetworks: {
+            ftn: {
+                networks: {
+                    fsxnet: { localAddress: '21:1/121' },
+                },
+                //  FSX_GEN is configured; FSX_BBS and FSX_MYS are not
+                areas: {
+                    fsx_gen: {
+                        network: 'fsxnet',
+                        tag: 'FSX_GEN',
+                        uplinks: ['21:1/100'],
+                    },
+                },
+            },
+        },
+    };
+}
+
+function makeHeader({ password = '' } = {}) {
+    const ph = new PacketHeader();
+    ph.origZone = 21;
+    ph.origNet = 1;
+    ph.origNode = 100;
+    ph.destZone = LOCAL_ZONE;
+    ph.destNet = LOCAL_NET;
+    ph.destNode = LOCAL_NODE;
+    ph.password = password;
+    return ph;
+}
+
+function makeEchoMessage(ftnAreaTag, subject) {
+    const message = new Message({
+        toUserName: 'All',
+        fromUserName: 'Someone',
+        subject,
+        message: 'body text',
+        areaTag: 'whatever',
+    });
+    message.meta.FtnProperty = Object.assign({}, message.meta.FtnProperty, {
+        ftn_area: ftnAreaTag,
+    });
+    message.meta.FtnKludge = message.meta.FtnKludge || {};
+    return message;
+}
+
+function writePacket(fileName, header, messages) {
+    const packetPath = paths.join(tempDir, 'in', fileName);
+    return new Promise((resolve, reject) => {
+        new Packet().write(packetPath, header, messages, {}, err => {
+            if (err) {
+                return reject(err);
+            }
+            //  write() streams; give the stream a tick to flush and close
+            setTimeout(() => resolve(packetPath), 50);
+        });
+    });
+}
+
+function makeModule() {
+    //  ftn_bso reads its module config from the pushed Config at construction
+    delete require.cache[FTN_BSO_PATH];
+    const { getModule } = require('../core/scanner_tossers/ftn_bso.js');
+    return new getModule();
+}
+
+function scan(inst, packetPath) {
+    return new Promise(resolve => {
+        inst.collectUnknownAreaTagsFromPacket(packetPath, (err, info) => resolve(info));
+    });
+}
+
+describe('FTN automatic area creation: read-only inbound scan', () => {
+    beforeEach(() => {
+        tempDir = fs.mkdtempSync(paths.join(os.tmpdir(), 'enig-areascan-'));
+        fs.mkdirSync(paths.join(tempDir, 'in'));
+        fs.mkdirSync(paths.join(tempDir, 'secin'));
+        fs.mkdirSync(paths.join(tempDir, 'out'));
+    });
+
+    afterEach(() => {
+        if (restoreConfig) {
+            restoreConfig();
+            restoreConfig = undefined;
+        }
+        delete require.cache[FTN_BSO_PATH];
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    function pushConfig(opts) {
+        const prev = configModule._pushTestConfig(makeConfig(opts));
+        restoreConfig = () => configModule._popTestConfig(prev);
+    }
+
+    it('finds area tags with no local area and ignores ones we already carry', async () => {
+        pushConfig();
+        const packetPath = await writePacket('test0001.pkt', makeHeader(), [
+            makeEchoMessage('FSX_GEN', 'configured'),
+            makeEchoMessage('FSX_BBS', 'not configured'),
+            makeEchoMessage('FSX_MYS', 'also not configured'),
+            makeEchoMessage('FSX_BBS', 'duplicate tag'),
+        ]);
+
+        const info = await scan(makeModule(), packetPath);
+
+        assert.ok(info);
+        assert.equal(info.networkName, 'fsxnet');
+        assert.deepEqual(info.ftnTags.sort(), ['FSX_BBS', 'FSX_MYS']);
+    });
+
+    it('does not consume or modify the packet it scanned', async () => {
+        pushConfig();
+        const packetPath = await writePacket('test0002.pkt', makeHeader(), [
+            makeEchoMessage('FSX_BBS', 'hello'),
+        ]);
+        const before = fs.readFileSync(packetPath);
+
+        await scan(makeModule(), packetPath);
+
+        assert.ok(fs.existsSync(packetPath), 'packet must survive the scan');
+        assert.ok(before.equals(fs.readFileSync(packetPath)));
+    });
+
+    it('refuses a packet whose password does not match', async () => {
+        pushConfig({ packetPassword: 'SECRET' });
+        const packetPath = await writePacket(
+            'test0003.pkt',
+            makeHeader({ password: 'WRONG' }),
+            [makeEchoMessage('FSX_BBS', 'hostile')]
+        );
+
+        //  The import rejects this packet, so nothing in it may create areas
+        assert.equal(await scan(makeModule(), packetPath), null);
+    });
+
+    it('accepts a packet whose password does match', async () => {
+        pushConfig({ packetPassword: 'SECRET' });
+        const packetPath = await writePacket(
+            'test0004.pkt',
+            makeHeader({ password: 'SECRET' }),
+            [makeEchoMessage('FSX_BBS', 'legit')]
+        );
+
+        const info = await scan(makeModule(), packetPath);
+        assert.deepEqual(info.ftnTags, ['FSX_BBS']);
+    });
+
+    it('refuses a packet that is not addressed to us', async () => {
+        pushConfig();
+        const header = makeHeader();
+        header.destNode = 999;
+
+        const packetPath = await writePacket('test0005.pkt', header, [
+            makeEchoMessage('FSX_BBS', 'misaddressed'),
+        ]);
+
+        assert.equal(await scan(makeModule(), packetPath), null);
+    });
+
+    it('survives a malformed packet without throwing', async () => {
+        pushConfig();
+        const packetPath = paths.join(tempDir, 'in', 'bad00001.pkt');
+        fs.writeFileSync(packetPath, Buffer.alloc(0));
+
+        assert.equal(await scan(makeModule(), packetPath), null);
+        assert.ok(fs.existsSync(packetPath));
+    });
+
+    it('collects across every packet in a directory', async () => {
+        pushConfig();
+        await writePacket('test0006.pkt', makeHeader(), [
+            makeEchoMessage('FSX_BBS', 'one'),
+        ]);
+        await writePacket('test0007.pkt', makeHeader(), [
+            makeEchoMessage('FSX_MYS', 'two'),
+        ]);
+
+        const inst = makeModule();
+        const collected = {};
+        await new Promise(resolve =>
+            inst.collectUnknownAreaTagsFromPacketDir(
+                paths.join(tempDir, 'in'),
+                collected,
+                resolve
+            )
+        );
+
+        assert.deepEqual(Array.from(collected.fsxnet).sort(), ['FSX_BBS', 'FSX_MYS']);
+        assert.equal(fs.readdirSync(paths.join(tempDir, 'in')).length, 2);
+    });
+
+    it('does nothing at all when no network has it enabled', async () => {
+        pushConfig();
+        await writePacket('test0008.pkt', makeHeader(), [
+            makeEchoMessage('FSX_BBS', 'one'),
+        ]);
+
+        const inst = makeModule();
+        let scanned = false;
+        inst.collectUnknownAreaTagsFromDirectory = (dir, collected, cb) => {
+            scanned = true;
+            return cb(null);
+        };
+
+        await new Promise(resolve => inst.maybeAutoCreateAreas(resolve));
+        assert.equal(scanned, false, 'no scan should run with the feature off');
+    });
+});

--- a/test/ftn_auto_area_scan.test.js
+++ b/test/ftn_auto_area_scan.test.js
@@ -258,3 +258,181 @@ describe('FTN automatic area creation: read-only inbound scan', () => {
         assert.equal(scanned, false, 'no scan should run with the feature off');
     });
 });
+
+//
+//  The whole path, end to end: real packets in a real inbound directory, a
+//  real config.hjson with a real include, through maybeAutoCreateAreas().
+//  Each half is covered above and in auto_area_create.test.js; this is the
+//  join between them.
+//
+describe('FTN automatic area creation: end to end', () => {
+    const hjson = require('hjson');
+    const autoAreaCreate = require('../core/auto_area_create.js');
+
+    let savedGet;
+    let savedReload;
+
+    before(() => {
+        savedGet = configModule.get;
+        savedReload = configModule.reload;
+    });
+
+    after(() => {
+        configModule.get = savedGet;
+        configModule.reload = savedReload;
+        delete require.cache[FTN_BSO_PATH];
+    });
+
+    function writeConfigHjson(autoAreas) {
+        const config = {
+            includes: [autoAreaCreate.GeneratedIncludeFileName],
+            debug: { assertsEnabled: false },
+            scannerTossers: {
+                ftn_bso: {
+                    paths: {
+                        inbound: paths.join(tempDir, 'in'),
+                        secInbound: paths.join(tempDir, 'secin'),
+                        outbound: paths.join(tempDir, 'out'),
+                    },
+                    nodes: {},
+                },
+            },
+            messageConferences: {
+                fsxnet: { name: 'fsxNet', desc: 'fsxNet', areas: {} },
+            },
+            messageNetworks: {
+                ftn: {
+                    networks: {
+                        fsxnet: Object.assign({ localAddress: '21:1/121' }, autoAreas),
+                    },
+                    areas: {
+                        fsx_gen: {
+                            network: 'fsxnet',
+                            tag: 'FSX_GEN',
+                            uplinks: ['21:1/100'],
+                        },
+                    },
+                },
+            },
+        };
+
+        fs.writeFileSync(
+            paths.join(tempDir, 'config.hjson'),
+            hjson.stringify(config, { emitRootBraces: true, space: 4, eol: '\n' }),
+            'utf8'
+        );
+    }
+
+    beforeEach(() => {
+        tempDir = fs.mkdtempSync(paths.join(os.tmpdir(), 'enig-autoarea-e2e-'));
+        ['in', 'secin', 'out'].forEach(d => fs.mkdirSync(paths.join(tempDir, d)));
+        fs.writeFileSync(
+            paths.join(tempDir, autoAreaCreate.GeneratedIncludeFileName),
+            '{}\n',
+            'utf8'
+        );
+    });
+
+    afterEach(() => {
+        delete require.cache[FTN_BSO_PATH];
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    function loadConfig() {
+        return new Promise((resolve, reject) =>
+            configModule.Config.create(
+                paths.join(tempDir, 'config.hjson'),
+                { hotReload: false },
+                err => (err ? reject(err) : resolve())
+            )
+        );
+    }
+
+    it('creates areas for unknown tags found in inbound mail, and they resolve', async () => {
+        writeConfigHjson({
+            autoAreas: {
+                confTag: 'fsxnet',
+                maxAutoCreate: 10,
+                onDemand: { enabled: true },
+            },
+        });
+        await loadConfig();
+
+        await writePacket('e2e00001.pkt', makeHeader(), [
+            makeEchoMessage('FSX_GEN', 'already configured'),
+            makeEchoMessage('FSX_BBS', 'unknown'),
+            makeEchoMessage('FSX_MYS', 'unknown too'),
+        ]);
+
+        const inst = makeModule();
+        await new Promise(resolve => inst.maybeAutoCreateAreas(resolve));
+
+        //  ...the areas now resolve, which is what lets pass 2 import the mail
+        const { getMessageAreaByTag } = require('../core/message_area.js');
+        assert.ok(getMessageAreaByTag('fsx_bbs'), 'fsx_bbs should now exist');
+        assert.ok(getMessageAreaByTag('fsx_mys'), 'fsx_mys should now exist');
+
+        //  ...and the tosser can map the FTN tag to them
+        assert.equal(inst.getLocalAreaTagByFtnAreaTag('FSX_BBS'), 'fsx_bbs');
+
+        //  read-only, both halves
+        const ftnArea = configModule.get().messageNetworks.ftn.areas.fsx_bbs;
+        assert.equal(ftnArea.uplinks, undefined);
+        assert.equal(getMessageAreaByTag('fsx_bbs').acs.write, autoAreaCreate.DenyAllAcs);
+
+        //  the packet is still there for pass 2
+        assert.ok(fs.existsSync(paths.join(tempDir, 'in', 'e2e00001.pkt')));
+    });
+
+    it('does nothing when the generated include is not wired into config.hjson', async () => {
+        writeConfigHjson({
+            autoAreas: {
+                confTag: 'fsxnet',
+                onDemand: { enabled: true },
+            },
+        });
+        //  drop the include entry, keeping the file
+        const configPath = paths.join(tempDir, 'config.hjson');
+        const parsed = hjson.parse(fs.readFileSync(configPath, 'utf8'));
+        parsed.includes = [];
+        fs.writeFileSync(
+            configPath,
+            hjson.stringify(parsed, { emitRootBraces: true, space: 4, eol: '\n' }),
+            'utf8'
+        );
+        await loadConfig();
+
+        await writePacket('e2e00002.pkt', makeHeader(), [
+            makeEchoMessage('FSX_BBS', 'unknown'),
+        ]);
+
+        const inst = makeModule();
+        await new Promise(resolve => inst.maybeAutoCreateAreas(resolve));
+
+        const { getMessageAreaByTag } = require('../core/message_area.js');
+        assert.equal(getMessageAreaByTag('fsx_bbs'), undefined);
+    });
+
+    it('honours the ignore list against real inbound mail', async () => {
+        writeConfigHjson({
+            autoAreas: {
+                confTag: 'fsxnet',
+                ignore: ['FSX_BOT'],
+                onDemand: { enabled: true },
+            },
+        });
+        await loadConfig();
+
+        await writePacket('e2e00003.pkt', makeHeader(), [
+            makeEchoMessage('FSX_BOT', 'noisy robot echo'),
+            makeEchoMessage('FSX_BBS', 'wanted'),
+        ]);
+
+        const inst = makeModule();
+        await new Promise(resolve => inst.maybeAutoCreateAreas(resolve));
+
+        const { getMessageAreaByTag } = require('../core/message_area.js');
+        assert.ok(getMessageAreaByTag('fsx_bbs'));
+        assert.equal(getMessageAreaByTag('fsx_bot'), undefined);
+    });
+});

--- a/test/ftn_auto_area_scan.test.js
+++ b/test/ftn_auto_area_scan.test.js
@@ -435,4 +435,56 @@ describe('FTN automatic area creation: end to end', () => {
         assert.ok(getMessageAreaByTag('fsx_bbs'));
         assert.equal(getMessageAreaByTag('fsx_bot'), undefined);
     });
+
+    it('mail that would have been skipped is routed to the new area on pass 2', async () => {
+        //
+        //  The whole point of the feature. Before pass 1, a message for an
+        //  unconfigured tag hits the unknown-area branch of the import, is
+        //  counted as skipped, and -- because the packet is unlinked straight
+        //  afterwards -- is gone. After pass 1 the same packet routes.
+        //
+        writeConfigHjson({
+            autoAreas: {
+                confTag: 'fsxnet',
+                maxAutoCreate: 10,
+                onDemand: { enabled: true },
+            },
+        });
+        await loadConfig();
+
+        const packetPath = await writePacket('e2e00004.pkt', makeHeader(), [
+            makeEchoMessage('FSX_GEN', 'known area'),
+            makeEchoMessage('FSX_BBS', 'unknown area'),
+        ]);
+
+        const inst = makeModule();
+
+        //  Stub only the DB-backed leaf so the real toss path runs
+        const routed = [];
+        inst.importMailToArea = (importConfig, header, message, cb) => {
+            routed.push({ areaTag: importConfig.localAreaTag, subject: message.subject });
+            return cb(null);
+        };
+
+        const toss = () =>
+            new Promise(resolve =>
+                inst.importMessagesFromPacketFile(packetPath, '', resolve)
+            );
+
+        await toss();
+        assert.deepEqual(
+            routed.map(r => r.subject),
+            ['known area'],
+            'the unknown-area message should be skipped before the areas exist'
+        );
+
+        routed.length = 0;
+        await new Promise(resolve => inst.maybeAutoCreateAreas(resolve));
+        await toss();
+
+        assert.deepEqual(routed.map(r => `${r.subject} -> ${r.areaTag}`).sort(), [
+            'known area -> fsx_gen',
+            'unknown area -> fsx_bbs',
+        ]);
+    });
 });

--- a/test/live/drill/README.md
+++ b/test/live/drill/README.md
@@ -1,0 +1,79 @@
+# FTN drill
+
+Drives automatic message area creation against a **real running ENiGMA½
+instance** — `./main.js`, the real scheduler, the real configuration watcher,
+real packets through the real tosser.
+
+```bash
+./test/live/drill/run.sh [drillDir] [path/to/menu.hjson]
+```
+
+It builds a throwaway configuration tree (its own databases, log, mail spool,
+and only telnet on port 9888), starts a real instance against it, and leaves
+the tree behind for inspection. **It does not touch your own configuration or
+data.**
+
+## Why this exists alongside the tests
+
+`test/live/ftn_auto_area.live.js` covers the same ground in-process and much
+faster. Three things it cannot cover, because it constructs the module itself:
+
+- **The configuration watcher.** The in-process test loads config with
+  `hotReload: false`. Only here does the `sane` watcher actually see the
+  generated file being renamed into place, which is how you find out whether
+  an atomic rename registers as a change on your platform.
+- **The scheduler.** Imports here are triggered the way a board triggers them
+  — through the `@watch:` file — rather than by calling `performImport()`.
+- **`@immediate` export.** This is how the bug fixed in `6417ed75` was found:
+  the rescan netmail was stored with a bare `message.persist()`, which never
+  records it with the message network modules, so `@immediate` never fired.
+  The outbound spool stayed empty while the log said the request was queued.
+  Nothing in-process noticed, because the test called `performExport()`
+  directly.
+
+## The mock uplink
+
+`robot.js` reads the request the board **actually sent** out of the outbound
+spool, extracts the area tags from it the way a conference manager would, and
+answers in a chosen dialect:
+
+| style | shape | from |
+|---|---|---|
+| `husky` | ` TAG ....... added` | `areafix.c`, dot fill |
+| `sbbsecho` | `TAG added.` | bare, trailing period |
+| `crashmail` | `+TAG<pad>Attached` | `%-30s STATUS`, command echoed |
+| `rescanned` | `TAG rescanned and 42 messages exported.` | variable tail, prefix matched |
+| `unknown` | ` TAG ....... wibbled sideways` | nothing says this |
+
+The last row is the point of the exercise: an unrecognized reply must be
+reported with its raw line rather than guessed at.
+
+**This cannot tell you how Mystic words its replies.** Nothing local can. It
+tells you the loop works end to end against a running board, and which
+dialects the parser understands.
+
+## What a good run looks like
+
+```
+== EchoMail arrives for areas that are not configured
+  [info] Refused to automatically create "TST_NOISY": in the network ignore list
+  [info] Automatically created 2 message area(s) for "testnet"
+  [info] Packet drill001.pkt imported with 3 new message(s), 1 message(s) skipped (unknown area)
+
+== The rescan request left the building
+  outbound/23ae1f2a.pkt
+  outbound/00010064.clo
+  [info] Queued AreaFix rescan request for 2 area(s)
+  [info] Message exported
+
+== A mock uplink answers, in each tosser's dialect
+  [info] AreaFix reply for "TST_HUSKX": added
+  [info] AreaFix reply for "TST_SBBSX": added
+  [info] AreaFix reply for "TST_CRASX": added
+  [info] AreaFix reply for "TST_RESCX": rescanned
+  [warn] AreaFix reply for "TST_UNKNX" was not understood "TST_UNKNX ... wibbled sideways"
+```
+
+One `skipped (unknown area)` is expected and correct — `TST_NOISY` is in the
+drill's `ignore` list, so no area is created for it and its message is not
+imported.

--- a/test/live/drill/mkpkt.js
+++ b/test/live/drill/mkpkt.js
@@ -1,0 +1,60 @@
+'use strict';
+
+//
+//  Write an inbound EchoMail packet into the drill's real inbound directory,
+//  as a mailer would. Area tags come from DRILL_AREAS.
+//
+
+const paths = require('path');
+
+const ROOT = paths.join(__dirname, '..', '..', '..');
+const DRILL = process.argv[2];
+const NAME = process.argv[3] || 'drill001.pkt';
+
+//  the packet writer asserts against Config(); it needs nothing else here
+require(paths.join(ROOT, 'core/config.js')).get = () => ({
+    debug: { assertsEnabled: false },
+});
+
+const { Packet, PacketHeader } = require(paths.join(ROOT, 'core/ftn_mail_packet.js'));
+const Message = require(paths.join(ROOT, 'core/message.js'));
+
+const header = new PacketHeader();
+header.origZone = 21;
+header.origNet = 1;
+header.origNode = 100;
+header.destZone = 21;
+header.destNet = 1;
+header.destNode = 121;
+
+const areas = (process.env.DRILL_AREAS || 'TST_GEN,TST_BBS,TST_ART,TST_NOISY').split(',');
+
+const messages = areas.map(areaTag => {
+    const message = new Message({
+        toUserName: 'All',
+        fromUserName: 'Remote User',
+        subject: `message for ${areaTag}`,
+        message: 'Body of the message.',
+        areaTag: 'placeholder',
+    });
+    message.meta.FtnProperty = Object.assign({}, message.meta.FtnProperty, {
+        ftn_area: areaTag,
+    });
+    message.meta.FtnKludge = {
+        MSGID: `21:1/100 ${Date.now().toString(16)}${Math.floor(Math.random() * 1e4)}`,
+    };
+    return message;
+});
+
+const out = paths.join(DRILL, 'in', NAME);
+new Packet().write(out, header, messages, {}, err => {
+    if (err) {
+        console.error(err);
+        process.exit(1);
+    }
+    //  the writer streams; let it flush before the tosser is told to look
+    setTimeout(() => {
+        console.log(`inbound: ${NAME} [${areas.join(', ')}]`);
+        process.exit(0);
+    }, 200);
+});

--- a/test/live/drill/mkuser.js
+++ b/test/live/drill/mkuser.js
@@ -1,0 +1,44 @@
+'use strict';
+
+//  Create the drill's sysop. AreaFix replies are addressed to a real user, and
+//  operator notifications need somewhere to land.
+
+const paths = require('path');
+
+const ROOT = paths.join(__dirname, '..', '..', '..');
+const DRILL = process.argv[2];
+
+const configModule = require(paths.join(ROOT, 'core/config.js'));
+const db = require(paths.join(ROOT, 'core/database.js'));
+const logger = require(paths.join(ROOT, 'core/logger.js'));
+
+configModule.Config.create(
+    paths.join(DRILL, 'config', 'config.hjson'),
+    { hotReload: false },
+    err => {
+        if (err) {
+            console.error('config:', err.message);
+            process.exit(1);
+        }
+
+        logger.init();
+        db.initializeDatabases(dbErr => {
+            if (dbErr) {
+                console.error('db:', dbErr.message);
+                process.exit(1);
+            }
+
+            const User = require(paths.join(ROOT, 'core/user.js'));
+            const user = new User();
+            user.username = 'drillop';
+            user.create({ password: 'drillpassword' }, userErr => {
+                if (userErr) {
+                    console.error('user:', userErr.message);
+                    process.exit(1);
+                }
+                console.log(`sysop: id=${user.userId} ${user.username}`);
+                process.exit(0);
+            });
+        });
+    }
+);

--- a/test/live/drill/robot.js
+++ b/test/live/drill/robot.js
@@ -1,0 +1,149 @@
+'use strict';
+
+//
+//  A mock AreaFix robot.
+//
+//  It reads the request the board *actually sent* out of the outbound spool,
+//  pulls the area tags out of it the way a real conference manager would, and
+//  answers in a chosen tosser's dialect.
+//
+//  This cannot tell you how Mystic words its replies -- nothing local can.
+//  What it does tell you is whether the whole loop works against a running
+//  board, and which dialects the parser understands. An unrecognized reply is
+//  supposed to degrade to "not understood" with the raw line rather than being
+//  guessed at, and the `unknown` style below exercises exactly that.
+//
+
+const fs = require('fs');
+const paths = require('path');
+
+const ROOT = paths.join(__dirname, '..', '..', '..');
+const [, , DRILL, style, opName] = process.argv;
+
+require(paths.join(ROOT, 'core/config.js')).get = () => ({
+    debug: { assertsEnabled: false },
+});
+
+const { Packet, PacketHeader } = require(paths.join(ROOT, 'core/ftn_mail_packet.js'));
+const Message = require(paths.join(ROOT, 'core/message.js'));
+
+const STYLES = {
+    //  husky areafix.c -- dot fill
+    husky: tag => ` ${tag} ${'.'.repeat(Math.max(3, 35 - tag.length))} added`,
+    //  SBBSecho -- bare, trailing period
+    sbbsecho: tag => `${tag} added.`,
+    //  CrashMail II -- "%-30s STATUS", command character echoed back
+    crashmail: tag => `+${tag.padEnd(30)}Attached`,
+    //  SBBSecho rescan confirmation -- variable tail, matched by prefix
+    rescanned: tag => `${tag} rescanned and 42 messages exported.`,
+    //  wording none of the three use: must be reported, not guessed
+    unknown: tag =>
+        ` ${tag} ${'.'.repeat(Math.max(3, 35 - tag.length))} wibbled sideways`,
+};
+
+if (!STYLES[style]) {
+    console.error(
+        `robot: unknown style "${style}"; try ${Object.keys(STYLES).join(', ')}`
+    );
+    process.exit(2);
+}
+
+const walk = dir =>
+    fs.existsSync(dir)
+        ? fs
+              .readdirSync(dir, { withFileTypes: true })
+              .flatMap(d =>
+                  d.isDirectory()
+                      ? walk(paths.join(dir, d.name))
+                      : [paths.join(dir, d.name)]
+              )
+        : [];
+
+//  newest first: nothing drains the spool here, so older requests linger
+const packets = walk(paths.join(DRILL, 'out'))
+    .filter(f => /\.(pkt|out|cut|hut|dut|iut)$/i.test(f))
+    .sort((a, b) => fs.statSync(b).mtimeMs - fs.statSync(a).mtimeMs);
+
+if (0 === packets.length) {
+    console.error('robot: no outbound request in the spool');
+    process.exit(2);
+}
+
+new Packet({ keepTearAndOrigin: false }).read(
+    packets[0],
+    (type, data, next) => {
+        if ('message' === type) {
+            const tags = data.message
+                .split(/\r?\n/)
+                .map(l => l.trim())
+                .filter(Boolean)
+                .map(l => /^[=+%-]?\s*([A-Z0-9_.-]+)/i.exec(l))
+                .filter(Boolean)
+                .map(m => m[1])
+                .filter(t => 'RESCAN' !== t.toUpperCase());
+
+            console.log(
+                `robot: read request to=${data.toUserName} password="${data.subject}" tags=${tags.join(',')}`
+            );
+            reply(tags);
+        }
+        return next(null);
+    },
+    err => {
+        if (err) {
+            console.error('robot: could not read the request:', err.message);
+            process.exit(2);
+        }
+    }
+);
+
+function reply(tags) {
+    const body = tags
+        .map(STYLES[style])
+        .concat([
+            '',
+            'Your linked areas:',
+            //  an area we never asked about; must be ignored
+            ' SOME_OTHER ....................... General chatter',
+        ])
+        .join('\r\n');
+
+    const header = new PacketHeader();
+    header.origZone = 21;
+    header.origNet = 1;
+    header.origNode = 100;
+    header.destZone = 21;
+    header.destNet = 1;
+    header.destNode = 121;
+
+    const message = new Message({
+        toUserName: opName,
+        fromUserName: 'AreaFix',
+        subject: 'AreaFix Reply',
+        message: body,
+        areaTag: 'placeholder',
+    });
+    message.meta.FtnProperty = Object.assign({}, message.meta.FtnProperty, {
+        ftn_attr_flags: Packet.Attribute.Private,
+        ftn_orig_node: 100,
+        ftn_orig_network: 1,
+        ftn_dest_node: 121,
+        ftn_dest_network: 1,
+    });
+    message.meta.FtnKludge = {
+        INTL: '21:1/121 21:1/100',
+        MSGID: `21:1/100 ${Date.now().toString(16)}`,
+    };
+
+    const out = paths.join(DRILL, 'in', `rply${Date.now().toString().slice(-4)}.pkt`);
+    new Packet().write(out, header, [message], {}, err => {
+        if (err) {
+            console.error(err);
+            process.exit(1);
+        }
+        setTimeout(() => {
+            console.log(`robot: answered in ${style} dialect`);
+            process.exit(0);
+        }, 200);
+    });
+}

--- a/test/live/drill/run.sh
+++ b/test/live/drill/run.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+#
+#  Drive automatic area creation against a REAL running ENiGMA½ instance.
+#
+#  Starts ./main.js against a throwaway configuration tree -- its own
+#  databases, log, mail spool and ports -- so nothing here touches your own
+#  board. See README.md.
+#
+set -u
+set +m   #  no job-control chatter when the instance is stopped
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/../../.." && pwd)"
+DRILL="${1:-/tmp/enigma-ftn-drill}"
+MENU="${2:-}"
+
+if [[ -z "$MENU" ]]; then
+    MENU="$(ls "$ROOT"/config/menus/*-main.hjson 2>/dev/null | head -1)"
+fi
+if [[ -z "$MENU" || ! -f "$MENU" ]]; then
+    echo "Could not find a menu file. Pass one:  run.sh <drillDir> <path/to/menu.hjson>"
+    exit 2
+fi
+
+say() { printf '\n\033[1m== %s\033[0m\n' "$*"; }
+logs() {
+    cat "$DRILL"/logs/*.log 2>/dev/null | node -e "
+let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{
+d.split('\n').filter(Boolean).forEach(l=>{try{const j=JSON.parse(l);
+ if(new RegExp(process.argv[1],'i').test(j.msg||''))
+  console.log('  ['+(j.level>=40?'warn':'info')+']', j.msg,
+    (j.areaTag?' '+j.areaTag:''), (j.status?' '+j.status:''),
+    (j.raw?' '+JSON.stringify(j.raw):''));
+}catch(e){}});});" "$1"
+}
+toss() { date > "$DRILL/trigger/import.now"; sleep "${1:-8}"; }
+
+stop() { pkill -f "main.js --config $DRILL" >/dev/null 2>&1; sleep 2; }
+trap stop EXIT
+
+say "Preparing $DRILL"
+stop
+rm -rf "$DRILL"; mkdir -p "$DRILL"
+node "$HERE/setup.js" "$DRILL" "$MENU"       || exit 1
+node "$ROOT/oputil.js" mb auto-areas init --config "$DRILL/config/" | grep -E 'Created|Added' 
+node "$HERE/mkuser.js" "$DRILL"              || exit 1
+
+say "Starting a real instance"
+( cd "$ROOT" && nohup ./main.js --config "$DRILL/config/" > "$DRILL/stdout.txt" 2>&1 & )
+for i in $(seq 1 30); do
+    grep -q 'System started!' "$DRILL/stdout.txt" 2>/dev/null && break
+    sleep 1
+done
+grep -qE 'System started!' "$DRILL/stdout.txt" || { tail -20 "$DRILL/stdout.txt"; exit 1; }
+grep -E 'listening|System started' "$DRILL/stdout.txt" | sed 's/^/  /'
+
+say "EchoMail arrives for areas that are not configured"
+node "$HERE/mkpkt.js" "$DRILL" drill001.pkt
+toss
+logs 'Automatically created|Refused to automatically|imported with'
+
+say "The rescan request left the building"
+find "$DRILL/out" -type f | sed "s|$DRILL/out/|  |"
+logs 'Queued AreaFix|Message exported|cannot be routed'
+
+say "A mock uplink answers, in each tosser's dialect"
+n=10
+for style in husky sbbsecho crashmail rescanned unknown; do
+    area="TST_$(echo "$style" | tr 'a-z' 'A-Z' | cut -c1-4)X"
+    find "$DRILL/out" -type f -delete 2>/dev/null
+    DRILL_AREAS="$area" node "$HERE/mkpkt.js" "$DRILL" "drill0$n.pkt" > /dev/null
+    toss 7
+    node "$HERE/robot.js" "$DRILL" "$style" drillop | sed 's/^/  /'
+    toss 7
+    n=$((n + 1))
+done
+logs 'AreaFix reply for'
+
+say "Restarting with a populated auto-areas.hjson"
+stop
+( cd "$ROOT" && nohup ./main.js --config "$DRILL/config/" > "$DRILL/stdout2.txt" 2>&1 & )
+for i in $(seq 1 30); do
+    grep -q 'System started!' "$DRILL/stdout2.txt" 2>/dev/null && break
+    sleep 1
+done
+grep -qE 'System started!' "$DRILL/stdout2.txt" \
+    && echo "  clean start with generated areas in place" \
+    || { tail -20 "$DRILL/stdout2.txt"; exit 1; }
+
+say "Areas as the board now sees them"
+node "$ROOT/oputil.js" mb list-confs --areas --config "$DRILL/config/" 2>/dev/null | sed 's/^/  /'
+
+say "Done -- drill tree left at $DRILL"

--- a/test/live/drill/setup.js
+++ b/test/live/drill/setup.js
@@ -1,0 +1,130 @@
+'use strict';
+
+//
+//  Build an isolated configuration tree for a real ENiGMA½ instance.
+//
+//  Everything lives under the drill directory: its own databases, log, mail
+//  spool and ports. Nothing touches the operator's own config or data.
+//
+
+const fs = require('fs');
+const paths = require('path');
+const hjson = require('hjson');
+
+const ROOT = paths.join(__dirname, '..', '..', '..');
+const DRILL = process.argv[2];
+const MENU = process.argv[3];
+
+if (!DRILL || !MENU) {
+    console.error('usage: setup.js <drillDir> <pathToMenuHjson>');
+    process.exit(2);
+}
+
+const LOCAL = '21:1/121';
+const UPLINK = '21:1/100';
+
+[
+    'config',
+    'db',
+    'db/mods',
+    'logs',
+    'in',
+    'secin',
+    'out',
+    'reject',
+    'trigger',
+    'drop',
+    'filebase',
+].forEach(d => fs.mkdirSync(paths.join(DRILL, d), { recursive: true }));
+
+const config = {
+    includes: ['auto-areas.hjson'],
+
+    general: {
+        boardName: 'FTN Drill',
+        prettyBoardName: 'Drill',
+        menuFile: MENU,
+    },
+
+    paths: {
+        db: paths.join(DRILL, 'db'),
+        modsDb: paths.join(DRILL, 'db', 'mods'),
+        logs: paths.join(DRILL, 'logs'),
+        dropFiles: paths.join(DRILL, 'drop'),
+    },
+
+    //  off every port a real instance on this box would want
+    loginServers: {
+        telnet: { enabled: true, port: 9888 },
+        ssh: { enabled: false },
+        webSocket: { ws: { enabled: false }, wss: { enabled: false } },
+    },
+    contentServers: {
+        web: { http: { enabled: false }, https: { enabled: false } },
+        gopher: { enabled: false },
+        nntp: { nntp: { enabled: false }, nntps: { enabled: false } },
+    },
+    chatServers: { mrc: { enabled: false } },
+
+    messageConferences: {
+        testnet: { name: 'TestNet', desc: 'Drill conference', areas: {} },
+    },
+
+    messageNetworks: {
+        ftn: {
+            networks: {
+                testnet: {
+                    localAddress: LOCAL,
+                    autoAreas: {
+                        confTag: 'testnet',
+                        maxAutoCreate: 25,
+                        ignore: ['TST_NOISY'],
+                        onDemand: {
+                            enabled: true,
+                            rescan: true,
+                            rescanUplink: UPLINK,
+                            rescanPassword: 'DRILLPASS',
+                            rescanDays: 30,
+                            //  the Mystic / CrashMail II form
+                            rescanCommand: '=%TAG% R=%DAYS%',
+                        },
+                    },
+                },
+            },
+            //  TST_GEN is configured; everything else the drill sends is not
+            areas: {
+                tst_gen: { network: 'testnet', tag: 'TST_GEN', uplinks: [UPLINK] },
+            },
+        },
+    },
+
+    scannerTossers: {
+        ftn_bso: {
+            defaultNetwork: 'testnet',
+            nodes: { [UPLINK]: { archiveType: 'ZIP', encoding: 'utf8' } },
+            //  without a route the rescan netmail cannot be exported
+            netMail: { routes: { '21:*': { address: UPLINK, network: 'testnet' } } },
+            paths: {
+                inbound: paths.join(DRILL, 'in'),
+                secInbound: paths.join(DRILL, 'secin'),
+                outbound: paths.join(DRILL, 'out'),
+                reject: paths.join(DRILL, 'reject'),
+            },
+            schedule: {
+                //  touching the watch file tosses immediately
+                import: `@watch:${paths.join(DRILL, 'trigger', 'import.now')}`,
+                //  proves the rescan request leaves without a timed schedule
+                export: '@immediate',
+            },
+        },
+    },
+};
+
+fs.writeFileSync(
+    paths.join(DRILL, 'config', 'config.hjson'),
+    hjson.stringify(config, { emitRootBraces: true, space: 4, eol: '\n' }),
+    'utf8'
+);
+
+console.log(`drill config: ${paths.join(DRILL, 'config', 'config.hjson')}`);
+console.log(`enigma root:  ${ROOT}`);

--- a/test/live/ftn_auto_area.live.js
+++ b/test/live/ftn_auto_area.live.js
@@ -1,0 +1,480 @@
+'use strict';
+
+//
+//  Automatic area creation driven the way a real board drives it.
+//
+//  Everything else in the suite stubs the leaves: importMailToArea is replaced,
+//  the archiver is faked, the message database never appears. That leaves the
+//  claim that matters unproven -- that mail which used to be dropped ends up in
+//  a real message base -- so this exercises the whole path for real:
+//
+//      a real config.hjson with a real `includes`
+//      real sqlite databases created under a temp directory
+//      real .pkt files written by the real packet writer
+//      the real performImport() / performExport()
+//      a real .zip opened by whatever archiver is configured
+//
+//  What it cannot cover is the network itself: no BinkP, and no actual uplink.
+//  The AreaFix reply below is a NetMail we hand to ourselves, so it proves the
+//  plumbing and the correlation, not that a given tosser words its replies the
+//  way we expect.
+//
+//  It runs in its own mocha process (`npm run test:live`, which `npm test`
+//  chains) because initializeDatabases() replaces the handles in
+//  core/database.js, and fourteen modules capture one of those at load time.
+//  Sharing a process with the unit suite would hand some of them a database
+//  belonging to a different test.
+//
+
+const { strict: assert } = require('assert');
+const fs = require('fs');
+const os = require('os');
+const paths = require('path');
+const hjson = require('hjson');
+const { execFileSync } = require('child_process');
+
+const configModule = require('../../core/config.js');
+const dbModule = require('../../core/database.js');
+const autoAreaCreate = require('../../core/auto_area_create.js');
+
+const FTN_BSO_PATH = require.resolve('../../core/scanner_tossers/ftn_bso.js');
+const FIXTURES = paths.join(__dirname, '..', 'fixtures', 'area_lists');
+
+const LOCAL = '21:1/121';
+const UPLINK = '21:1/100';
+
+let tempDir;
+let inst;
+let savedGet;
+let savedReload;
+let savedDbs;
+
+function haveZip() {
+    try {
+        execFileSync('zip', ['-h'], { stdio: 'ignore' });
+        execFileSync('unzip', ['-h'], { stdio: 'ignore' });
+        return true;
+    } catch (e) {
+        return false;
+    }
+}
+
+function writeConfig() {
+    const config = {
+        includes: [autoAreaCreate.GeneratedIncludeFileName],
+        general: { boardName: 'Integration' },
+        users: { usernameMin: 2, usernameMax: 16, requireActivation: false },
+        paths: {
+            db: paths.join(tempDir, 'db'),
+            modsDb: paths.join(tempDir, 'db', 'mods'),
+            logs: paths.join(tempDir, 'logs'),
+        },
+        fileBase: {
+            areaStoragePrefix: paths.join(tempDir, 'filebase'),
+            storageTags: { fsxnet_info: 'fsxnet_info' },
+            areas: {
+                fsxnet_info: {
+                    name: 'fsxNet Info',
+                    desc: 'fsxNet info packs',
+                    storageTags: ['fsxnet_info'],
+                },
+            },
+        },
+        messageConferences: {
+            fsxnet: { name: 'fsxNet', desc: 'fsxNet', areas: {} },
+        },
+        messageNetworks: {
+            ftn: {
+                networks: {
+                    fsxnet: {
+                        localAddress: LOCAL,
+                        autoAreas: {
+                            confTag: 'fsxnet',
+                            maxAutoCreate: 50,
+                            infoPack: {
+                                enabled: true,
+                                areaTag: 'fsxnet_info',
+                                match: 'fsxnet*.zip',
+                                areaFile: 'fsxnet.na',
+                            },
+                            onDemand: {
+                                enabled: true,
+                                rescan: true,
+                                rescanUplink: UPLINK,
+                                rescanPassword: 'RIGPASS',
+                                rescanDays: 30,
+                                rescanCommand: '=%TAG% R=%DAYS%',
+                            },
+                        },
+                    },
+                },
+                //  FSX_GEN is configured; FSX_BBS and FSX_MYS are not
+                areas: {
+                    fsx_gen: { network: 'fsxnet', tag: 'FSX_GEN', uplinks: [UPLINK] },
+                },
+            },
+        },
+        scannerTossers: {
+            ftn_bso: {
+                defaultNetwork: 'fsxnet',
+                nodes: { [UPLINK]: { archiveType: 'ZIP', encoding: 'utf8' } },
+                netMail: {
+                    routes: { '21:*': { address: UPLINK, network: 'fsxnet' } },
+                },
+                paths: {
+                    inbound: paths.join(tempDir, 'in'),
+                    secInbound: paths.join(tempDir, 'secin'),
+                    outbound: paths.join(tempDir, 'out'),
+                    reject: paths.join(tempDir, 'reject'),
+                },
+            },
+        },
+    };
+
+    fs.writeFileSync(
+        paths.join(tempDir, 'config', 'config.hjson'),
+        hjson.stringify(config, { emitRootBraces: true, space: 4, eol: '\n' }),
+        'utf8'
+    );
+    fs.writeFileSync(
+        paths.join(tempDir, 'config', autoAreaCreate.GeneratedIncludeFileName),
+        '{}\n',
+        'utf8'
+    );
+}
+
+function makeHeader() {
+    const { PacketHeader } = require('../../core/ftn_mail_packet.js');
+    const ph = new PacketHeader();
+    ph.origZone = 21;
+    ph.origNet = 1;
+    ph.origNode = 100;
+    ph.destZone = 21;
+    ph.destNet = 1;
+    ph.destNode = 121;
+    return ph;
+}
+
+let msgIdSeq = 0;
+function echoMessage(ftnAreaTag, subject) {
+    const Message = require('../../core/message.js');
+    const m = new Message({
+        toUserName: 'All',
+        fromUserName: 'Someone',
+        subject,
+        message: 'body',
+        areaTag: 'placeholder',
+    });
+    m.meta.FtnProperty = Object.assign({}, m.meta.FtnProperty, {
+        ftn_area: ftnAreaTag,
+    });
+    m.meta.FtnKludge = { MSGID: `${UPLINK} ${(++msgIdSeq).toString(16)}` };
+    return m;
+}
+
+function writePacket(name, messages) {
+    const { Packet } = require('../../core/ftn_mail_packet.js');
+    const packetPath = paths.join(tempDir, 'in', name);
+    return new Promise((resolve, reject) => {
+        new Packet().write(packetPath, makeHeader(), messages, {}, err => {
+            if (err) {
+                return reject(err);
+            }
+            setTimeout(() => resolve(packetPath), 60);
+        });
+    });
+}
+
+const runImport = () => new Promise(resolve => inst.performImport(resolve));
+const runExport = () => new Promise(resolve => inst.performExport(resolve));
+
+function messageRows() {
+    return dbModule.dbs.message
+        .prepare(
+            'SELECT area_tag, subject, from_user_name FROM message ORDER BY message_id;'
+        )
+        .all();
+}
+
+describe('FTN automatic area creation against real databases', function () {
+    this.timeout(30000);
+
+    before(done => {
+        savedGet = configModule.get;
+        savedReload = configModule.reload;
+        //  initializeDatabases() mutates the shared dbs object; other suites
+        //  inject their own handles into it, so put back what we found.
+        savedDbs = Object.assign({}, dbModule.dbs);
+
+        tempDir = fs.mkdtempSync(paths.join(os.tmpdir(), 'enig-ftn-live-'));
+        ['config', 'db', 'logs', 'in', 'secin', 'out', 'reject', 'filebase'].forEach(d =>
+            fs.mkdirSync(paths.join(tempDir, d), { recursive: true })
+        );
+        writeConfig();
+
+        configModule.Config.create(
+            paths.join(tempDir, 'config', 'config.hjson'),
+            { hotReload: false },
+            err => {
+                if (err) {
+                    return done(err);
+                }
+                dbModule.initializeDatabases(dbErr => {
+                    if (dbErr) {
+                        return done(dbErr);
+                    }
+
+                    //  a sysop for notifications and NetMail delivery to land on
+                    const User = require('../../core/user.js');
+                    const user = new User();
+                    user.username = 'integop';
+                    user.create({ password: 'integration' }, userErr => {
+                        if (userErr) {
+                            return done(userErr);
+                        }
+
+                        delete require.cache[FTN_BSO_PATH];
+                        inst =
+                            new (require('../../core/scanner_tossers/ftn_bso.js').getModule)();
+                        inst.createTempDirectories(done);
+                    });
+                });
+            }
+        );
+    });
+
+    after(() => {
+        configModule.get = savedGet;
+        configModule.reload = savedReload;
+        Object.keys(dbModule.dbs).forEach(k => delete dbModule.dbs[k]);
+        Object.assign(dbModule.dbs, savedDbs);
+        delete require.cache[FTN_BSO_PATH];
+        fs.rmSync(tempDir, { recursive: true, force: true });
+    });
+
+    // ─────────────────────────────────────────────────────────────────────────
+
+    it('imports mail for unknown areas that would previously have been lost', async () => {
+        await writePacket('live0001.pkt', [
+            echoMessage('FSX_GEN', 'known area message'),
+            echoMessage('FSX_BBS', 'unknown area message'),
+            echoMessage('FSX_MYS', 'another unknown'),
+        ]);
+
+        assert.ifError(await runImport());
+
+        const subjects = messageRows()
+            .filter(r => r.area_tag.startsWith('fsx_'))
+            .map(r => `${r.area_tag}|${r.subject}`)
+            .sort();
+
+        assert.deepEqual(subjects, [
+            'fsx_bbs|unknown area message',
+            'fsx_gen|known area message',
+            'fsx_mys|another unknown',
+        ]);
+
+        //  the packet was consumed, as it always is
+        assert.deepEqual(fs.readdirSync(paths.join(tempDir, 'in')), []);
+    });
+
+    it('created them read-only', () => {
+        const config = configModule.get();
+        const area = config.messageConferences.fsxnet.areas.fsx_bbs;
+
+        assert.equal(area.acs.write, autoAreaCreate.DenyAllAcs);
+        assert.equal(config.messageNetworks.ftn.areas.fsx_bbs.uplinks, undefined);
+        assert.equal(
+            inst.isAreaConfigValid(
+                Object.assign({}, config.messageNetworks.ftn.areas.fsx_bbs)
+            ),
+            false
+        );
+    });
+
+    it('told the operator once, listing what it made', () => {
+        const notices = messageRows().filter(
+            r => 'private_mail' === r.area_tag && /automatically created/.test(r.subject)
+        );
+        assert.equal(notices.length, 1);
+        assert.match(notices[0].subject, /^2 message area\(s\)/);
+    });
+
+    it('spooled a well-formed AreaFix request that reads back correctly', async () => {
+        assert.ifError(await runExport());
+
+        const walk = dir =>
+            fs
+                .readdirSync(dir, { withFileTypes: true })
+                .flatMap(d =>
+                    d.isDirectory()
+                        ? walk(paths.join(dir, d.name))
+                        : [paths.join(dir, d.name)]
+                );
+
+        const packets = walk(paths.join(tempDir, 'out')).filter(f =>
+            /\.(pkt|out|cut|hut|dut|iut)$/i.test(f)
+        );
+        assert.equal(packets.length, 1, 'expected exactly one outbound packet');
+
+        //  read it back with our own reader rather than trusting the writer
+        const { Packet } = require('../../core/ftn_mail_packet.js');
+        const seen = [];
+        await new Promise((resolve, reject) => {
+            new Packet({ keepTearAndOrigin: false }).read(
+                packets[0],
+                (type, data, next) => {
+                    seen.push({ type, data });
+                    return next(null);
+                },
+                err => (err ? reject(err) : resolve())
+            );
+        });
+
+        const header = seen.find(s => 'header' === s.type).data;
+        assert.equal(header.destNode, 100);
+        assert.equal(header.origNode, 121);
+
+        const message = seen.find(s => 'message' === s.type).data;
+        assert.equal(message.toUserName, 'AreaFix');
+        assert.equal(message.subject, 'RIGPASS'); //  AreaFix password
+        assert.match(message.message, /=FSX_BBS R=30/);
+        assert.match(message.message, /=FSX_MYS R=30/);
+    });
+
+    it('recorded the request so a reply can be correlated to it', () => {
+        const pending = inst.getPendingAreaFixRequests();
+        assert.deepEqual(Object.keys(pending), [UPLINK]);
+        assert.deepEqual(Object.keys(pending[UPLINK].tags).sort(), [
+            'FSX_BBS',
+            'FSX_MYS',
+        ]);
+    });
+
+    it('parses an uplink AreaFix reply arriving as ordinary inbound NetMail', async () => {
+        const { Packet } = require('../../core/ftn_mail_packet.js');
+        const Message = require('../../core/message.js');
+
+        const reply = new Message({
+            toUserName: 'integop',
+            fromUserName: 'AreaFix',
+            subject: 'Areafix reply: node change request',
+            message: [
+                ' FSX_BBS ........................... added',
+                ' FSX_MYS ........................... not found',
+                '',
+                'Your linked areas:',
+                //  an area we never asked about, which must be ignored
+                ' SOME_OTHER ........................ General chatter',
+            ].join('\r\n'),
+            areaTag: 'placeholder',
+        });
+        reply.meta.FtnProperty = Object.assign({}, reply.meta.FtnProperty, {
+            ftn_attr_flags: Packet.Attribute.Private,
+            ftn_orig_node: 100,
+            ftn_orig_network: 1,
+            ftn_dest_node: 121,
+            ftn_dest_network: 1,
+        });
+        reply.meta.FtnKludge = {
+            INTL: `${LOCAL} ${UPLINK}`,
+            MSGID: `${UPLINK} ${(++msgIdSeq).toString(16)}`,
+        };
+
+        await writePacket('live0002.pkt', [reply]);
+        assert.ifError(await runImport());
+
+        //  answered, so no longer pending
+        assert.deepEqual(inst.getPendingAreaFixRequests(), {});
+
+        const notice = messageRows().find(r => /AreaFix reply from/.test(r.subject));
+        assert.ok(notice, 'operator should have been told');
+
+        const body = dbModule.dbs.message
+            .prepare('SELECT message FROM message WHERE subject = ?;')
+            .get(notice.subject).message;
+
+        assert.match(body, /FSX_BBS: added/);
+        assert.match(body, /FSX_MYS: not_found/);
+        //  the %LIST entry for an area we never mentioned must not appear
+        assert.equal(/SOME_OTHER/.test(body), false);
+    });
+
+    // ─────────────────────────────────────────────────────────────────────────
+
+    (haveZip() ? it : it.skip)(
+        'takes real descriptions from a real .zip info pack',
+        async () => {
+            const FileEntry = require('../../core/file_entry.js');
+
+            const stage = paths.join(tempDir, 'packstage');
+            const store = paths.join(tempDir, 'filebase', 'fsxnet_info');
+            fs.mkdirSync(stage, { recursive: true });
+            fs.mkdirSync(store, { recursive: true });
+
+            //  the real fsxNet message list, plus the decoys the pack ships:
+            //  a FILEBONE file list with the same extension, and binaries
+            fs.copyFileSync(
+                paths.join(FIXTURES, 'fsxnet-2025.na'),
+                paths.join(stage, 'fsxnet.na')
+            );
+            fs.copyFileSync(
+                paths.join(FIXTURES, 'fsxnet-file-2025.na'),
+                paths.join(stage, 'fsx_file.na')
+            );
+            fs.writeFileSync(paths.join(stage, 'nodelist.z21'), 'binary junk');
+            fs.writeFileSync(paths.join(stage, 'readme.txt'), 'read me');
+
+            const zipPath = paths.join(store, 'fsxnet.zip');
+            execFileSync('zip', [
+                '-j',
+                '-q',
+                zipPath,
+                paths.join(stage, 'fsxnet.na'),
+                paths.join(stage, 'fsx_file.na'),
+                paths.join(stage, 'nodelist.z21'),
+                paths.join(stage, 'readme.txt'),
+            ]);
+
+            const entry = new FileEntry({
+                areaTag: 'fsxnet_info',
+                fileName: 'fsxnet.zip',
+                storageTag: 'fsxnet_info',
+                desc: 'fsxNet info pack',
+            });
+            await new Promise((resolve, reject) =>
+                entry.persist(err => (err ? reject(err) : resolve()))
+            );
+
+            assert.ifError(await runImport());
+
+            //  placeholders replaced with what fsxNet actually calls these
+            const areas = configModule.get().messageConferences.fsxnet.areas;
+            assert.equal(areas.fsx_bbs.name, 'BBS Support/Dev');
+            assert.equal(areas.fsx_bbs.desc, 'BBS Support/Dev');
+            assert.equal(areas.fsx_mys.desc, 'Mystic BBS Support/Dev');
+
+            //  ...and enrichment did not drop the write deny
+            assert.equal(areas.fsx_bbs.acs.write, autoAreaCreate.DenyAllAcs);
+
+            //  we are not linked to the rest of the pack, so nothing else was made
+            assert.deepEqual(Object.keys(areas).sort(), ['fsx_bbs', 'fsx_mys']);
+        }
+    );
+
+    (haveZip() ? it : it.skip)('does not re-ingest an unchanged pack', async () => {
+        const before = fs.statSync(
+            paths.join(tempDir, 'config', autoAreaCreate.GeneratedIncludeFileName)
+        ).mtimeMs;
+
+        assert.ifError(await runImport());
+
+        assert.equal(
+            fs.statSync(
+                paths.join(tempDir, 'config', autoAreaCreate.GeneratedIncludeFileName)
+            ).mtimeMs,
+            before,
+            'an unchanged pack should not rewrite anything'
+        );
+    });
+});


### PR DESCRIPTION
Implements #241 for EchoMail. Fixes #733 on the way.

File areas / TIC auto-creation stay out — message areas need two config entries, file areas additionally need a storage tag and a physical directory on disk, and an auto-created area writing to an unexpected path is a bigger deal than an unwanted echo.

## The bug

EchoMail arriving for an FTN area tag that is not configured is skipped with a `Log.warn` at `ftn_bso.js:1801`, and the packet is unlinked immediately afterwards. **Skipped means lost.** Link a new echo at your uplink before configuring it locally and the first batch is gone.

## What this adds

Automatic creation of those areas, per network, under `messageNetworks.ftn.networks.<net>.autoAreas`. **Off unless configured** — a system with no `autoAreas` block behaves exactly as before, and with no network enabled the new code paths return immediately without scanning anything.

Setup is one command:

```
./oputil.js mb auto-areas init
```

### Two-pass toss

Creating inline is not possible: it would mean writing config, reloading, and re-resolving *inside* the packet loop, with every message already iterated past still lost. So `performImport()` scans the inbound directories read-only first, creates the areas, then runs the import normally.

Pass 1 is new code rather than a reuse of the import, because the import disposes of its input as it goes — each tossed `.pkt` is archived then unlinked, and bundles are extracted, tossed and unlinked one at a time so a backlog drains monotonically. For bundles the scan costs a second extraction, into its own temp directory so the two do not delete each other's work.

The scan applies the same rejections the import applies — wrong destination, packet password mismatch. A packet whose messages will be rejected must not be able to create areas on the way past.

### Where created areas go

Into a generated `auto-areas.hjson` pulled in through `includes`, never into `config.hjson`. Includes merge with `_.defaultsDeep(config, includedConfig)`, so `config.hjson` wins: the generated file can be rewritten wholesale on every pass and an operator's own `desc` survives untouched. **No per-field provenance tracking is needed** — the precedence falls out of the merge. That was the concern that originally blocked this feature.

Consequences of that same merge are respected: no arrays are emitted (they merge by index, not replacement, and the customizer that fixes array semantics does not apply to includes), and nothing `config_default.js` defines is restated.

### Created areas are read-only, both halves

They carry no `uplinks`, so `isAreaConfigValid()` sends both export sites down their silent-skip path. That alone is **not** read-only: a local user could still post into an area that looks live and goes nowhere. So they also get `acs: { write: ID0 }`, which no user satisfies — enforced on all three post paths (FSE, NNTP, REST).

To adopt one, define it in `config.hjson` with your own `uplinks` and `acs`. Nothing in the generated file needs editing or deleting.

### Guardrails

* **Collisions are refused, never merged.** An FTN tag lower cases straight onto a local area tag, and `PRIVATE_MAIL` would land an echo in everyone's mailbox. Also refused: a tag already used in any conference, or carried by another network.
* **`maxAutoCreate` caps the total, not the run** — a per-run cap compounds, and ten runs of 500 is 5000 areas. The generated file is the durable counter.
* **`ignore` removes areas already created**, not just new ones, so it is a genuine un-create. Messages stay in the database keyed by area tag and reappear if the tag is created again.
* Writes are staged to a temp file and **parsed back before the rename** — a truncated include fails the entire config load and the board will not start.
* One operator notification per batch, not per area.

### Info pack enrichment

Areas start named after their FTN tag. The network info pack replaces that with real names. Ingest **queries the file area** rather than reacting to a TIC arrival, the same way a FREQ resolves a TIC-fed nodelist — so a pack that landed before the feature was enabled counts too, and a missed trigger is picked up next pass. An unchanged pack costs one query (`fileSha256` is populated by `scanFile` during TIC import).

It only renames areas we already carry. A pack lists what the *network* carries; creating from it wholesale leaves you with hundreds of permanently empty areas, so `createUnlinked` is opt-in.

Extraction is bounded — basename only, `.na`/`.txt` only, size caps — but enforcement is applied to **what actually lands on disk**, because the request cannot be assumed honoured: `extractTo()` silently downgrades to a full decompress when the archiver has no file-list verb, and `listEntries()` sizes are scraped from archiver stdout with a regex.

### AreaFix

Rescan after creation is **off by default and has no default command**. FSC-0057 specifies `=TAG R=n`, and Mystic and CrashMail II implement it — but husky and SBBSecho have no `=` case: the line falls through to a subscribe of a garbage tag, and a husky hub with `forwardRequests` may pass that upstream as a request for a new area. There is no portable form, so the operator states the one their uplink speaks or nothing is sent.

Replies are read only for requests we actually sent, correlated by uplink address, robot name and a 14 day window, and only lines naming a tag we asked about are considered — husky appends its full linked-areas list to the same netmail when `queryReports` is on.

The parser returns a **status enum and nothing else**, so a confirmation line can never become an area description. These are structurally identical and no regex separates them:

```
 FSX_GEN ........................... added              <- confirmation
 FSX_GEN ........................... General chatter    <- %LIST entry
```

Vocabulary is seeded from husky, SBBSecho and CrashMail II and extensible via `messageNetworks.ftn.areaFixStatusPhrases`; anything unrecognised is reported to the operator with the raw line rather than acted on.

---

## Fixes #733 — the shared parser

`oputil mb import-areas` parsed `.na` with one regex that skipped nothing. A leading `;` or `%` comment line became an area whose tag was the comment character. Measured against real packs, importing fsxNet's file echo list produced **18 junk areas** and AgoraNet's **14**, written straight into `config.hjson`.

Both oputil halves now share `core/area_import.js`, and the format is worked out from the file's **content**:

* `;`, `%` and `#` comments are skipped — fsxNet used `%` in its 2018 pack and `;` in the current one.
* A FILEBONE list — which six of eight surveyed networks ship named `*.na`, alongside their message list — is recognised and routed to `fb import-areas` instead of importing as areas all tagged `Area`.
* A **reversed-column** list is recognised and refused. SpookNet ships one, and the old parser took 35 entries from it with tags like `Aliens,`. Nothing on those lines is malformed enough to reject one at a time, so the decision has to be about the file as a whole — a charset check on the tag is not sufficient.
* Lines that survive but cannot be used are listed before the confirmation prompt instead of being silently dropped.

`fb import-areas` shares it too: FileGate `.ZXX` and FILEBONE `.NA` output was diffed **record for record** against the previous regex and is identical, area tags and storage tags included — changing those would orphan the storage directories of anyone who has already imported. A file echo list shipped as a plain `TAG Description` list (ArakNet's, among others) now imports rather than reporting "Nothing to import"; since that is indistinguishable from a *message* echo list, it says so before the confirmation prompt.

`AREAS.BBS` is unchanged — it cannot be told from a plain area list by shape, so it is still only assumed from the `.bbs` extension or `--type bbs`.

## Incidental fixes found on the way

* **`ConfigCache` served a stale include.** It caches parsed configs by path and is refreshed only by the file watcher, so a reload immediately after a write returned the *previous* copy and the new areas did not resolve. `ConfigLoader` gains an explicit `reload()` that forces a re-cache — and returns the error directly, unlike `ConfigChanged`, which fires only on *success*, so an unguarded await after a bad include never returns.
* **A missing `includes:` file gave wrong advice at boot.** It said "Configuration file does not exist" and told you to run `oputil config new`, printing the literal placeholder `'{configFile}'` from a single-quoted string. Both cases now name the file actually missing.
* **`mb auto-areas init` no longer reformats `config.hjson`.** `writeConfig()` round-trips the whole document; against a real 688-line hand-maintained config that is a seven-hunk diff for a one-line addition. The include is now inserted textually and the result parsed back and compared against the original before writing — it must parse, must list the file, and must be otherwise deep-equal. It appends **last**, since includes merge in order and the earliest wins.
* **A queued AreaFix rescan with no NetMail route never left**, while the log said it was queued. Now warns at queue time.
* **The AreaFix rescan request was never exported on an `@immediate`-only schedule.** It was stored with a bare `message.persist()`, which does not record the message with the message network modules — and `record()` is what drives `@immediate`. The outbound spool stayed empty while the log said the request had been queued. Now goes through `persistMessage()`.
* `ftn_bso` and the new modules look up `config.js`'s getter per call instead of capturing it at load, matching `message_area.js`. A load-time capture freezes whichever getter was installed first — an existing test already had a require-cache workaround for exactly that.

## Tests

1724 unit, plus a live integration pass (`npm run test:live`, chained from `npm test`) that drives the whole thing for real: a temp `config.hjson` with a real `includes`, **real sqlite databases**, real `.pkt` files, the real `performImport()`/`performExport()`, and a real `.zip` opened by the configured archiver.

Every other test stubs the leaves, which left the claim that matters unproven — that mail which used to be dropped ends up in a real message base. The live pass covers three EchoMail messages (one configured area, two not) all landing in `message.sqlite3`; the AreaFix request spooled and read back with our own reader; a reply arriving as ordinary inbound NetMail and correlated, with an unrelated `%LIST` entry ignored; and real fsxNet descriptions taken out of a real zip with the FILEBONE decoy left alone.

It runs in its own process: `initializeDatabases()` replaces the handles in `core/database.js` and fourteen modules capture one at load time, so sharing a process hands some of them a database belonging to a different test.

Parser coverage is the thirteen committed fixtures from eight real networks with their measured entry counts, plus tabs, CRLF, bare CR, missing final newline and a leading BOM.

### The drill

`./test/live/drill/run.sh` starts a **real `./main.js`** against a throwaway configuration tree — its own databases, log, mail spool and ports — drops real packets in, and drives the feature through the real scheduler. It touches nothing of the operator's.

Three things the in-process test structurally cannot cover, because it builds the module itself:

- **The configuration watcher.** The in-process test loads config with `hotReload: false`, so nothing there ever watched the generated file being renamed into place. The drill shows `sane` reporting the atomic rename as a change, with the areas already live from the explicit reload before it — the design listed this as unverified.
- **The scheduler.** Imports are triggered through the `@watch:` file rather than by calling `performImport()`.
- **`@immediate` export** — which is how the bug above was found.

A mock uplink reads the request the board *actually sent* out of the outbound spool, pulls the tags from it the way a conference manager would, and answers in a chosen dialect:

```
[info] AreaFix reply for "TST_HUSKX": added      "TST_HUSKX ......... added"
[info] AreaFix reply for "TST_SBBSX": added      "TST_SBBSX added."
[info] AreaFix reply for "TST_CRASX": added      "+TST_CRASX        Attached"
[info] AreaFix reply for "TST_RESCX": rescanned  "TST_RESCX rescanned and 42 messages exported."
[warn] AreaFix reply for "TST_UNKNX" was not understood  "TST_UNKNX ......... wibbled sideways"
```

All four real dialects parse. The invented one is reported with its raw line rather than guessed at, which is the behaviour that matters. It cannot tell us how Mystic words its replies — nothing local can.

## Not verified

Needs a live uplink; none of it is fakeable locally:

1. **Reply wording.** The vocabulary came from reading sources. The drill proves a reply is found, correlated and parsed against four dialects — not that Mystic phrases things the way any of them do. A mismatch surfaces as "not understood" with the raw line, which is the designed failure.
2. **`=TAG R=n` against a live Mystic hub** — documented in its shipped `areafixhelp.txt`, never executed.
3. **The filename fsxNet hatches** — `match: "fsxnet*.zip"` is assumed from the web copy.
4. **Backlog cost.** Two-pass doubles packet parse cost and adds one extraction per bundle per cycle, when enabled. Never measured against real volume.

Going onto Xibalba first, staged, before this merges.

## Docs

`docs/_docs/messageareas/ftn.md` (setup, read-only default, adopting an area, info pack, per-uplink rescan syntax, removal), `docs/_docs/admin/oputil.md`, `WHATSNEW.md` and `UPGRADE.md`.

