### PR TITLE
fix(ftn): file routed NetMail under the uplink's zone, not the recipient's

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -22,6 +22,16 @@ Refer to [Upgrading](./docs/_docs/admin/upgrading.md) for details around this pr
 
 ## 0.5.0-beta to 0.5.1-beta
 
+* **Cross-zone routed NetMail queued before this release will not have been delivered, and needs moving by hand** ([#734](https://github.com/NuSkooler/enigma-bbs/issues/734)). NetMail routed through an uplink in a zone other than the recipient's was filed in the outbound directory for the *recipient's* zone rather than the uplink's, where no mailer would ever find it. The fix applies to newly exported mail only -- it does not relocate what is already queued.
+
+  **Action:** only if you route NetMail across zones. Look for a zone-suffixed outbound directory that should not hold mail for that uplink -- for a `1:154/10` uplink carrying zone 2 mail, that is `outbound.002/009a000a.*` (`009a` = net 154, `000a` = node 10) plus the `.pkt` files its flow file names. Move both the flow file and the packets into the uplink's own outbound directory (`outbound/` when the uplink is in your network's default zone). **The stored paths inside the flow file do not need editing** -- a reference that no longer resolves is now also looked for by name in the flow file's own directory. If you would rather not sort it out, deleting the stray directory's contents loses the affected messages and nothing else.
+
+  Two related changes are worth knowing about even if none of this applies to you: a flow file entry whose file is missing is now logged rather than silently skipped, and a node whose entries all point at missing files is no longer reported as having pending mail -- so it stops being dialled every poll cycle with nothing to send.
+
+* **The most specific `nodes{}` and NetMail `routes{}` pattern now wins, rather than the first one written.** Where only one pattern matched an address nothing changes. Where several matched, the entry that applied used to depend on the order of your `config.hjson`.
+
+  **Action:** review your configuration if it mixes a wildcard with more specific entries that also match. Two cases change behaviour, both towards what the specific entry says: a `"21:*"` node block written above `"21:1/100"` no longer shadows that node's own settings -- including `packetPassword`, which means a packet password you configured and believed to be in force may only now start being enforced -- and a `"*"` NetMail route written above `"21:*"` no longer claims mail the narrower route was meant to take.
+
 * **The `download` file area ACS is now actually enforced.** It previously applied only to the REST API; over telnet and SSH any user who could browse an area could also download from it. If you set a `download` ACS on any file area expecting it to restrict downloads, **it was not doing so until now**.
 
   **Action:** review your `fileBase.areas` ACS blocks. Areas with no `download` ACS are unaffected -- the default (`GM[users]`) matches the `read` default, so nothing changes for them. Areas where you *did* set `download` will now restrict downloads to what you configured, which may be tighter than what users have actually been getting. Note that an entry whose area is no longer in `config.hjson` fails closed and can no longer be downloaded.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -32,6 +32,17 @@ Refer to [Upgrading](./docs/_docs/admin/upgrading.md) for details around this pr
 
   **Action:** review your configuration if it mixes a wildcard with more specific entries that also match. Two cases change behaviour, both towards what the specific entry says: a `"21:*"` node block written above `"21:1/100"` no longer shadows that node's own settings -- including `packetPassword`, which means a packet password you configured and believed to be in force may only now start being enforced -- and a `"*"` NetMail route written above `"21:*"` no longer claims mail the narrower route was meant to take.
 
+  **The same rule can also relax a packet password, so check this direction too.** A matching entry is used whole; its fields are not merged with those of the wildcard it beat. So where the wildcard carries the password and the specific entry does not:
+
+  ````hjson
+  nodes: {
+      "21:*"     : { packetPassword: MUHPA55 }
+      "21:1/100" : { archiveType: ZIP }        //  no packetPassword
+  }
+  ````
+
+  packets from `21:1/100` used to be password checked by way of the wildcard and now are not, because the specific entry wins and sets no password. If any of your specific node blocks omit a `packetPassword` that a broader entry supplies, add it to them.
+
 * **The `download` file area ACS is now actually enforced.** It previously applied only to the REST API; over telnet and SSH any user who could browse an area could also download from it. If you set a `download` ACS on any file area expecting it to restrict downloads, **it was not doing so until now**.
 
   **Action:** review your `fileBase.areas` ACS blocks. Areas with no `download` ACS are unaffected -- the default (`GM[users]`) matches the `read` default, so nothing changes for them. Areas where you *did* set `download` will now restrict downloads to what you configured, which may be tighter than what users have actually been getting. Note that an entry whose area is no longer in `config.hjson` fails closed and can no longer be downloaded.

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -3,6 +3,22 @@ This document attempts to track **major** changes and additions in ENiGMA½. For
 
 ## 0.5.1-beta
 
+* **Routed cross-zone NetMail was filed where nothing would ever look for it** ([#734](https://github.com/NuSkooler/enigma-bbs/issues/734)) -- NetMail routed through an uplink in a different zone than the recipient (the standard FidoNet zone gate: zone 2 mail leaving through a zone 1 hub) was written to the outbound directory of the *recipient's* zone instead of the *uplink's*. A mailer only looks in the zone of the node it is calling, so the session to the uplink completed cleanly having transferred nothing and the message sat on disk indefinitely.
+
+  Nothing surfaced it. The packet's flow file was named for the uplink but filed under the recipient's zone, so the pending-mail scan -- which reads a node's address from the directory's zone plus the flow file's name -- reported a node that does not exist (`2:154/10`, for an uplink of `1:154/10`), which the poller then skipped at `debug` level. Every visible signal said success.
+
+  Packets are now filed for the node that will actually be dialled. Three related changes mean this shape of failure is noisy rather than silent if it ever recurs:
+
+  * A flow file entry whose file is missing is **logged** rather than skipped in silence.
+  * A node whose live flow entries all point at missing files is **no longer reported as having pending mail**. That state used to put the poller in a dial-every-cycle-and-transfer-nothing loop.
+  * A reference is also looked for by name **in the flow file's own directory**. Flow files store absolute paths, so mail that has been moved -- including anything misfiled by this bug before upgrading -- now ships by moving the files, with no hand-editing of flow files. See [UPGRADE](UPGRADE.md).
+
+  Each routed NetMail also logs where it was routed, so the effective route can be confirmed rather than inferred.
+
+* **A wildcard could shadow a more specific entry in `nodes{}` and NetMail `routes{}`** -- where several patterns matched an address, which one applied depended on nothing but the order they were written in `config.hjson`. A `"*"` route above `"21:*"` took every message; a `"21:*"` node block above `"21:1/100"` meant that node's `packetPassword` was never the one checked. The **most specific match now wins** regardless of order, which is what the native BinkP mailer already did for its own `binkp.nodes{}`.
+
+  `routes{}` is still consulted before `nodes{}`, so a catch-all `"*"` route claims all NetMail -- AreaFix to your uplinks on other networks included. With ordering no longer deciding the outcome, a more specific route can now reliably send those direct. See [NetMail](docs/_docs/messageareas/netmail.md#which-route-applies).
+
 * **The `download` file area ACS was enforced over the REST API and nowhere else** -- a security control that silently did not work. A file area can reasonably let everyone browse while restricting who may actually pull bytes down:
 
   ```hjson

--- a/core/binkp/bso_spool.js
+++ b/core/binkp/bso_spool.js
@@ -42,9 +42,13 @@ const DEFAULT_STALE_LOCK_MAX_AGE_MS = 30 * 60 * 1000;
 // the complaint is about static configuration — once per process is plenty.
 const warnedNetworks = new Set();
 
-// Flow file references that resolve to nothing. Same reasoning as
-// |warnedNetworks|: a dangling reference is a standing condition the sysop
-// needs told about once, not once per poll cycle.
+// Flow file references we've already complained about. Same reasoning as
+// |warnedNetworks|: an unusable reference is a standing condition the sysop
+// needs told about once, not once per poll cycle. Bounded because unlike
+// networks these are unbounded in principle -- a downlink that never answers
+// accumulates a uniquely named packet per export. Past the cap we start over
+// rather than grow: a little repetition beats a leak.
+const MAX_WARNED_FLOW_REFS = 1024;
 const warnedFlowRefs = new Set();
 
 //
@@ -705,12 +709,27 @@ async function flowHasPending(flowPath) {
 //  reports success.
 //
 async function resolveFlowRef(flowPath, ref) {
+    const warnOnce = (key, fields, message) => {
+        if (warnedFlowRefs.has(key)) return;
+        if (warnedFlowRefs.size >= MAX_WARNED_FLOW_REFS) warnedFlowRefs.clear();
+        warnedFlowRefs.add(key);
+        Log.warn(fields, message);
+    };
+
     const tryStat = async p => {
         try {
-            return await fsp.stat(p);
+            const stat = await fsp.stat(p);
+            //  A reference has to name a regular file. A directory sitting at
+            //  the path would queue, fail to open, and leave its node pending
+            //  forever — the very loop the existence check above exists to
+            //  break. The fallback below can also collapse a wholly dangling
+            //  reference onto one: a path ending in ".." lands on the parent
+            //  of the outbound directory.
+            return stat.isFile() ? stat : null;
         } catch (err) {
             if ('ENOENT' !== err.code && 'ENOTDIR' !== err.code) {
-                Log.warn(
+                warnOnce(
+                    `stat\0${p}`,
                     { path: p, error: err.message },
                     '[BinkP/BSO] Error stat-ing flow file reference'
                 );
@@ -731,14 +750,11 @@ async function resolveFlowRef(flowPath, ref) {
         if (stat) return { path: alt, stat };
     }
 
-    const key = `${flowPath}\0${ref}`;
-    if (!warnedFlowRefs.has(key)) {
-        warnedFlowRefs.add(key);
-        Log.warn(
-            { flowFile: flowPath, ref },
-            '[BinkP/BSO] Flow file references a file that does not exist; skipping entry'
-        );
-    }
+    warnOnce(
+        `ref\0${flowPath}\0${ref}`,
+        { flowFile: flowPath, ref },
+        '[BinkP/BSO] Flow file reference names no usable file; skipping entry'
+    );
 
     return null;
 }

--- a/core/binkp/bso_spool.js
+++ b/core/binkp/bso_spool.js
@@ -42,6 +42,11 @@ const DEFAULT_STALE_LOCK_MAX_AGE_MS = 30 * 60 * 1000;
 // the complaint is about static configuration — once per process is plenty.
 const warnedNetworks = new Set();
 
+// Flow file references that resolve to nothing. Same reasoning as
+// |warnedNetworks|: a dangling reference is a standing condition the sysop
+// needs told about once, not once per poll cycle.
+const warnedFlowRefs = new Set();
+
 //
 //  BsoSpool — filesystem adapter between BinkP sessions and the BSO outbound/
 //  inbound spool that ftn_bso manages.
@@ -469,22 +474,20 @@ class BsoSpool {
                 filePath = trimmed;
             }
 
-            let stat;
-            try {
-                stat = await fsp.stat(filePath);
-            } catch {
-                // File referenced in flow but missing on disk — skip silently
-                continue;
-            }
+            const resolved = await resolveFlowRef(flowPath, filePath);
+            if (!resolved) continue;
 
             const lineIdx = i;
             const captured = trimmed; // close over the line as it was when read
             results.push({
-                name: path.basename(filePath),
-                path: filePath,
-                size: stat.size,
-                timestamp: Math.floor(stat.mtimeMs / 1000),
+                name: path.basename(resolved.path),
+                path: resolved.path,
+                size: resolved.stat.size,
+                timestamp: Math.floor(resolved.stat.mtimeMs / 1000),
                 disposition,
+                //  Bookkeeping keys off the line as it was written, not off
+                //  |resolved.path| — so a reference rescued by the fallback
+                //  above is still marked sent correctly.
                 disposeFn: () => this._applyFlowDisposition(flowPath, lineIdx, captured),
             });
         }
@@ -665,12 +668,79 @@ function uniquePacketName(filePath) {
     return `${`00000000${hash}`.slice(-8)}.pkt`;
 }
 
+//
+//  True when |flowPath| has at least one entry that is neither already marked
+//  sent ('~') nor dangling.
+//
+//  The existence check matters: a flow file whose live entries all resolve to
+//  nothing would otherwise keep its node in the pending list forever, and the
+//  poller would dial it every cycle only to transfer nothing and log a clean
+//  "Session complete".
+//
 async function flowHasPending(flowPath) {
     const content = await fsp.readFile(flowPath, 'utf8').catch(() => '');
-    return content.split('\n').some(line => {
-        const t = line.trim();
-        return t.length > 0 && t[0] !== '~';
-    });
+    for (const line of content.split('\n')) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed[0] === '~') continue;
+
+        const ref = /^[\^#-]/.test(trimmed) ? trimmed.slice(1) : trimmed;
+        if (await resolveFlowRef(flowPath, ref)) return true;
+    }
+    return false;
+}
+
+//
+//  Resolve a flow file reference to a file that exists, as { path, stat }, or
+//  null when it resolves nowhere.
+//
+//  Flow files carry absolute paths (FTS-5005.003 §3.1). A stored path that no
+//  longer resolves means the file moved out from under the reference — a
+//  relocated outbound tree, or a sysop hand-recovering mail that was filed in
+//  the wrong directory. Before giving up we look for the referenced basename
+//  in the flow file's own directory, which makes that recovery a matter of
+//  moving files rather than also hand-editing flow files.
+//
+//  A reference that resolves nowhere is logged once per process. Silence here
+//  is how misfiled outbound mail hides: the session finds nothing to send and
+//  reports success.
+//
+async function resolveFlowRef(flowPath, ref) {
+    const tryStat = async p => {
+        try {
+            return await fsp.stat(p);
+        } catch (err) {
+            if ('ENOENT' !== err.code && 'ENOTDIR' !== err.code) {
+                Log.warn(
+                    { path: p, error: err.message },
+                    '[BinkP/BSO] Error stat-ing flow file reference'
+                );
+            }
+            return null;
+        }
+    };
+
+    let stat = await tryStat(ref);
+    if (stat) return { path: ref, stat };
+
+    //  Split on either separator — the reference may have been written by a
+    //  mailer running on the other sort of platform.
+    const base = ref.split(/[\\/]/).pop();
+    const alt = base && path.join(path.dirname(flowPath), base);
+    if (alt && alt !== ref) {
+        stat = await tryStat(alt);
+        if (stat) return { path: alt, stat };
+    }
+
+    const key = `${flowPath}\0${ref}`;
+    if (!warnedFlowRefs.has(key)) {
+        warnedFlowRefs.add(key);
+        Log.warn(
+            { flowFile: flowPath, ref },
+            '[BinkP/BSO] Flow file references a file that does not exist; skipping entry'
+        );
+    }
+
+    return null;
 }
 
 //

--- a/core/binkp/util.js
+++ b/core/binkp/util.js
@@ -47,24 +47,16 @@ function addressKey(addr) {
 //  shadow the override depending on how the user wrote the HJSON. Scoring
 //  by Address#getMatchScore makes the result deterministic and intuitive.
 //
-//  |addr| can be an Address instance or anything with the same shape; we
-//  wrap it in Address only to call getMatchScore.
+//  |addr| can be an Address instance or anything with the same shape.
+//
+//  The scoring itself lives on Address so the FTN/BSO tosser can apply the
+//  same rule to its own pattern-keyed tables (nodes{}, NetMail routes{})
+//  without reaching into the BinkP module.
 //
 function findBestNodeMatch(nodes, addr) {
     if (_.isEmpty(nodes)) return undefined;
-    const a = addr instanceof Address ? addr : new Address(addr);
-
-    let bestScore = 0;
-    let bestConf;
-    for (const [pattern, conf] of Object.entries(nodes)) {
-        if (!a.isPatternMatch(pattern)) continue;
-        const score = a.getMatchScore(pattern);
-        if (score > bestScore) {
-            bestScore = score;
-            bestConf = conf;
-        }
-    }
-    return bestConf;
+    const best = Address.findBestPatternMatch(nodes, addr);
+    return best ? best.value : undefined;
 }
 
 //

--- a/core/ftn_address.js
+++ b/core/ftn_address.js
@@ -128,6 +128,45 @@ module.exports = class Address {
         return score;
     }
 
+    //
+    //  The most-specific entry of |patterned| whose key matches |addr|.
+    //
+    //  |patterned| is an object keyed by FTN address patterns -- concrete or
+    //  wildcard -- such as scannerTossers.ftn_bso.nodes{} or the NetMail
+    //  routes{} table. Configurations routinely pair a catch-all ("21:*", or
+    //  even "*") with more specific overrides ("21:1/100"). A first-match-wins
+    //  scan follows object iteration order, so which one wins depends only on
+    //  the order the sysop happened to write the HJSON -- and a catch-all
+    //  listed first silently shadows every override below it. Scoring with
+    //  getMatchScore() makes the outcome deterministic and matches intent.
+    //
+    //  Returns { pattern, value } for the winner, or undefined when nothing
+    //  matches. |addr| may be an Address or anything of the same shape.
+    //
+    static findBestPatternMatch(patterned, addr) {
+        if (!patterned || 'object' !== typeof patterned) {
+            return undefined;
+        }
+
+        const a = addr instanceof Address ? addr : new Address(addr);
+
+        let best;
+        let bestScore = 0;
+        for (const [pattern, value] of Object.entries(patterned)) {
+            if (!a.isPatternMatch(pattern)) {
+                continue;
+            }
+
+            const score = a.getMatchScore(pattern);
+            if (score > bestScore) {
+                bestScore = score;
+                best = { pattern, value };
+            }
+        }
+
+        return best;
+    }
+
     isPatternMatch(pattern) {
         const addr = this.getMatchAddr(pattern);
         if (addr) {

--- a/core/scanner_tossers/ftn_bso.js
+++ b/core/scanner_tossers/ftn_bso.js
@@ -709,13 +709,24 @@ function FTNMessageScanTossModule() {
         }
     };
 
+    //
+    //  Node configuration for |addr|, or undefined when none matches.
+    //
+    //  nodes{} keys are FTN patterns and more than one can match a given
+    //  address. The *most specific* match wins -- see
+    //  Address.findBestPatternMatch(). First-match-wins would let a catch-all
+    //  such as "21:*" shadow a specific "21:1/100" block purely by virtue of
+    //  appearing first in config.hjson, which among other things would drop
+    //  that node's packetPassword.
+    //
     this.getNodeConfigByAddress = function (addr) {
         addr = _.isString(addr) ? Address.fromString(addr) : addr;
+        if (!addr) {
+            return undefined;
+        }
 
-        //  :TODO: sort wildcard nodes{} entries by most->least explicit according to FTN hierarchy
-        return _.find(this.moduleConfig.nodes, (node, nodeAddrWildcard) => {
-            return addr.isPatternMatch(nodeAddrWildcard);
-        });
+        const best = Address.findBestPatternMatch(this.moduleConfig.nodes, addr);
+        return best ? best.value : undefined;
     };
 
     this.exportNetMailMessagePacket = function (message, exportOpts, cb) {
@@ -998,18 +1009,20 @@ function FTNMessageScanTossModule() {
         );
     };
 
+    //
+    //  NetMail route for |dstAddr|, or undefined when none is configured.
+    //
+    //  routes{} keys are FTN patterns; the *most specific* match wins so that
+    //  a catch-all "*" alongside a specific "21:*" behaves the same no matter
+    //  which order they appear in config.hjson.
+    //
     this.getNetMailRoute = function (dstAddr) {
         //
         //  Route full|wildcard -> full adddress/network lookup
         //
         const routes = _.get(Config(), 'scannerTossers.ftn_bso.netMail.routes');
-        if (!routes) {
-            return;
-        }
-
-        return _.find(routes, (route, addrWildcard) => {
-            return dstAddr.isPatternMatch(addrWildcard);
-        });
+        const best = Address.findBestPatternMatch(routes, dstAddr);
+        return best ? best.value : undefined;
     };
 
     this.getNetMailRouteInfoFromAddress = function (destAddress, cb) {
@@ -1040,9 +1053,7 @@ function FTNMessageScanTossModule() {
 
         networkName = networkName || this.getNetworkNameByAddress(routeAddress);
 
-        const config = _.find(this.moduleConfig.nodes, (node, nodeAddrWildcard) => {
-            return routeAddress.isPatternMatch(nodeAddrWildcard);
-        }) || {
+        const config = this.getNodeConfigByAddress(routeAddress) || {
             packetType: '2+',
             encoding: Config().scannerTossers.ftn_bso.packetMsgEncoding,
         };
@@ -1063,7 +1074,7 @@ function FTNMessageScanTossModule() {
             messagesOrMessageUuids,
             (msgOrUuid, nextMessageOrUuid) => {
                 const exportOpts = {};
-                const message = new Message();
+                let message = new Message();
                 let messageLoaded = false;
 
                 async.series(
@@ -1077,8 +1088,13 @@ function FTNMessageScanTossModule() {
                                     return callback(err, message);
                                 });
                             } else {
+                                //  Already-loaded Message. Adopt it -- every
+                                //  step below reads |message|, so leaving the
+                                //  empty placeholder in place would export a
+                                //  blank message to nowhere.
+                                message = msgOrUuid;
                                 messageLoaded = true;
-                                return callback(null, msgOrUuid);
+                                return callback(null, message);
                             }
                         },
                         function discoverUplink(callback) {
@@ -1102,10 +1118,23 @@ function FTNMessageScanTossModule() {
                                         routeInfo.networkName
                                     );
                                     exportOpts.networkName = routeInfo.networkName;
+                                    //
+                                    //  The packet is filed for the node we
+                                    //  will *dial*, not the message's final
+                                    //  recipient. For routed NetMail those
+                                    //  differ, and when they differ by zone
+                                    //  they resolve to different outbound
+                                    //  directories -- so using destAddress
+                                    //  here filed cross-zone routed mail in a
+                                    //  directory the mailer never looks in
+                                    //  when calling the uplink (issue #734).
+                                    //  |routeAddress| is |destAddress| when
+                                    //  the message is unrouted.
+                                    //
                                     exportOpts.outgoingDir =
                                         self.getOutgoingEchoMailPacketDir(
                                             exportOpts.networkName,
-                                            exportOpts.destAddress
+                                            exportOpts.routeAddress
                                         );
                                     exportOpts.exportType = self.getExportType(
                                         routeInfo.config
@@ -1116,6 +1145,23 @@ function FTNMessageScanTossModule() {
                                             Errors.DoesNotExist(
                                                 `No configuration found for network ${routeInfo.networkName}`
                                             )
+                                        );
+                                    }
+
+                                    if (routeInfo.isRouted) {
+                                        //  Which routes{} pattern applied is
+                                        //  not obvious from the outside -- a
+                                        //  catch-all captures NetMail for
+                                        //  every network, AreaFix to your
+                                        //  uplinks included. Say where the
+                                        //  message actually went.
+                                        Log.debug(
+                                            {
+                                                dest: exportOpts.destAddress.toString(),
+                                                route: exportOpts.routeAddress.toString(),
+                                                network: exportOpts.networkName,
+                                            },
+                                            'Routing NetMail via uplink'
                                         );
                                     }
 
@@ -1799,11 +1845,7 @@ function FTNMessageScanTossModule() {
                     } else {
                         //  Validate packet password against node config (if configured)
                         const originAddr = new Address(packetHeader.origAddress);
-                        const nodeConfig = _.find(
-                            self.moduleConfig.nodes,
-                            (node, addrWildcard) =>
-                                originAddr.isPatternMatch(addrWildcard)
-                        );
+                        const nodeConfig = self.getNodeConfigByAddress(originAddr);
                         if (nodeConfig && nodeConfig.packetPassword) {
                             const expected = nodeConfig.packetPassword.toUpperCase();
                             const actual = (packetHeader.password || '').toUpperCase();
@@ -2042,10 +2084,7 @@ function FTNMessageScanTossModule() {
                     //  not be able to create areas on its way past.
                     //
                     const originAddr = new Address(entryData.origAddress);
-                    const nodeConfig = _.find(
-                        self.moduleConfig.nodes,
-                        (node, addrWildcard) => originAddr.isPatternMatch(addrWildcard)
-                    );
+                    const nodeConfig = self.getNodeConfigByAddress(originAddr);
                     if (nodeConfig && nodeConfig.packetPassword) {
                         const expected = nodeConfig.packetPassword.toUpperCase();
                         const actual = (entryData.password || '').toUpperCase();

--- a/docs/_docs/messageareas/bso-import-export.md
+++ b/docs/_docs/messageareas/bso-import-export.md
@@ -142,6 +142,8 @@ scannerTossers: {
 
     defaultNetwork: fsxnet
 
+    //  Node keys are address patterns; where several match an address, the
+    //  most specific one wins regardless of the order written here.
     nodes: {
       "21:1/100" : {            //  May also contain wildcards, ie: "21:1/*"
         archiveType: ZIP        //  By-ext archive type: ZIP, ARJ, ..., optional.

--- a/docs/_docs/messageareas/netmail.md
+++ b/docs/_docs/messageareas/netmail.md
@@ -33,3 +33,39 @@ scannerTossers: {
 }
 ````
 The `network` tag must match the networks defined in `messageNetworks::ftn::networks` within `config.hjson`.
+
+### Routing Out Of Zone
+
+The route address does not have to be in the same zone as the recipient — routing zone 2 mail out through a zone 1 uplink is the standard FidoNet zone gate:
+
+````hjson
+scannerTossers: {
+    ftn_bso: {
+        netMail: {
+            routes: {
+                "2:*" : {
+                    address: "1:154/10"
+                    network: fidonet
+                }
+            }
+        }
+    }
+}
+````
+
+The packet is filed in the outbound directory belonging to the **route** address, since that is the node the mailer will call.
+
+### Which Route Applies
+
+Route keys are address patterns, and more than one can match a given recipient. The **most specific match wins**, regardless of the order entries appear in `config.hjson` — `"21:1/100"` beats `"21:*"`, which in turn beats `"*"`.
+
+Note that `routes` is consulted *before* `nodes`, so a catch-all `"*"` route claims **all** NetMail — including AreaFix messages addressed to your uplinks on other networks. Prefer a pattern per zone. Where you do want a catch-all, you can send specific addresses direct by pointing a more specific route at them:
+
+````hjson
+routes: {
+    "21:1/100" : { address: "21:1/100", network: fsxnet }   //  direct
+    "*"        : { address: "1:154/10", network: fidonet }  //  everything else
+}
+````
+
+Each routed NetMail logs the address it was routed to at `debug` level, so the effective route can be confirmed from `logs/enigma-bbs.log`.

--- a/test/binkp_bso_spool.test.js
+++ b/test/binkp_bso_spool.test.js
@@ -560,6 +560,100 @@ describe('BsoSpool — getNodesWithPendingMail', () => {
     });
 });
 
+// ── dangling and rescued flow references ──────────────────────────────────────
+//
+//  Flow files carry absolute paths (FTS-5005.003 §3.1), so a file that moves
+//  out from under its reference becomes invisible: the entry is skipped, the
+//  session finds nothing to send, and the call reports success. That is how
+//  misfiled outbound mail hid (see issue #734) -- and hand-repairing it meant
+//  editing flow files, because moving the packet alone left the stored path
+//  stale.
+//
+//  Two behaviours close that off: a reference is also looked for by basename
+//  in the flow file's own directory, and a flow file whose live entries all
+//  resolve to nothing no longer reports its node as pending -- which used to
+//  put the poller in a dial-every-cycle-and-send-nothing loop.
+
+describe('BsoSpool — dangling and rescued flow references', () => {
+    beforeEach(cleanOutbound);
+
+    it('resolves a reference by basename in the flow file directory', async () => {
+        const moved = path.join(outboundDir(tmpDir), 'moved.pkt');
+        await fsp.writeFile(moved, 'MOVED');
+
+        //  The stored path is where the packet used to live
+        const flowPath = path.join(outboundDir(tmpDir), '00680001.flo');
+        await fsp.writeFile(flowPath, `^${path.join(tmpDir, 'old_home', 'moved.pkt')}\n`);
+
+        const files = await spool.getOutboundFilesForNode(TEST_ADDR);
+        assert.equal(files.length, 1, 'the moved packet must still be found');
+        assert.equal(files[0].path, moved);
+        assert.equal(files[0].disposition, 'delete');
+    });
+
+    it('marks a rescued entry sent using the line as written', async () => {
+        const moved = path.join(outboundDir(tmpDir), 'rescued.pkt');
+        await fsp.writeFile(moved, 'RESCUED');
+
+        const stale = path.join(tmpDir, 'old_home', 'rescued.pkt');
+        const flowPath = path.join(outboundDir(tmpDir), '00680001.flo');
+        await fsp.writeFile(flowPath, `^${stale}\nkeepme\n`);
+
+        const files = await spool.getOutboundFilesForNode(TEST_ADDR);
+        assert.equal(files.length, 1);
+
+        await files[0].disposeFn();
+
+        const content = await fsp.readFile(flowPath, 'utf8');
+        assert.ok(
+            content.includes(`~${stale}`),
+            `expected the original line marked sent, got:\n${content}`
+        );
+    });
+
+    it('excludes a node whose live entries all resolve to nothing', async () => {
+        const flowPath = path.join(outboundDir(tmpDir), '00680001.flo');
+        await fsp.writeFile(flowPath, `^${path.join(tmpDir, 'gone', 'nope.pkt')}\n`);
+
+        const nodes = await spool.getNodesWithPendingMail();
+        assert.deepEqual(
+            nodes,
+            [],
+            'a node with nothing shippable must not be reported as pending'
+        );
+    });
+
+    it('still reports a node whose only entry needed rescuing', async () => {
+        const moved = path.join(outboundDir(tmpDir), 'pending_moved.pkt');
+        await fsp.writeFile(moved, 'DATA');
+
+        const flowPath = path.join(outboundDir(tmpDir), '00680001.flo');
+        await fsp.writeFile(
+            flowPath,
+            `^${path.join(tmpDir, 'old_home', 'pending_moved.pkt')}\n`
+        );
+
+        const nodes = await spool.getNodesWithPendingMail();
+        assert.equal(nodes.length, 1);
+        assert.equal(nodes[0].net, 104);
+        assert.equal(nodes[0].node, 1);
+    });
+
+    it('does not rescue across directories, only the flow file own directory', async () => {
+        //  A same-named file elsewhere in the outbound tree must not be picked
+        //  up; that would ship the wrong packet to the wrong node.
+        const elsewhere = path.join(tmpDir, 'elsewhere');
+        await fsp.mkdir(elsewhere, { recursive: true });
+        await fsp.writeFile(path.join(elsewhere, 'decoy.pkt'), 'DECOY');
+
+        const flowPath = path.join(outboundDir(tmpDir), '00680001.flo');
+        await fsp.writeFile(flowPath, `^${path.join(tmpDir, 'gone', 'decoy.pkt')}\n`);
+
+        const files = await spool.getOutboundFilesForNode(TEST_ADDR);
+        assert.equal(files.length, 0);
+    });
+});
+
 // ── Filename case ─────────────────────────────────────────────────────────────
 //
 //  FTS-5005.003 §2: "Lower case filenames are prefered if supported by the file

--- a/test/binkp_bso_spool.test.js
+++ b/test/binkp_bso_spool.test.js
@@ -652,6 +652,52 @@ describe('BsoSpool — dangling and rescued flow references', () => {
         const files = await spool.getOutboundFilesForNode(TEST_ADDR);
         assert.equal(files.length, 0);
     });
+
+    it('skips a reference that names a directory', async () => {
+        //  A directory would queue, then fail to open at send time, and its
+        //  node would stay pending forever.
+        const dir = path.join(outboundDir(tmpDir), 'itsadir');
+        await fsp.mkdir(dir, { recursive: true });
+
+        const flowPath = path.join(outboundDir(tmpDir), '00680001.flo');
+        await fsp.writeFile(flowPath, `^${dir}\n`);
+
+        assert.deepEqual(await spool.getOutboundFilesForNode(TEST_ADDR), []);
+        assert.deepEqual(await spool.getNodesWithPendingMail(), []);
+    });
+
+    it('does not collapse a dangling reference onto a directory', async () => {
+        //  The rescue takes the reference's last path segment. For a path
+        //  ending in ".." that segment resolves to the parent of the outbound
+        //  directory -- outside the spool entirely -- and for "." to the
+        //  outbound directory itself. Neither is a file, and neither may be
+        //  offered to a remote.
+        for (const tail of ['..', '.']) {
+            await cleanOutbound();
+            const flowPath = path.join(outboundDir(tmpDir), '00680001.flo');
+            //  built by hand: path.join() would normalise the tail away
+            await fsp.writeFile(flowPath, `^${tmpDir}/gone/missing/${tail}\n`);
+
+            assert.deepEqual(
+                await spool.getOutboundFilesForNode(TEST_ADDR),
+                [],
+                `a reference ending in "${tail}" must resolve to nothing`
+            );
+            assert.deepEqual(await spool.getNodesWithPendingMail(), []);
+        }
+    });
+
+    it('rescues a reference written with the other platform separators', async () => {
+        const here = path.join(outboundDir(tmpDir), 'aabbccdd.pkt');
+        await fsp.writeFile(here, 'PKT');
+
+        const flowPath = path.join(outboundDir(tmpDir), '00680001.flo');
+        await fsp.writeFile(flowPath, '^C:\\bbs\\out\\aabbccdd.pkt\n');
+
+        const files = await spool.getOutboundFilesForNode(TEST_ADDR);
+        assert.equal(files.length, 1);
+        assert.equal(files[0].path, here);
+    });
 });
 
 // ── Filename case ─────────────────────────────────────────────────────────────

--- a/test/binkp_ftn_bso_integration.test.js
+++ b/test/binkp_ftn_bso_integration.test.js
@@ -27,9 +27,14 @@ describe('ftn_bso ↔ BinkP integration', function () {
         await fsp.rm(tmpDir, { recursive: true, force: true });
     });
 
+    //  core/ftn_util.js captures config.js's |get| at require time, so whatever
+    //  config is pushed when this file first pulls ftn_bso in is the one its
+    //  origin-line/tear-line helpers see for the rest of the run. Everything
+    //  those read has to be present here, not just in the per-test configs.
     function makeConfig() {
         return {
             debug: { assertsEnabled: false },
+            general: { boardName: 'Test BBS' },
             scannerTossers: {
                 ftn_bso: {
                     paths: {
@@ -931,6 +936,304 @@ describe('ftn_bso ↔ BinkP integration', function () {
                         })
                         .catch(done);
                 }
+            );
+        });
+    });
+
+    // ── routed NetMail export (issue #734) ───────────────────────────────────
+    //
+    //  NetMail can be routed: the message is addressed to one node but handed
+    //  to a different one for onward delivery. The standard FidoNet zone gate
+    //  is exactly this -- zone 2 mail leaves through a zone 1 uplink.
+    //
+    //  The packet has to be filed for the node we are going to DIAL, not for
+    //  the node the message is ultimately addressed to. The moment those two
+    //  differ by zone they resolve to different outbound directories, and a
+    //  BinkP session only ever looks in the dialed node's zone. Filing by
+    //  destination therefore put the mail somewhere nothing would ever read:
+    //  the call to the uplink completed cleanly having transferred nothing,
+    //  and the message sat on disk indefinitely with no error anywhere.
+    //
+    //  These drive the REAL exportNetMailMessagesToUplinks series and then
+    //  hand the resulting spool to BsoSpool, so writer and reader are checked
+    //  against each other rather than against a restatement of either.
+
+    describe('ftn_bso — routed NetMail export (issue #734)', () => {
+        const UPLINK = '1:154/10'; //  in the network's default zone (1)
+        const ZONE2_UPLINK = '2:280/1'; //  out of zone -> outbound.002
+
+        function makeNetMailConfig(root, routes, nodes) {
+            const config = makeConfig();
+            //  prepareMessage() builds an origin line from the board name
+            config.general = { boardName: 'Test BBS' };
+            config.scannerTossers.ftn_bso.paths = {
+                outbound: root,
+                inbound: path.join(root, 'ftn_in'),
+                secInbound: path.join(root, 'ftn_secin'),
+            };
+            config.scannerTossers.ftn_bso.defaultNetwork = 'testnet';
+            config.scannerTossers.ftn_bso.packetMsgEncoding = 'utf8';
+            config.scannerTossers.ftn_bso.nodes = nodes;
+            config.scannerTossers.ftn_bso.netMail = { routes };
+            return config;
+        }
+
+        //  Export one NetMail addressed to |dest| under |routes|. Yields the
+        //  outbound root for inspection.
+        function runNetMailExport({ label, dest, routes, nodes }, cb) {
+            const root = path.join(tmpDir, `netmail_${label}`);
+            const tempDir = path.join(root, 'export_temp');
+
+            const config = makeNetMailConfig(root, routes, nodes);
+            const prev = configModule._pushTestConfig(config);
+
+            const { getModule } = require('../core/scanner_tossers/ftn_bso.js');
+            const Message = require('../core/message.js');
+
+            const mod = new getModule();
+            //  Same reasoning as the EchoMail block above: set the pieces the
+            //  export reaches through |moduleConfig| directly.
+            mod.moduleConfig = config.scannerTossers.ftn_bso;
+            mod.exportTempDir = tempDir;
+
+            const message = new Message({
+                areaTag: Message.WellKnownAreaTags.Private,
+                toUserName: 'Sysop',
+                fromUserName: 'Tester',
+                subject: `routed netmail ${label}`,
+                message: 'Body text.',
+            });
+            message.setExternalFlavor(Message.AddressFlavor.FTN);
+            message.meta.System[Message.SystemMetaNames.RemoteToUser] = dest;
+            //  There is no message database here; the export only writes
+            //  export bookkeeping, which nothing under test reads back.
+            message.persistMetaValue = (sect, name, value, callback) => callback(null);
+
+            fsp.mkdir(tempDir, { recursive: true })
+                .then(() =>
+                    mod.exportNetMailMessagesToUplinks([message], err => {
+                        configModule._popTestConfig(prev);
+                        cb(err, { root, mod });
+                    })
+                )
+                .catch(cb);
+        }
+
+        function spoolFor(root) {
+            const { BsoSpool } = require('../core/binkp/bso_spool.js');
+            return new BsoSpool({
+                paths: {
+                    outbound: root,
+                    inbound: path.join(root, 'ftn_in'),
+                    secInbound: path.join(root, 'ftn_secin'),
+                },
+                networks: { testnet: { localAddress: '1:218/700', defaultZone: 1 } },
+                defaultNetwork: 'testnet',
+            });
+        }
+
+        const CROSS_ZONE = {
+            label: 'crosszone',
+            dest: '2:280/464',
+            routes: { '*': { address: UPLINK, network: 'testnet' } },
+            nodes: { [UPLINK]: { packetType: '2+' } },
+        };
+
+        it('files cross-zone routed mail under the uplink, not the recipient', done => {
+            runNetMailExport(CROSS_ZONE, (err, { root }) => {
+                if (err) return done(err);
+
+                Promise.all([
+                    fsp.readdir(path.join(root, 'outbound')),
+                    fsp.readdir(path.join(root, 'outbound.002')).catch(() => []),
+                ])
+                    .then(([inZone, destZone]) => {
+                        //  009a000a = net 154 (0x9a) / node 10 (0x0a), and the
+                        //  packet is named from a message serial.
+                        assert.ok(
+                            inZone.includes('009a000a.clo'),
+                            `flow file must be in outbound/, saw ${inZone}`
+                        );
+                        assert.equal(
+                            inZone.filter(f => f.endsWith('.pkt')).length,
+                            1,
+                            `packet must be in outbound/, saw ${inZone}`
+                        );
+                        assert.deepEqual(
+                            destZone,
+                            [],
+                            'nothing may be filed under the recipient zone'
+                        );
+                        done();
+                    })
+                    .catch(done);
+            });
+        });
+
+        it('BsoSpool ships the routed packet when the uplink is dialed', done => {
+            runNetMailExport(
+                { ...CROSS_ZONE, label: 'crosszone_ship' },
+                (err, { root }) => {
+                    if (err) return done(err);
+                    const Address = require('../core/ftn_address.js');
+                    spoolFor(root)
+                        .getOutboundFilesForNode(Address.fromString(UPLINK))
+                        .then(files => {
+                            assert.equal(
+                                files.length,
+                                1,
+                                'the call to the uplink must have the packet queued'
+                            );
+                            assert.ok(files[0].path.endsWith('.pkt'));
+                            done();
+                        })
+                        .catch(done);
+                }
+            );
+        });
+
+        it('reports the uplink as pending, not a phantom in the recipient zone', done => {
+            //  Filing by destination did not merely hide the mail: the pending
+            //  scan derives a node from directory zone + flow basename, so it
+            //  reported 2:154/10 -- a node that does not exist, and which the
+            //  poller then skipped at debug level.
+            runNetMailExport(
+                { ...CROSS_ZONE, label: 'crosszone_pending' },
+                (err, { root }) => {
+                    if (err) return done(err);
+                    spoolFor(root)
+                        .getNodesWithPendingMail()
+                        .then(addrs => {
+                            assert.deepEqual(
+                                addrs.map(a => a.toString()),
+                                [UPLINK],
+                                'pending mail must be attributed to the uplink'
+                            );
+                            done();
+                        })
+                        .catch(done);
+                }
+            );
+        });
+
+        it('follows the route into a non-default zone as well', done => {
+            //  The mirror image: an in-zone recipient routed out through an
+            //  out-of-zone uplink belongs in that uplink's zone directory.
+            runNetMailExport(
+                {
+                    label: 'routeoutofzone',
+                    dest: '1:218/701',
+                    routes: { '*': { address: ZONE2_UPLINK, network: 'testnet' } },
+                    nodes: { [ZONE2_UPLINK]: { packetType: '2+' } },
+                },
+                (err, { root }) => {
+                    if (err) return done(err);
+                    const Address = require('../core/ftn_address.js');
+                    fsp.readdir(path.join(root, 'outbound.002'))
+                        .then(entries => {
+                            //  01180001 = net 280 (0x118) / node 1
+                            assert.ok(
+                                entries.includes('01180001.clo'),
+                                `expected the zone 2 flow file, saw ${entries}`
+                            );
+                            return spoolFor(root).getOutboundFilesForNode(
+                                Address.fromString(ZONE2_UPLINK)
+                            );
+                        })
+                        .then(files => {
+                            assert.equal(files.length, 1);
+                            done();
+                        })
+                        .catch(done);
+                }
+            );
+        });
+    });
+
+    // ── NetMail route selection ──────────────────────────────────────────────
+    //
+    //  routes{} keys are FTN patterns and several can match one address. The
+    //  lookup used to take the first match in object iteration order, so a
+    //  catch-all silently shadowed every more specific route written below it
+    //  -- the route that applied depended only on how the sysop happened to
+    //  order config.hjson.
+
+    describe('ftn_bso — NetMail route selection', () => {
+        function routeFor(routes, dest) {
+            const config = makeConfig();
+            config.scannerTossers.ftn_bso.netMail = { routes };
+            const prev = configModule._pushTestConfig(config);
+            try {
+                const { getModule } = require('../core/scanner_tossers/ftn_bso.js');
+                const Address = require('../core/ftn_address.js');
+                const mod = new getModule();
+                mod.moduleConfig = config.scannerTossers.ftn_bso;
+                const route = mod.getNetMailRoute(Address.fromString(dest));
+                return route && route.address;
+            } finally {
+                configModule._popTestConfig(prev);
+            }
+        }
+
+        it('prefers a specific route over a catch-all listed first', () => {
+            assert.equal(
+                routeFor(
+                    {
+                        '*': { address: '1:154/10', network: 'testnet' },
+                        '21:*': { address: '21:1/100', network: 'fsxnet' },
+                    },
+                    '21:1/234'
+                ),
+                '21:1/100'
+            );
+        });
+
+        it('gives the same answer when the catch-all is listed last', () => {
+            assert.equal(
+                routeFor(
+                    {
+                        '21:*': { address: '21:1/100', network: 'fsxnet' },
+                        '*': { address: '1:154/10', network: 'testnet' },
+                    },
+                    '21:1/234'
+                ),
+                '21:1/100'
+            );
+        });
+
+        it('prefers an exact node route over a zone wildcard', () => {
+            assert.equal(
+                routeFor(
+                    {
+                        '21:*': { address: '21:1/100', network: 'fsxnet' },
+                        '21:1/234': { address: '21:1/999', network: 'fsxnet' },
+                    },
+                    '21:1/234'
+                ),
+                '21:1/999'
+            );
+        });
+
+        it('still falls back to the catch-all when nothing specific matches', () => {
+            assert.equal(
+                routeFor(
+                    {
+                        '21:*': { address: '21:1/100', network: 'fsxnet' },
+                        '*': { address: '1:154/10', network: 'testnet' },
+                    },
+                    '2:280/464'
+                ),
+                '1:154/10'
+            );
+        });
+
+        it('returns undefined when no route matches and none is a catch-all', () => {
+            assert.equal(
+                routeFor(
+                    { '21:*': { address: '21:1/100', network: 'fsxnet' } },
+                    '2:280/464'
+                ),
+                undefined
             );
         });
     });

--- a/test/ftn_address.test.js
+++ b/test/ftn_address.test.js
@@ -1,0 +1,90 @@
+'use strict';
+
+const { strict: assert } = require('assert');
+
+const Address = require('../core/ftn_address.js');
+
+// ── Address.findBestPatternMatch ──────────────────────────────────────────────
+//
+//  Several FTN patterns can match one address, and configuration routinely
+//  pairs a catch-all with more specific overrides. Picking the first match in
+//  object iteration order makes the winner depend on nothing but the order the
+//  sysop happened to write config.hjson -- a catch-all at the top silently
+//  shadows every override below it. These pin the "most specific wins" rule
+//  that nodes{}, the NetMail routes{} table and binkp.nodes{} all share.
+
+describe('Address.findBestPatternMatch', () => {
+    const ADDR = Address.fromString('21:1/100');
+
+    it('returns undefined for an empty or absent table', () => {
+        assert.equal(Address.findBestPatternMatch({}, ADDR), undefined);
+        assert.equal(Address.findBestPatternMatch(null, ADDR), undefined);
+        assert.equal(Address.findBestPatternMatch(undefined, ADDR), undefined);
+    });
+
+    it('returns undefined when nothing matches', () => {
+        assert.equal(Address.findBestPatternMatch({ '46:*': 'other' }, ADDR), undefined);
+    });
+
+    it('returns the pattern alongside the value', () => {
+        const got = Address.findBestPatternMatch({ '21:*': 'zone' }, ADDR);
+        assert.deepEqual(got, { pattern: '21:*', value: 'zone' });
+    });
+
+    it('prefers an exact address over a zone wildcard, listed first', () => {
+        const got = Address.findBestPatternMatch(
+            { '21:1/100': 'exact', '21:*': 'zone' },
+            ADDR
+        );
+        assert.equal(got.value, 'exact');
+    });
+
+    it('prefers an exact address over a zone wildcard, listed last', () => {
+        const got = Address.findBestPatternMatch(
+            { '21:*': 'zone', '21:1/100': 'exact' },
+            ADDR
+        );
+        assert.equal(got.value, 'exact');
+    });
+
+    it('prefers a zone wildcard over a bare catch-all', () => {
+        const got = Address.findBestPatternMatch(
+            { '*': 'everything', '21:*': 'zone' },
+            ADDR
+        );
+        assert.equal(got.value, 'zone');
+    });
+
+    it('prefers a net wildcard over a zone wildcard', () => {
+        const got = Address.findBestPatternMatch(
+            { '21:*': 'zone', '21:1/*': 'net' },
+            ADDR
+        );
+        assert.equal(got.value, 'net');
+    });
+
+    it('falls back to the catch-all when nothing more specific matches', () => {
+        const got = Address.findBestPatternMatch(
+            { '21:*': 'zone', '*': 'everything' },
+            Address.fromString('2:280/464')
+        );
+        assert.equal(got.value, 'everything');
+    });
+
+    it('accepts a plain address-shaped object', () => {
+        const got = Address.findBestPatternMatch(
+            { '21:1/100': 'exact' },
+            { zone: 21, net: 1, node: 100 }
+        );
+        assert.equal(got.value, 'exact');
+    });
+
+    it('distinguishes a point from its boss node', () => {
+        const table = { '21:1/100': 'boss', '21:1/100.5': 'point' };
+        assert.equal(
+            Address.findBestPatternMatch(table, Address.fromString('21:1/100.5')).value,
+            'point'
+        );
+        assert.equal(Address.findBestPatternMatch(table, ADDR).value, 'boss');
+    });
+});

--- a/test/setup.js
+++ b/test/setup.js
@@ -23,9 +23,16 @@ const configModule = require('../core/config.js');
 //  Config to THIS default. It must therefore carry everything a core constructor
 //  reads, or those tests fail order-dependently with "Cannot read properties of
 //  undefined (reading 'cls')".
+//  |general.boardName| is here for the same reason: core/ftn_util.js captures
+//  config.js's |get| at require time, and mocha loads every test file (and so
+//  every top-level require) before running anything -- so ftn_util is pinned
+//  to THIS config for the whole run, no matter what a later suite pushes.
+//  getOrigin() reads general.boardName, and without it any test that exports
+//  an FTN message throws from inside an async series.
 const MINIMAL_CONFIG = {
     debug: { assertsEnabled: false },
     menus: { cls: false },
+    general: { boardName: 'ENiGMA½ BBS' },
 };
 configModule.get = () => MINIMAL_CONFIG;
 


### PR DESCRIPTION
Fixes #734.

## The bug

NetMail routed through an uplink in a different zone than the recipient — the standard FidoNet zone gate, zone 2 mail leaving through a zone 1 hub — was filed in the outbound directory for the **recipient's** zone. A mailer only looks in the zone of the node it is calling, so the session to the uplink completed cleanly having transferred nothing, and the message sat on disk indefinitely.

`exportNetMailMessagesToUplinks()` passed `destAddress` where its sibling steps in the same series already used `routeAddress` — the packet header (`exportNetMailMessagePacket`), the flow file name, and the `NewOutboundBSO` emit. Introduced by afe0c88c (2018-01-20, "NetMail non-HUB fixes"). Before that commit `exportOpts.destAddress` **was** the route address:

```js
exportOpts.destAddress = routeAddress;
...
exportOpts.outgoingDir = self.getOutgoingEchoMailPacketDir(exportOpts.networkName, exportOpts.destAddress);
```

afe0c88c split the two apart — `destAddress` became the real recipient and `routeAddress` the uplink — and left the `outgoingDir` line untouched as context, so its meaning changed underneath it.

Reproduced against the real modules, with the reporter's configuration (`"*" → 1:154/10`, recipient `2:280/464`, local `1:103/705`):

| | outbound dir | dialing `1:154/10` | pending scan |
|---|---|---|---|
| before | `outbound.002` | **0 files** | `2:154/10` |
| after | `outbound` | 1 file | `1:154/10` |

That `2:154/10` is the part the issue did not catch, and it is why nothing surfaced: the pending scan derives a node from *directory zone + flow file basename*, so the misfiled `.clo` reported a node that does not exist. `pollNodes` found no host for it and skipped it at `debug` level, while the crashmail dial to the real uplink found nothing to send. Every visible signal said success.

## The fix

One identifier — the outbound directory now resolves from `routeAddress`. `routeAddress` is `destAddress` when the message is unrouted, so direct NetMail is unchanged (a test covers that direction too).

## Making this shape of failure noisy

Three changes in `core/binkp/bso_spool.js`, because the silence was the real damage:

- A flow entry whose file is missing is **logged** (once per process per reference) rather than `catch { continue }`.
- `flowHasPending()` now resolves references, so a node whose live entries all point at nothing is **no longer reported as pending** — that state used to put the poller in a dial-every-cycle-and-transfer-nothing loop.
- A reference that does not resolve is retried **by basename in the flow file's own directory**. Flow files store absolute paths (FTS-5005.003 §3.1), so recovering mail misfiled before this fix meant hand-editing them; now it is a matter of moving the files. Deliberately scoped to that one directory — a test asserts it will not pick up a same-named file elsewhere in the tree.

Routed NetMail also logs where it was routed, since which `routes{}` pattern applied is not observable from outside.

## Pattern matching: most specific wins

Adjacent footgun, fixed here because the packet-password case is a real hole. Where several `nodes{}` or `netMail.routes{}` patterns matched an address, the one that applied depended on nothing but `config.hjson` ordering — a catch-all shadowed every override below it.

`getMatchScore()` scoring already existed but only `binkp.nodes{}` used it. It is now `Address.findBestPatternMatch()`, backing all three pattern-keyed tables; `findBestNodeMatch()` delegates to it, and the standing `:TODO:` on `getNodeConfigByAddress()` is closed. Both packet-password lookups were open-coding the same `_.find` and now go through it — **a `"21:*"` block written above `"21:1/100"` meant the specific node's `packetPassword` was never the one checked.** Flagged in UPGRADE.md, since someone may find a password they configured only now starts being enforced.

Routes are still consulted before nodes: `"*": { address: "1:154/10" }` genuinely means "route everything here", and hubs do forward AreaFix. With ordering no longer deciding the outcome, a more specific route can now reliably send particular addresses direct — documented in `docs/_docs/messageareas/netmail.md`.

## Also fixed

Passing an already-loaded `Message` to `exportNetMailMessagesToUplinks()` exported an **empty placeholder** — `message` was never assigned from `msgOrUuid`. Latent, since every caller passes UUIDs today, but the regression test needs the documented form.

## Tests

- `test/binkp_ftn_bso_integration.test.js` — routed NetMail export end to end through the real `exportNetMailMessagesToUplinks` series, then handed to `BsoSpool`, so writer and reader are checked against each other rather than against a restatement of either. Covers cross-zone routing, the reverse direction (in-zone recipient routed out of zone), the pending-scan attribution, and route selection order. Verified these fail before the fix and pass after.
- `test/binkp_bso_spool.test.js` — rescued and dangling flow references, including that post-send bookkeeping still marks the line as written, and that the fallback does not reach across directories.
- `test/ftn_address.test.js` (new) — `Address.findBestPatternMatch()` specificity.
- `test/setup.js` gained `general.boardName`: `core/ftn_util.js` captures `config.js`'s getter at require time, so whichever config is live at first require is pinned for the whole run. Without it any test exercising a real FTN export throws from inside an async series and surfaces only as a timeout.

Full suite green — 1761 unit, 8 live. eslint and prettier clean.

## Upgrading

The fix applies to newly exported mail; it does not relocate what is already queued. `UPGRADE.md` has the procedure, which I verified end to end against a reconstructed misfiled spool: move the flow file and its packets into the uplink's outbound directory, leave the flow file's contents alone, and it ships.
