### PR TITLE
ci: run the test suite, and fix the race that would have made it flaky

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,35 @@
+name: Test
+
+on:
+  push:
+    branches: [ master ]
+
+  pull_request:
+
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          #  package.json requires >=22
+          node-version: '22'
+          cache: npm
+
+      - name: Install
+        #  ci rather than install so the lockfile is honoured, and
+        #  --include=dev because mocha is a devDependency
+        run: npm ci --include=dev
+
+      - name: Test
+        #  Runs the unit suite and then test:live, which drives real
+        #  databases and real files rather than mocks. Neither needs any
+        #  setup beyond the checkout -- no config.hjson, no seeded
+        #  directories -- so there is nothing to prepare here.
+        run: npm test

--- a/core/binkp/session.js
+++ b/core/binkp/session.js
@@ -96,6 +96,12 @@ class BinkpSession extends EventEmitter {
         //  M_GET and are waiting for the sender to re-announce the file.
         this._pendingOffsetReq = null; // { name, size, timestamp, useGZ }
         this._pendingGots = new Map(); // `name\0size\0ts` → { name, path, size, timestamp, disposition }
+        //  Disposition side effects -- the unlink or truncate of a file the
+        //  remote has acknowledged -- still in flight. The session is not done
+        //  until these land: 'session-end' is what callers act on, and what
+        //  the process may exit after. A sent packet still on disk is picked
+        //  up by the next outbound scan and delivered a second time.
+        this._pendingDispositions = new Set();
         //  Files we have already asked to have resent uncompressed, so a
         //  second failure falls through to M_SKIP instead of looping.
         this._nzRequested = new Set();
@@ -805,20 +811,33 @@ class BinkpSession extends EventEmitter {
     }
 
     _applyDisposition(file) {
+        let work;
         if (file.disposition === 'delete') {
-            fsp.unlink(file.path).catch(err =>
-                Log.warn(
-                    { path: file.path, error: err.message },
-                    '[BinkP] Could not delete sent file'
-                )
-            );
+            work = fsp
+                .unlink(file.path)
+                .catch(err =>
+                    Log.warn(
+                        { path: file.path, error: err.message },
+                        '[BinkP] Could not delete sent file'
+                    )
+                );
         } else if (file.disposition === 'truncate') {
-            fsp.truncate(file.path, 0).catch(err =>
-                Log.warn(
-                    { path: file.path, error: err.message },
-                    '[BinkP] Could not truncate sent file'
-                )
-            );
+            work = fsp
+                .truncate(file.path, 0)
+                .catch(err =>
+                    Log.warn(
+                        { path: file.path, error: err.message },
+                        '[BinkP] Could not truncate sent file'
+                    )
+                );
+        }
+
+        //  Not awaited here -- the protocol must keep moving -- but tracked so
+        //  the session can settle it before ending. Already .catch()'d above,
+        //  so it always resolves and can never wedge _finishSession().
+        if (work) {
+            this._pendingDispositions.add(work);
+            work.finally(() => this._pendingDispositions.delete(work));
         }
     }
 
@@ -1274,6 +1293,18 @@ class BinkpSession extends EventEmitter {
         if (this._state === 'done') return;
         this._state = 'done';
         if (this._timeoutHandle) clearTimeout(this._timeoutHandle);
+
+        //  |_state| is already 'done', so nothing re-enters while we wait for
+        //  the sent files to actually be gone (see |_pendingDispositions|).
+        const pending = Array.from(this._pendingDispositions);
+        if (0 === pending.length) {
+            return this._emitSessionEnd();
+        }
+
+        Promise.all(pending).then(() => this._emitSessionEnd());
+    }
+
+    _emitSessionEnd() {
         this.emit('session-end');
         setImmediate(() => this._destroy(true));
     }

--- a/test/binkp_session.test.js
+++ b/test/binkp_session.test.js
@@ -415,12 +415,41 @@ describe('BinkpSession — file transfer', () => {
 
         await runToEnd(clientSess, serverSess);
 
-        // File should have been deleted after M_GOT
+        //  'session-end' must not fire until the unlink has landed. It used to
+        //  be started and forgotten, so this assertion raced it and failed
+        //  roughly one full-suite run in fourteen -- and, worse, a process
+        //  exiting on 'session-end' could leave a sent packet on disk for the
+        //  next outbound scan to deliver a second time.
         await assert.rejects(
             fsp.access(tmpFile.filePath),
             { code: 'ENOENT' },
             'sent file should be deleted'
         );
+    });
+
+    it('truncates the outbound file when disposition is truncate', async () => {
+        const tmpFile = await makeTempFile('TRUNCATE_ME');
+        const { clientSess, serverSess } = await makeSessionPair();
+
+        serverSess.on('file-received', (name, size, ts, tempPath) => {
+            fsp.unlink(tempPath).catch(() => {});
+        });
+
+        clientSess.queueFile(
+            tmpFile.filePath,
+            'truncate_me.pkt',
+            tmpFile.size,
+            tmpFile.timestamp,
+            'truncate'
+        );
+
+        await runToEnd(clientSess, serverSess);
+
+        //  Same guarantee as above for the other disposition.
+        const { size } = await fsp.stat(tmpFile.filePath);
+        assert.equal(size, 0, 'sent file should be truncated by session-end');
+
+        await fsp.unlink(tmpFile.filePath).catch(() => {});
     });
 });
 


### PR DESCRIPTION
Two changes that belong together: CI does not run the tests, and turning that on without the second change would have made it intermittently red.

## CI never ran the tests

The workflows are `lint`, `codeql-analysis`, `docker` and `jekyll`. None invokes mocha, so a green PR said nothing about whether the 1772 tests passed — they only ever ran on someone's machine.

`.github/workflows/test.yml` is otherwise a copy of `lint.yml`. Verified against a clean clone: `git clone` → `npm ci --include=dev` → `npm test` needs nothing else — no `config.hjson`, no seeded directories (`db/`, `logs/`, `mail/` are gitignored and nothing wants them), no native build trouble. ~30s to install, ~35s to run. Passes under `TZ=UTC` and `LANG=C LC_ALL=C`, so it will not go red for being on a runner.

`npm test` covers `test:live` as well, which drives real databases and a real zip rather than mocks and takes under a second.

## …and it would have been flaky on day one

Repeated full-suite runs on `master` fail about one in fourteen:

```
1) BinkpSession — file transfer
     deletes the outbound file when disposition is delete:
   AssertionError: Missing expected rejection: sent file should be deleted
   at test/binkp_session.test.js:419
```

It never fails when that file runs alone (0/20) — it needs the timing of a full run.

`BinkpSession._applyDisposition()` started the `unlink`/`truncate` of an acknowledged file and forgot the promise, so `session-end` could be emitted — and the assertion run — before the unlink landed.

**This is not only a test problem.** `session-end` is what callers act on, and what the process may exit after. A sent packet still on disk is picked up by the next outbound scan and delivered a second time. Rare, but it is duplicate delivery, and it is invisible when it happens.

The promise is now tracked and settled in `_finishSession()` before `session-end` is emitted. Still not awaited inline — the protocol has to keep moving — and it is already `.catch()`'d, so it always resolves and cannot wedge the session. `_state` is set to `'done'` before the wait, so nothing re-enters.

## Demonstrated, not sampled

A flake at 1-in-14 is hard to prove fixed by re-running. With a 50ms delay inserted in front of the unlink the race becomes certain, which makes it a clean A/B:

| | delete test |
|---|---|
| `master` code + 50ms delay | **fails** every time |
| this branch + 50ms delay | passes |
| this branch, no delay | passes |

Twelve consecutive full-suite runs on this branch are clean, against one failure in fourteen on `master`.

Also adds the truncate-disposition case, which had no coverage at all — only `delete` was tested.

## Suggested follow-up

Once this has been green for a few runs, add `test` to branch protection next to `lint`.