### PR TITLE
fix(ftn): deliver NetMail direct to a configured node, without a route

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -22,6 +22,15 @@ Refer to [Upgrading](./docs/_docs/admin/upgrading.md) for details around this pr
 
 ## 0.5.0-beta to 0.5.1-beta
 
+* **NetMail no longer needs a `netMail.routes` entry to reach a node you have already configured** ([#739](https://github.com/NuSkooler/enigma-bbs/issues/739)). A destination listed in `scannerTossers.ftn_bso.nodes` is now delivered direct; routes are still consulted first and behave exactly as before, so **no action is required** and every existing configuration resolves identically.
+
+  **Two cases do get stricter**, both of which previously "succeeded" into a dead end:
+
+  * NetMail addressed to **your own** FTN address used to be accepted and filed into your own outbound, where nothing would ever send it. It is now refused unless you list your own address in `nodes`, and the sender is told.
+  * A route whose `network` names something not in `messageNetworks.ftn.networks` is refused when the route is chosen, rather than a step later with an error about the network. The message is the same failure either way; only the wording and timing change.
+
+  Worth a look if you have more than one network in the **same zone**: with no `network` named on the route or the node, the zone alone cannot tell them apart and the tie goes to `defaultNetwork`. Add `network` to the `nodes` entry to be explicit — the wrong choice means mail sent from the wrong address.
+
 * **Cross-zone routed NetMail queued before this release will not have been delivered, and needs moving by hand** ([#734](https://github.com/NuSkooler/enigma-bbs/issues/734)). NetMail routed through an uplink in a zone other than the recipient's was filed in the outbound directory for the *recipient's* zone rather than the uplink's, where no mailer would ever find it. The fix applies to newly exported mail only -- it does not relocate what is already queued.
 
   **Action:** only if you route NetMail across zones. Look for a zone-suffixed outbound directory that should not hold mail for that uplink -- for a `1:154/10` uplink carrying zone 2 mail, that is `outbound.002/009a000a.*` (`009a` = net 154, `000a` = node 10) plus the `.pkt` files its flow file names. Move both the flow file and the packets into the uplink's own outbound directory (`outbound/` when the uplink is in your network's default zone). **The stored paths inside the flow file do not need editing** -- a reference that no longer resolves is now also looked for by name in the flow file's own directory. If you would rather not sort it out, deleting the stray directory's contents loses the affected messages and nothing else.

--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -3,6 +3,20 @@ This document attempts to track **major** changes and additions in ENiGMA½. For
 
 ## 0.5.1-beta
 
+* **NetMail could not be sent to a node you had configured, without also adding a route for it** ([#739](https://github.com/NuSkooler/enigma-bbs/issues/739)) — `netMail.routes` is meant to say where mail goes when it is *not* going direct, but in practice it was mandatory for every NetMail destination. A message to an uplink sitting right there in `nodes{}` was refused with `No NetMail route for …`, and the sender got a delivery failure notice.
+
+  The network was being resolved with a helper that compares an address against your own `localAddress` — the right question when *importing* a packet addressed to you, and one a correspondent can never answer yes to. So the unrouted path could only ever succeed for mail addressed to yourself.
+
+  Destinations are now settled as the code always described: a `routes` entry if one matches, otherwise a `nodes` entry for the recipient itself, otherwise refused. Nothing that worked before changes — routes are still consulted first and handled exactly as they were.
+
+  Two smaller things fall out of the same rework:
+
+  * **`network` is now optional on a route.** Omitting it used to produce the same `No NetMail route` error even though a route had matched. It is filled in from the zone of the node being dialed, which is what picks the outbound directory anyway, so the from-address and the spool path cannot disagree. Name a `network` — on a route or on a `nodes` entry — only when two of your networks share a zone.
+
+  * **Bad configuration is reported for what it is.** A route naming a network that does not exist, or carrying an address that will not parse, now says so. The first was reported a step later as a problem with the network rather than the route; the second threw.
+
+  This also means automatic AreaFix rescan requests ([#241](https://github.com/NuSkooler/enigma-bbs/issues/241)) reach an uplink without a `routes` entry having to cover it.
+
 * **Routed cross-zone NetMail was filed where nothing would ever look for it** ([#734](https://github.com/NuSkooler/enigma-bbs/issues/734)) -- NetMail routed through an uplink in a different zone than the recipient (the standard FidoNet zone gate: zone 2 mail leaving through a zone 1 hub) was written to the outbound directory of the *recipient's* zone instead of the *uplink's*. A mailer only looks in the zone of the node it is calling, so the session to the uplink completed cleanly having transferred nothing and the message sat on disk indefinitely.
 
   Nothing surfaced it. The packet's flow file was named for the uplink but filed under the recipient's zone, so the pending-mail scan -- which reads a node's address from the directory's zone plus the flow file's name -- reported a node that does not exist (`2:154/10`, for an uplink of `1:154/10`), which the poller then skipped at `debug` level. Every visible signal said success.

--- a/core/bso_util.js
+++ b/core/bso_util.js
@@ -117,6 +117,38 @@ function resolveNetworkDefaultZone(networks, networkName) {
 }
 
 //
+//  Which of our networks should originate mail to a node in |zone|.
+//
+//  Zone is what identifies a network in practice, and it already decides which
+//  outbound directory a packet lands in (see outboundDirName below). Sending
+//  from the wrong network's localAddress while filing under that network's
+//  directory would be incoherent, so both answers come from here.
+//
+//  Returns { name, candidates }: |candidates| is every network claiming the
+//  zone, and |name| the one to use -- undefined when no network claims it.
+//  More than one can, and there is no way to tell them apart from the zone
+//  alone; the tie goes to |defaultNetwork|, which is the same network that
+//  owns the bare "outbound" directory, so the from-address and the spool path
+//  stay consistent. Callers with better information (a node's own |network|
+//  key) should not be asking in the first place.
+//
+function resolveNetworkNameForZone(networks, defaultNetwork, zone) {
+    const candidates = networkNames(networks).filter(
+        name => resolveNetworkDefaultZone(networks, name) === zone
+    );
+
+    if (candidates.length < 2) {
+        return { name: candidates[0], candidates };
+    }
+
+    const preferred = resolveDefaultNetworkName(networks, defaultNetwork);
+    return {
+        name: preferred && candidates.includes(preferred) ? preferred : candidates[0],
+        candidates,
+    };
+}
+
+//
 //  ".<zzz>" suffix for |zone| within |networkName|, or "" when |zone| is that
 //  network's default zone. A network whose default zone can't be resolved is
 //  treated as matching nothing, so every zone gets an explicit suffix.
@@ -211,6 +243,7 @@ module.exports = {
     canonicalNetworkName,
     resolveDefaultNetworkName,
     resolveNetworkDefaultZone,
+    resolveNetworkNameForZone,
     outboundDirName,
     legacyOutboundDirName,
     validateOutboundConfig,

--- a/core/scanner_tossers/ftn_bso.js
+++ b/core/scanner_tossers/ftn_bso.js
@@ -32,8 +32,10 @@ const User = require('../user.js');
 const StatLog = require('../stat_log.js');
 const SysProps = require('../system_property.js');
 const {
+    canonicalNetworkName,
     resolveDefaultNetworkName,
     resolveNetworkDefaultZone,
+    resolveNetworkNameForZone,
     outboundDirName,
     legacyOutboundDirName,
     validateOutboundConfig,
@@ -1025,46 +1027,110 @@ function FTNMessageScanTossModule() {
         return best ? best.value : undefined;
     };
 
+    //
+    //  Where to send NetMail for |destAddress|, and as whom.
+    //
+    //  1) A netMail.routes{} entry hands the message to another node for
+    //     onward delivery: where we send is not where it is addressed.
+    //  2) Otherwise, if |destAddress| is itself a node we are configured for,
+    //     we deliver direct.
+    //  3) Otherwise there is nowhere to send it. The export fails, and the
+    //     sender is told rather than the message sitting unexplained.
+    //
+    //  Either way the *network* has to be settled, since it decides both the
+    //  address we send from and the outbound directory we file under. A route
+    //  may name one outright. Failing that it comes from the zone of the node
+    //  being dialed, which is what picks the outbound directory anyway -- so
+    //  the two cannot disagree. A nodes{} entry may also carry its own
+    //  |network|, which is only needed when two networks share a zone.
+    //
     this.getNetMailRouteInfoFromAddress = function (destAddress, cb) {
-        //
-        //  Attempt to find route information for |destAddress|:
-        //
-        //  1) Routes: scannerTossers.ftn_bso.netMail.routes{} -> scannerTossers.ftn_bso.nodes{} -> config
-        //      - Where we send may not be where destAddress is (it's routed!)
-        //  2) Direct to nodes: scannerTossers.ftn_bso.nodes{} -> config
-        //      - Where we send is direct to destAddress
-        //
-        //  In both cases, attempt to look up Zone:Net/* to discover local "from" network/address
-        //  falling back to Config.scannerTossers.ftn_bso.defaultNetwork
-        //
         const route = this.getNetMailRoute(destAddress);
 
         let routeAddress;
         let networkName;
+        let nodeConfig;
         let isRouted;
+
         if (route) {
             routeAddress = Address.fromString(route.address);
+            if (!routeAddress) {
+                return cb(
+                    Errors.Invalid(
+                        `NetMail route for ${destAddress.toString()} has an unusable address: "${
+                            route.address
+                        }"`
+                    )
+                );
+            }
             networkName = route.network;
+            nodeConfig = this.getNodeConfigByAddress(routeAddress);
             isRouted = true;
         } else {
+            //
+            //  Direct delivery, but only to a node we actually carry
+            //  configuration for. Anything else has nowhere to go: filing a
+            //  packet for a node we know nothing about would leave it in the
+            //  spool indefinitely instead of telling the sender.
+            //
+            nodeConfig = this.getNodeConfigByAddress(destAddress);
+            if (!nodeConfig) {
+                return cb(
+                    Errors.DoesNotExist(
+                        `No NetMail route for ${destAddress.toString()}, and it is not a configured node`
+                    )
+                );
+            }
             routeAddress = destAddress;
             isRouted = false;
         }
 
-        networkName = networkName || this.getNetworkNameByAddress(routeAddress);
+        networkName = networkName || _.get(nodeConfig, 'network');
 
-        const config = this.getNodeConfigByAddress(routeAddress) || {
+        if (networkName) {
+            const canonical = canonicalNetworkName(this.getNetworks(), networkName);
+            if (!canonical) {
+                return cb(
+                    Errors.DoesNotExist(
+                        `NetMail for ${destAddress.toString()} names network "${networkName}", which is not configured`
+                    )
+                );
+            }
+            networkName = canonical;
+        } else {
+            const { name, candidates } = resolveNetworkNameForZone(
+                this.getNetworks(),
+                this.getConfiguredDefaultNetwork(),
+                routeAddress.zone
+            );
+
+            if (!name) {
+                return cb(
+                    Errors.DoesNotExist(
+                        `No network configured for zone ${routeAddress.zone}, needed to reach ${routeAddress.toString()}`
+                    )
+                );
+            }
+
+            if (candidates.length > 1) {
+                //  Resolvable, but only by falling back on defaultNetwork --
+                //  say so, since the cost of guessing wrong is mail sent from
+                //  the wrong address.
+                Log.debug(
+                    { zone: routeAddress.zone, candidates, using: name },
+                    'More than one network claims this zone; set a "network" on the node to be explicit'
+                );
+            }
+
+            networkName = name;
+        }
+
+        const config = nodeConfig || {
             packetType: '2+',
             encoding: Config().scannerTossers.ftn_bso.packetMsgEncoding,
         };
 
-        //  we should never be failing here; we may just be using defaults.
-        return cb(
-            networkName
-                ? null
-                : Errors.DoesNotExist(`No NetMail route for ${destAddress.toString()}`),
-            { destAddress, routeAddress, networkName, config, isRouted }
-        );
+        return cb(null, { destAddress, routeAddress, networkName, config, isRouted });
     };
 
     this.exportNetMailMessagesToUplinks = function (messagesOrMessageUuids, cb) {

--- a/docs/_docs/messageareas/bso-import-export.md
+++ b/docs/_docs/messageareas/bso-import-export.md
@@ -149,6 +149,7 @@ scannerTossers: {
         archiveType: ZIP        //  By-ext archive type: ZIP, ARJ, ..., optional.
         encoding: utf8          //  Encoding for exported messages
         packetPassword: MUHPA55 //  FTN .PKT password, optional
+        //  network: fsxnet     //  Only needed if two networks share this zone
 
         tic: {
           //  See TIC docs

--- a/docs/_docs/messageareas/netmail.md
+++ b/docs/_docs/messageareas/netmail.md
@@ -4,6 +4,17 @@ title: Netmail
 ---
 ENiGMA supports import and export of Netmail from the Private Mail area. `RiPuk @ 21:1/136` and `RiPuk <21:1/136>` 'To' address formats are supported.
 
+## Where NetMail Goes
+
+A NetMail message reaches its destination one of two ways:
+
+* **Direct** — the recipient is a node you have configured in `scannerTossers::ftn_bso::nodes`, and ENiGMA½ files the packet for that node. Nothing beyond the `nodes` entry is required.
+* **Routed** — the recipient is handed to a *different* node for onward delivery, per a `netMail::routes` entry. This is how you reach anything outside the nodes you talk to directly.
+
+Routes are consulted first, so a route always wins over a direct `nodes` match for the same address.
+
+A destination that is neither routed nor a configured node is refused: the export is marked failed and the sender is sent a notice, rather than the message sitting in the spool unexplained.
+
 ## Netmail Routing
 
 A configuration block must be added to the `scannerTossers::ftn_bso` section in `config.hjson` to tell the ENiGMA½ tosser where to route NetMail.
@@ -59,7 +70,7 @@ The packet is filed in the outbound directory belonging to the **route** address
 
 Route keys are address patterns, and more than one can match a given recipient. The **most specific match wins**, regardless of the order entries appear in `config.hjson` — `"21:1/100"` beats `"21:*"`, which in turn beats `"*"`.
 
-Note that `routes` is consulted *before* `nodes`, so a catch-all `"*"` route claims **all** NetMail — including AreaFix messages addressed to your uplinks on other networks. Prefer a pattern per zone. Where you do want a catch-all, you can send specific addresses direct by pointing a more specific route at them:
+Note that `routes` is consulted *before* `nodes`, so a catch-all `"*"` route claims **all** NetMail — including AreaFix messages addressed to your uplinks on other networks, which would otherwise go direct. Prefer a pattern per zone. Where you do want a catch-all, you can send specific addresses direct by pointing a more specific route at them:
 
 ````hjson
 routes: {
@@ -69,3 +80,23 @@ routes: {
 ````
 
 Each routed NetMail logs the address it was routed to at `debug` level, so the effective route can be confirmed from `logs/enigma-bbs.log`.
+
+### Which Network It Is Sent As
+
+The network decides two things: the address the message is sent **from**, and the outbound directory the packet is filed in. It is settled in this order:
+
+1. The `network` named on the matching `routes` entry.
+2. The `network` named on the matching `nodes` entry.
+3. Otherwise, the network whose zone matches the node being dialed — mail to `1:154/10` goes out as your zone 1 identity, mail to `21:1/100` as your zone 21 one.
+
+`network` is therefore optional in both places; the zone answers it for any ordinary setup. Name one only when two of your networks share a zone, which is the single case the zone cannot distinguish:
+
+````hjson
+nodes: {
+    "1:154/10" : {
+        network: fidonet   //  and not the other zone 1 network
+    }
+}
+````
+
+If no configured network claims the destination's zone, the message is refused rather than sent from an unrelated address.

--- a/test/binkp_ftn_bso_integration.test.js
+++ b/test/binkp_ftn_bso_integration.test.js
@@ -1237,4 +1237,256 @@ describe('ftn_bso ↔ BinkP integration', function () {
             );
         });
     });
+
+    // ── NetMail destination resolution (issue #739) ──────────────────────────
+    //
+    //  Deciding where NetMail goes settles two things at once: the node to
+    //  dial, and the network -- which is the address we send *from* and the
+    //  outbound directory we file under.
+    //
+    //  The network used to be looked up with getNetworkNameByAddress(), which
+    //  compares against our own localAddress and so answers "is this me?".
+    //  That is the right question on import, where the packet is addressed to
+    //  us, and the only question this path could never use: a correspondent is
+    //  by definition not us. Every unrouted destination therefore failed, even
+    //  one explicitly listed in nodes{}, and netMail.routes{} became mandatory
+    //  for all NetMail rather than for routing.
+
+    describe('ftn_bso — NetMail destination resolution (issue #739)', () => {
+        const NETWORKS = {
+            fsxnet: { localAddress: '21:1/234' },
+            fidonet: { localAddress: '1:103/705' },
+        };
+
+        //  Resolve one destination under a given nodes{}/routes{} shape.
+        function resolve({ nodes, routes, networks, defaultNetwork }, dest) {
+            const config = makeConfig();
+            config.messageNetworks.ftn.networks = networks || NETWORKS;
+            config.scannerTossers.ftn_bso.defaultNetwork = defaultNetwork;
+            config.scannerTossers.ftn_bso.nodes = nodes || {};
+            if (routes) {
+                config.scannerTossers.ftn_bso.netMail = { routes };
+            }
+
+            const prev = configModule._pushTestConfig(config);
+            try {
+                const { getModule } = require('../core/scanner_tossers/ftn_bso.js');
+                const Address = require('../core/ftn_address.js');
+                const mod = new getModule();
+                mod.moduleConfig = config.scannerTossers.ftn_bso;
+
+                let out;
+                mod.getNetMailRouteInfoFromAddress(
+                    Address.fromString(dest),
+                    (err, info) => {
+                        out = err
+                            ? { refused: err.message }
+                            : {
+                                  route: info.routeAddress.toString(),
+                                  network: info.networkName,
+                                  isRouted: info.isRouted,
+                              };
+                    }
+                );
+                return out;
+            } finally {
+                configModule._popTestConfig(prev);
+            }
+        }
+
+        it('sends direct to a node listed in nodes{}, with no route at all', () => {
+            const nodes = { '21:1/100': {}, '1:154/10': {} };
+            assert.deepEqual(resolve({ nodes }, '21:1/100'), {
+                route: '21:1/100',
+                network: 'fsxnet',
+                isRouted: false,
+            });
+            assert.deepEqual(resolve({ nodes }, '1:154/10'), {
+                route: '1:154/10',
+                network: 'fidonet',
+                isRouted: false,
+            });
+        });
+
+        it('picks the network by the zone of the node being dialed', () => {
+            //  Not by our own address, and not by defaultNetwork: mail to a
+            //  zone 1 node must go out as our zone 1 identity even when the
+            //  default network is the zone 21 one.
+            assert.equal(
+                resolve(
+                    { nodes: { '1:154/10': {} }, defaultNetwork: 'fsxnet' },
+                    '1:154/10'
+                ).network,
+                'fidonet'
+            );
+        });
+
+        it('refuses a destination that is neither routed nor a configured node', () => {
+            const got = resolve({ nodes: { '21:1/100': {} } }, '21:5/99');
+            assert.ok(got.refused, 'must not silently queue mail with nowhere to go');
+            assert.match(got.refused, /not a configured node/);
+        });
+
+        it('refuses when no configured network claims the destination zone', () => {
+            const got = resolve({ nodes: { '2:280/464': {} } }, '2:280/464');
+            assert.match(got.refused, /No network configured for zone 2/);
+        });
+
+        it('makes network optional on a route, falling back to the route zone', () => {
+            assert.deepEqual(
+                resolve({ routes: { '21:*': { address: '21:1/100' } } }, '21:5/99'),
+                { route: '21:1/100', network: 'fsxnet', isRouted: true }
+            );
+        });
+
+        it('refuses a route naming a network that is not configured', () => {
+            //  Previously accepted here and failed a step later, in the export,
+            //  with an error about the network rather than about the route.
+            const got = resolve(
+                { routes: { '21:*': { address: '21:1/100', network: 'nope' } } },
+                '21:5/99'
+            );
+            assert.match(got.refused, /names network "nope"/);
+        });
+
+        it('refuses a route whose address cannot be parsed', () => {
+            const got = resolve(
+                { routes: { '21:*': { address: 'not-an-address' } } },
+                '21:5/99'
+            );
+            assert.match(got.refused, /unusable address/);
+        });
+
+        it('lets a node name its own network when two share a zone', () => {
+            const networks = {
+                fidonet: { localAddress: '1:103/705' },
+                privnet: { localAddress: '1:999/1' },
+            };
+            //  defaultNetwork would otherwise win the tie
+            assert.equal(
+                resolve(
+                    {
+                        networks,
+                        defaultNetwork: 'privnet',
+                        nodes: { '1:154/10': { network: 'fidonet' } },
+                    },
+                    '1:154/10'
+                ).network,
+                'fidonet'
+            );
+        });
+
+        it('still prefers a route over a nodes{} entry for the same address', () => {
+            const got = resolve(
+                {
+                    nodes: { '21:1/100': {} },
+                    routes: { '*': { address: '1:154/10', network: 'fidonet' } },
+                },
+                '21:1/100'
+            );
+            assert.deepEqual(got, {
+                route: '1:154/10',
+                network: 'fidonet',
+                isRouted: true,
+            });
+        });
+
+        it('leaves routed cross-zone delivery (issue #734) alone', () => {
+            assert.deepEqual(
+                resolve(
+                    {
+                        networks: { fidonet: { localAddress: '1:103/705' } },
+                        routes: { '*': { address: '1:154/10', network: 'fidonet' } },
+                    },
+                    '2:280/464'
+                ),
+                { route: '1:154/10', network: 'fidonet', isRouted: true }
+            );
+        });
+
+        it('exports direct NetMail where the mailer will look for it', done => {
+            //  End to end: the real export series, then the real spool reader.
+            //  Resolution agreeing with itself is not enough -- the packet has
+            //  to land in the directory a BinkP call to that node scans.
+            const root = path.join(tmpDir, 'netmail_direct');
+            const tempDir = path.join(root, 'export_temp');
+
+            const config = makeConfig();
+            config.general = { boardName: 'Test BBS' };
+            config.messageNetworks.ftn.networks = NETWORKS;
+            config.scannerTossers.ftn_bso.defaultNetwork = 'fsxnet';
+            config.scannerTossers.ftn_bso.packetMsgEncoding = 'utf8';
+            config.scannerTossers.ftn_bso.nodes = { '1:154/10': { packetType: '2+' } };
+            config.scannerTossers.ftn_bso.paths = {
+                outbound: root,
+                inbound: path.join(root, 'ftn_in'),
+                secInbound: path.join(root, 'ftn_secin'),
+            };
+            //  deliberately no netMail.routes at all
+
+            const prev = configModule._pushTestConfig(config);
+            const { getModule } = require('../core/scanner_tossers/ftn_bso.js');
+            const { BsoSpool } = require('../core/binkp/bso_spool.js');
+            const Address = require('../core/ftn_address.js');
+            const Message = require('../core/message.js');
+
+            const mod = new getModule();
+            mod.moduleConfig = config.scannerTossers.ftn_bso;
+            mod.exportTempDir = tempDir;
+
+            const message = new Message({
+                areaTag: Message.WellKnownAreaTags.Private,
+                toUserName: 'Sysop',
+                fromUserName: 'Tester',
+                subject: 'direct netmail',
+                message: 'Body text.',
+            });
+            message.setExternalFlavor(Message.AddressFlavor.FTN);
+            message.meta.System[Message.SystemMetaNames.RemoteToUser] = '1:154/10';
+            message.persistMetaValue = (sect, name, value, callback) => callback(null);
+
+            fsp.mkdir(tempDir, { recursive: true })
+                .then(() =>
+                    mod.exportNetMailMessagesToUplinks([message], err => {
+                        configModule._popTestConfig(prev);
+                        if (err) return done(err);
+
+                        const spool = new BsoSpool({
+                            paths: config.scannerTossers.ftn_bso.paths,
+                            networks: NETWORKS,
+                            defaultNetwork: 'fsxnet',
+                        });
+
+                        spool
+                            .getOutboundFilesForNode(Address.fromString('1:154/10'))
+                            .then(files => {
+                                assert.equal(
+                                    files.length,
+                                    1,
+                                    'a call to 1:154/10 must find the packet'
+                                );
+                                assert.ok(files[0].path.endsWith('.pkt'));
+                                //  fidonet is not the default network, so its
+                                //  own directory -- not outbound/
+                                assert.ok(
+                                    files[0].path.includes(
+                                        `${path.sep}fidonet${path.sep}`
+                                    ),
+                                    `expected the fidonet outbound tree, got ${files[0].path}`
+                                );
+                                return spool.getNodesWithPendingMail();
+                            })
+                            .then(addrs => {
+                                assert.deepEqual(
+                                    addrs.map(a => a.toString()),
+                                    ['1:154/10']
+                                );
+                                done();
+                            })
+                            .catch(done);
+                    })
+                )
+                .catch(done);
+        });
+    });
 }); // describe('ftn_bso ↔ BinkP integration')

--- a/test/bso_util.test.js
+++ b/test/bso_util.test.js
@@ -7,6 +7,7 @@ const {
     canonicalNetworkName,
     resolveDefaultNetworkName,
     resolveNetworkDefaultZone,
+    resolveNetworkNameForZone,
     outboundDirName,
     legacyOutboundDirName,
     validateOutboundConfig,
@@ -94,6 +95,101 @@ describe('bso_util — outbound spool path resolution', () => {
                 undefined
             );
             assert.equal(resolveNetworkDefaultZone(THREE_NETWORKS, 'nope'), undefined);
+        });
+    });
+
+    //  Which network originates mail to a given zone. The answer has to match
+    //  outboundDirName()'s idea of who owns the directory for that zone, or a
+    //  packet would be sent from one network's address and filed under
+    //  another's -- see issue #739.
+    describe('resolveNetworkNameForZone', () => {
+        it('resolves a zone claimed by exactly one network', () => {
+            const got = resolveNetworkNameForZone(THREE_NETWORKS, undefined, 21);
+            assert.equal(got.name, 'fsxnet');
+            assert.deepEqual(got.candidates, ['fsxnet']);
+        });
+
+        it('resolves each of several networks by its own zone', () => {
+            assert.equal(
+                resolveNetworkNameForZone(THREE_NETWORKS, undefined, 1).name,
+                'fidonet'
+            );
+            assert.equal(
+                resolveNetworkNameForZone(THREE_NETWORKS, undefined, 700).name,
+                'spooknet'
+            );
+        });
+
+        it('returns no name for a zone no network claims', () => {
+            const got = resolveNetworkNameForZone(THREE_NETWORKS, undefined, 2);
+            assert.equal(got.name, undefined);
+            assert.deepEqual(got.candidates, []);
+        });
+
+        it('honours an explicit defaultZone over the localAddress zone', () => {
+            const networks = { odd: { localAddress: '1:1/1', defaultZone: 42 } };
+            assert.equal(resolveNetworkNameForZone(networks, undefined, 42).name, 'odd');
+            assert.equal(
+                resolveNetworkNameForZone(networks, undefined, 1).name,
+                undefined
+            );
+        });
+
+        it('breaks a shared zone with defaultNetwork, and reports the tie', () => {
+            const networks = {
+                fidonet: { localAddress: '1:103/705' },
+                privnet: { localAddress: '1:999/1' },
+            };
+            const got = resolveNetworkNameForZone(networks, 'privnet', 1);
+            assert.equal(got.name, 'privnet');
+            assert.deepEqual(got.candidates.sort(), ['fidonet', 'privnet']);
+        });
+
+        it('agrees with outboundDirName on who owns a shared zone', () => {
+            //  The from-address and the outbound directory must be decided the
+            //  same way; this is the case where they could diverge.
+            const networks = {
+                fidonet: { localAddress: '1:103/705' },
+                privnet: { localAddress: '1:999/1' },
+            };
+            for (const defaultNetwork of [undefined, 'fidonet', 'privnet']) {
+                const { name } = resolveNetworkNameForZone(networks, defaultNetwork, 1);
+                assert.equal(
+                    outboundDirName(networks, defaultNetwork, name, 1),
+                    outboundDirName(
+                        networks,
+                        defaultNetwork,
+                        resolveDefaultNetworkName(networks, defaultNetwork),
+                        1
+                    ),
+                    `defaultNetwork=${defaultNetwork}`
+                );
+            }
+        });
+
+        it('still resolves when defaultNetwork names something unconfigured', () => {
+            const networks = {
+                fidonet: { localAddress: '1:103/705' },
+                privnet: { localAddress: '1:999/1' },
+            };
+            const got = resolveNetworkNameForZone(networks, 'nope', 1);
+            assert.ok(got.candidates.includes(got.name));
+        });
+
+        it('ignores a network whose zone cannot be resolved', () => {
+            const networks = { broken: {}, fsxnet: { localAddress: '21:1/121' } };
+            assert.equal(
+                resolveNetworkNameForZone(networks, undefined, 21).name,
+                'fsxnet'
+            );
+        });
+
+        it('returns no name for an empty or absent network table', () => {
+            assert.equal(resolveNetworkNameForZone({}, undefined, 21).name, undefined);
+            assert.equal(
+                resolveNetworkNameForZone(undefined, undefined, 21).name,
+                undefined
+            );
         });
     });
 


### PR DESCRIPTION
Fixes #739.

## The bug

`netMail.routes{}` is meant to say where mail goes when it is *not* going direct. In practice it was mandatory for **every** NetMail destination — a message to an uplink sitting right there in `nodes{}` was refused with `No NetMail route for …`, and the sender got a delivery failure notice.

The network was resolved with `getNetworkNameByAddress()`, which compares an address against our own `localAddress` via `Address.isEqual`. That is the right question when *importing* a packet addressed to us — its three other call sites are all import paths — and one a correspondent can never answer yes to. The unrouted path could therefore only ever resolve for mail addressed to ourselves, which files a packet into our own outbound that nothing will ever send.

The function's own comment has described the intended design since 2018:

```
//  2) Direct to nodes: scannerTossers.ftn_bso.nodes{} -> config
//      - Where we send is direct to destAddress
```

That path has never worked.

Concrete consequence: automatic AreaFix rescan (#241) carries a warning that requests "cannot be routed … until `netMail.routes` covers this uplink". That workaround exists because of this bug.

## The fix

Destinations are settled as described: a `routes{}` entry if one matches, else a `nodes{}` entry for the recipient itself, else refused so the sender is told rather than the message sitting unexplained.

The network — which decides both the address we send **from** and the outbound directory we file **under** — comes from the route's own `network`, then the node's, then the **zone** of the node being dialed. That zone answer lives in `bso_util.js` next to `outboundDirName()`, so the from-address and the spool path are decided by the same code and cannot disagree; a test pins that.

`network` becomes optional on both a route and a node, needed only when two networks share a zone.

## Measured, not assumed

Ran a matrix of realistic configs against `master` in a worktree and against this branch, and diffed:

**11 rows identical, 10 changed.** Every config that resolves today resolves identically — routes are consulted first and handled exactly as before.

Of the 10 changes, **7 are the fix** (destinations that were refused now resolve). The other 3 previously "succeeded" into a dead end:

| case | master | here |
|---|---|---|
| route names an unconfigured network | resolved, then failed in the export with an error about the *network* | refused where the route is chosen, naming the *route* |
| mail to our own address (×2) | filed into our own outbound, never sent | refused, sender told |

Listing your own address in `nodes{}` restores the second if anyone wants it.

## No migration

Existing setups need no changes, and the shipped `config_default.js` has no `netMail` block at all — so this makes fresh installs work rather than changing established ones. If anything it *removes* a config requirement.

One case worth a look, called out in UPGRADE.md: with two networks in the same zone and no `network` named anywhere, the zone alone cannot tell them apart and the tie goes to `defaultNetwork` — chosen to match whoever owns that zone's outbound directory, so the two stay coherent. Naming `network` on the `nodes{}` entry is the explicit answer.

## Tests

- `test/bso_util.test.js` — `resolveNetworkNameForZone`, including a case asserting it agrees with `outboundDirName()` on a shared zone.
- `test/binkp_ftn_bso_integration.test.js` — 11 cases covering direct delivery, zone-derived network, optional route `network`, node-level `network`, each refusal, and two guards pinning that route precedence and #734 cross-zone routing are untouched. Verified against `master`'s resolver: **9 of the 11 fail**, and the 2 that pass are precisely the two "must not change" guards.
- One end-to-end case runs the real export series with no `routes{}` at all and then asks `BsoSpool` for the node's files, so writer and reader are checked against each other rather than against a restatement of either.

1785 unit + 8 live green, eslint and prettier clean.