### PR TITLE
fix(wfc): empty full-log viewer and the crash it caused

### DIFF
--- a/core/logger.js
+++ b/core/logger.js
@@ -24,6 +24,14 @@ module.exports = class Log {
                 logPath,
                 Config.logging.rotatingFile.fileName
             );
+
+            //  Remember the path we resolved: the value assigned above lives on
+            //  the *current* config object, which a config.hjson hot-reload
+            //  replaces wholesale -- taking the injected 'path' with it. Bunyan
+            //  keeps writing to the stream created here either way, so this is
+            //  the authoritative location of the active log file.
+            this.rotatingFilePath = Config.logging.rotatingFile.path;
+
             logStreams.push(Config.logging.rotatingFile);
         }
 
@@ -34,6 +42,12 @@ module.exports = class Log {
             streams: logStreams,
             serializers: serializers,
         });
+    }
+
+    //  Path of the active rotating log file, or undefined if not enabled.
+    //  Prefer this over Config().logging.rotatingFile.path; see init().
+    static getRotatingFilePath() {
+        return this.rotatingFilePath;
     }
 
     static standardSerializers() {

--- a/core/menu_view.js
+++ b/core/menu_view.js
@@ -199,7 +199,7 @@ class MenuView extends View {
     }
 
     getItem(index) {
-        if (index > this.items.length - 1) {
+        if (index < 0 || index > this.items.length - 1) {
             return null;
         }
 
@@ -234,8 +234,12 @@ class MenuView extends View {
         this.emitIndexUpdate();
     }
 
+    //  Clamp to a valid index; an empty list has none, so park at 0 where
+    //  getItem() and the draw paths already no-op.
     setFocusItemIndex(index) {
-        this.focusedItemIndex = index;
+        this.focusedItemIndex = this.items.length
+            ? Math.min(Math.max(index, 0), this.items.length - 1)
+            : 0;
     }
 
     getFocusItemIndex() {

--- a/core/vertical_menu_view.js
+++ b/core/vertical_menu_view.js
@@ -212,10 +212,11 @@ class VerticalMenuView extends MenuView {
     }
 
     setFocusItemIndex(index) {
-        super.setFocusItemIndex(index); //  sets this.focusedItemIndex
+        super.setFocusItemIndex(index); //  sets this.focusedItemIndex, clamped
 
+        //  use the clamped value, not the caller's raw |index|
         const remainAfterFocus = this.focusItemAtTop
-            ? this.items.length - index
+            ? this.items.length - this.focusedItemIndex
             : this.items.length;
 
         if (remainAfterFocus >= this.maxVisibleItems) {
@@ -285,6 +286,13 @@ class VerticalMenuView extends MenuView {
     //  item.row is guaranteed valid from the last full redraw() since this is only
     //  called when the viewWindow has not scrolled.
     _focusRedraw(prevFocusedIndex) {
+        const focusedItem = this.items[this.focusedItemIndex];
+        if (!focusedItem) {
+            //  nothing to focus (e.g. empty list) — a full redraw handles the
+            //  blanking and leaves no stale highlight behind
+            return this.redraw();
+        }
+
         if (this.items[prevFocusedIndex] && this.items[prevFocusedIndex].row == null) {
             //  item.row not yet set — fall back to a full redraw
             return this.redraw();
@@ -293,17 +301,22 @@ class VerticalMenuView extends MenuView {
         if (
             prevFocusedIndex !== this.focusedItemIndex &&
             prevFocusedIndex >= this.viewWindow.top &&
-            prevFocusedIndex <= this.viewWindow.bottom
+            prevFocusedIndex <= this.viewWindow.bottom &&
+            this.items[prevFocusedIndex]
         ) {
             this.items[prevFocusedIndex].focused = false;
             this.drawItem(prevFocusedIndex);
         }
 
-        this.items[this.focusedItemIndex].focused = true;
+        focusedItem.focused = true;
         this.drawItem(this.focusedItemIndex);
     }
 
     focusNext() {
+        if (!this.items.length) {
+            return; //  nothing to move to; don't emit a bogus index update
+        }
+
         if (this.items.length - 1 === this.focusedItemIndex) {
             //  wrap-around: viewWindow changes — full redraw
             this.focusedItemIndex = 0;
@@ -328,6 +341,10 @@ class VerticalMenuView extends MenuView {
     }
 
     focusPrevious() {
+        if (!this.items.length) {
+            return; //  nothing to move to; don't emit a bogus index update
+        }
+
         if (0 === this.focusedItemIndex) {
             //  wrap-around: viewWindow changes — full redraw
             this.focusedItemIndex = this.items.length - 1;
@@ -362,6 +379,10 @@ class VerticalMenuView extends MenuView {
     }
 
     focusPreviousPageItem() {
+        if (!this.items.length) {
+            return;
+        }
+
         //
         //  Jump to current - up to page size or top
         //  If already at the top, jump to bottom
@@ -378,6 +399,10 @@ class VerticalMenuView extends MenuView {
     }
 
     focusNextPageItem() {
+        if (!this.items.length) {
+            return;
+        }
+
         //
         //  Jump to current + up to page size or bottom
         //  If already at the bottom, jump to top
@@ -397,11 +422,19 @@ class VerticalMenuView extends MenuView {
     }
 
     focusFirst() {
+        if (!this.items.length) {
+            return;
+        }
+
         this.setFocusItemIndex(0);
         return super.focusFirst();
     }
 
     focusLast() {
+        if (!this.items.length) {
+            return;
+        }
+
         this.setFocusItemIndex(this.items.length - 1);
         return super.focusLast();
     }

--- a/core/wfc.js
+++ b/core/wfc.js
@@ -821,8 +821,11 @@ exports.getModule = class WaitingForCallerModule extends MenuModule {
     }
 
     _readLogSnapshot(cb) {
-        const config = Config();
-        const logFilePath = _.get(config, 'logging.rotatingFile.path');
+        //  Note: Log.getRotatingFilePath() rather than reading
+        //  logging.rotatingFile.path off the config -- that key is injected into
+        //  the live config object by Log.init() at startup and is lost the first
+        //  time config.hjson is hot-reloaded, which left this viewer empty.
+        const logFilePath = Log.getRotatingFilePath();
         if (!logFilePath) {
             return cb(null, []);
         }
@@ -1020,6 +1023,20 @@ exports.getModule = class WaitingForCallerModule extends MenuModule {
                             this._updateFullLogDetail(
                                 detailView,
                                 records[records.length - 1]
+                            );
+                        }
+                    } else {
+                        //  Nothing to navigate or submit: keep the empty list out
+                        //  of the form data path and tell the op why it's blank.
+                        logListView.acceptsInput = false;
+
+                        if (detailView) {
+                            detailView.setAnsi(
+                                pipeToAnsi(
+                                    this.config.fullLogEmptyMessage ||
+                                        '|08No log entries available|00',
+                                    this.client
+                                )
                             );
                         }
                     }

--- a/test/vertical_menu_view_empty.test.js
+++ b/test/vertical_menu_view_empty.test.js
@@ -1,0 +1,206 @@
+'use strict';
+
+//  Regression coverage for navigating a VerticalMenuView that has no items.
+//
+//  An empty list is legitimately reachable (a list built from a log file that
+//  is empty/rotated/unreadable, a filtered result set, etc.).  Before this was
+//  fixed, arrow/page navigation walked focusedItemIndex out of range -- including
+//  negative -- and two separate dereferences threw:
+//
+//    * _focusRedraw() -> this.items[idx].focused = ...
+//        "Cannot set properties of undefined (setting 'focused')"
+//        Not caught anywhere; it escaped the ssh2 data handler and dropped the
+//        user's connection.
+//
+//    * MenuView.getItem() -> this.items[-1].text, reached via getData()
+//        "Cannot read properties of undefined (reading 'text')"
+//        Caught by ViewController.getFormData(), but logged on every keypress.
+
+const { strict: assert } = require('assert');
+
+const { VerticalMenuView } = require('../core/vertical_menu_view.js');
+
+//  Minimal client stub — satisfies View base requirements without a real terminal.
+function makeClient() {
+    return {
+        term: {
+            termWidth: 80,
+            termHeight: 25,
+            write: () => {},
+            rawWrite: () => {},
+        },
+    };
+}
+
+function makeView(opts = {}) {
+    const view = new VerticalMenuView(
+        Object.assign(
+            {
+                client: makeClient(),
+                id: 1,
+                position: { row: 1, col: 1 },
+                dimens: { width: 40, height: 5 },
+            },
+            opts
+        )
+    );
+
+    //  Mirror the real lifecycle: a view is always drawn (which establishes
+    //  viewWindow) before it can receive any key press.
+    view.redraw();
+
+    return view;
+}
+
+describe('VerticalMenuView with an empty item list', () => {
+    describe('focus navigation does not throw', () => {
+        it('focusNext()', () => {
+            const view = makeView();
+            assert.doesNotThrow(() => view.focusNext());
+        });
+
+        it('focusPrevious()', () => {
+            const view = makeView();
+            assert.doesNotThrow(() => view.focusPrevious());
+        });
+
+        it('focusNextPageItem()', () => {
+            const view = makeView();
+            assert.doesNotThrow(() => view.focusNextPageItem());
+        });
+
+        it('focusPreviousPageItem()', () => {
+            const view = makeView();
+            assert.doesNotThrow(() => view.focusPreviousPageItem());
+        });
+
+        it('focusFirst()', () => {
+            const view = makeView();
+            assert.doesNotThrow(() => view.focusFirst());
+        });
+
+        it('focusLast()', () => {
+            const view = makeView();
+            assert.doesNotThrow(() => view.focusLast());
+        });
+    });
+
+    describe('focusedItemIndex never leaves a valid range', () => {
+        it('focusPrevious() does not produce a negative index', () => {
+            const view = makeView();
+            view.focusPrevious();
+            assert.equal(view.focusedItemIndex, 0);
+        });
+
+        it('focusLast() does not produce a negative index', () => {
+            const view = makeView();
+            view.focusLast();
+            assert.equal(view.focusedItemIndex, 0);
+        });
+
+        it('repeated mixed navigation leaves the index at 0', () => {
+            const view = makeView();
+
+            //  the sort of key mashing that originally dropped the connection
+            for (let i = 0; i < 10; ++i) {
+                view.focusNext();
+                view.focusPrevious();
+                view.focusNextPageItem();
+                view.focusPreviousPageItem();
+                view.focusLast();
+                view.focusFirst();
+            }
+
+            assert.equal(view.focusedItemIndex, 0);
+        });
+    });
+
+    describe('getData() / getItem() stay safe after navigation', () => {
+        it('getData() does not throw once focus has been moved', () => {
+            const view = makeView();
+            view.focusPrevious(); //  previously set focusedItemIndex to -1
+            assert.doesNotThrow(() => view.getData());
+        });
+
+        it('getItem(-1) returns null rather than dereferencing items[-1]', () => {
+            const view = makeView();
+            assert.equal(view.getItem(-1), null);
+        });
+
+        it('getItem(0) returns null on an empty list', () => {
+            const view = makeView();
+            assert.equal(view.getItem(0), null);
+        });
+    });
+
+    describe('onKeyPress navigation', () => {
+        const keys = ['up', 'down', 'page up', 'page down', 'home', 'end'];
+
+        keys.forEach(name => {
+            it(`"${name}" does not throw`, () => {
+                const view = makeView();
+                assert.doesNotThrow(() => view.onKeyPress(null, { name }));
+            });
+        });
+    });
+});
+
+describe('VerticalMenuView with items (unchanged behaviour)', () => {
+    const ITEMS = ['one', 'two', 'three'];
+
+    it('focusNext() advances focus', () => {
+        const view = makeView({ items: ITEMS });
+        view.focusNext();
+        assert.equal(view.focusedItemIndex, 1);
+    });
+
+    it('focusNext() wraps at the end', () => {
+        const view = makeView({ items: ITEMS });
+        view.setFocusItemIndex(ITEMS.length - 1);
+        view.focusNext();
+        assert.equal(view.focusedItemIndex, 0);
+    });
+
+    it('focusPrevious() wraps at the start', () => {
+        const view = makeView({ items: ITEMS });
+        view.focusPrevious();
+        assert.equal(view.focusedItemIndex, ITEMS.length - 1);
+    });
+
+    it('focusLast() selects the final item', () => {
+        const view = makeView({ items: ITEMS });
+        view.focusLast();
+        assert.equal(view.focusedItemIndex, ITEMS.length - 1);
+    });
+
+    it('getItem() returns item text', () => {
+        const view = makeView({ items: ITEMS });
+        assert.equal(view.getItem(0), 'one');
+    });
+
+    describe('setFocusItemIndex() clamps out-of-range values', () => {
+        it('an index past the end clamps to the last item', () => {
+            const view = makeView({ items: ITEMS });
+            view.setFocusItemIndex(99);
+            assert.equal(view.focusedItemIndex, ITEMS.length - 1);
+        });
+
+        it('a negative index clamps to the first item', () => {
+            const view = makeView({ items: ITEMS });
+            view.setFocusItemIndex(-5);
+            assert.equal(view.focusedItemIndex, 0);
+        });
+    });
+
+    it('a list emptied by setItems() resets focus and stays navigable', () => {
+        const view = makeView({ items: ITEMS });
+        view.focusLast();
+
+        view.setItems([]);
+        assert.equal(view.focusedItemIndex, 0);
+
+        assert.doesNotThrow(() => view.focusNext());
+        assert.doesNotThrow(() => view.focusPrevious());
+        assert.doesNotThrow(() => view.getData());
+    });
+});


### PR DESCRIPTION
Two linked defects behind an empty WFC log viewer that disconnected the operator on the next key press.

1) The viewer was always empty after any config.hjson hot-reload.

   logging.rotatingFile.path is not a config key: logger.init() injects it
   into the live config object at startup. ConfigLoader._reload() rebuilds
   from a fresh DefaultConfig() and replaces this.current wholesale, so the
   injected value is dropped the first time config.hjson changes.
   _readLogSnapshot() read that key and bailed to an empty list.

   Log now records the path it resolved and exposes getRotatingFilePath().
   That is also more correct than deriving it from live config: bunyan keeps
   writing to the stream created at init, so a post-reload fileName change
   must not redirect the reader.

2) Navigating the resulting empty list crashed the session.

   VerticalMenuView's focus movement assumed a non-empty list.
   focusPrevious() set focusedItemIndex to items.length - 1 (-1 when empty)
   and setFocusItemIndex() never clamped, so the index drifted out of range:

     - _focusRedraw() dereferenced this.items[idx].focused. Uncaught, it escaped the ssh2 data handler, tripped the connection error path and dropped the user.
     - MenuView.getItem() guarded only the upper bound, so items[-1].text threw via getData(). Caught by getFormData(), but logged on every key press.

   getItem() now rejects negative indices, setFocusItemIndex() clamps, the
   focus-movement methods no-op on an empty list, and _focusRedraw() falls
   back to a full redraw when there is nothing to focus.

An empty list stays reachable by design (rotated, empty or unreadable log), so the WFC viewer also drops the list out of the form-data path and shows a message instead of a blank pane.