### PR TITLE
fix(binkp/ftn): take the FTS-5005 .bsy lock before touching a flow file, and stop losing outbound

### DIFF
--- a/core/binkp/bso_spool.js
+++ b/core/binkp/bso_spool.js
@@ -14,6 +14,7 @@ const {
     legacyOutboundDirName,
     DEFAULT_NETWORK_DIR_NAME,
 } = require('../bso_util');
+const bsoLock = require('../bso_lock');
 
 // In priority order (highest first)
 const FLOW_EXTS = ['ilo', 'clo', 'dlo', 'flo', 'hlo'];
@@ -35,7 +36,11 @@ const POINT_DIR_RE = /^([0-9a-f]{8})\.pnt$/i;
 // (BBS crashed mid-session). 6× the BinkP session timeout (5 min) gives a
 // generous safety margin without making post-crash recovery slow. Tunable
 // via scannerTossers.ftn_bso.binkp.staleLockMaxAgeMs.
-const DEFAULT_STALE_LOCK_MAX_AGE_MS = 30 * 60 * 1000;
+//
+// Defined in core/bso_lock.js, which owns the FTS-5005 §5.1 .bsy protocol for
+// both this reader and the ftn_bso writer -- see the note there on why the two
+// must not carry separate implementations (issue #719).
+const DEFAULT_STALE_LOCK_MAX_AGE_MS = bsoLock.DEFAULT_STALE_LOCK_MAX_AGE_MS;
 
 // Networks we've already complained about. Module scope rather than per
 // instance: a spool is rebuilt for every poll and every inbound session, but
@@ -83,48 +88,18 @@ class BsoSpool {
     // ── Lock management ──────────────────────────────────────────────────────
 
     // Acquire the per-node .bsy lock. Returns false if already locked by another
-    // process; throws on unexpected errors.
+    // process (ours or an external mailer's); throws on unexpected errors.
+    // The protocol itself lives in core/bso_lock.js.
     async acquireLock(addr) {
-        const bsyPath = this._bsyPath(addr);
-        await fsp.mkdir(path.dirname(bsyPath), { recursive: true });
-
-        const tryCreate = async () => {
-            // 'wx' = exclusive create; fails with EEXIST if file is present
-            const fh = await fsp.open(bsyPath, 'wx');
-            await fh.writeFile(String(process.pid));
-            await fh.close();
-        };
-
-        //  Another mailer sharing this spool may have written the lock under a
-        //  different case (FTS-5005.003 §2); an exclusive create on our own
-        //  spelling would not collide with it, and we would both believe we
-        //  held the lock.
-        const existing = await this._resolveExistingBsy(bsyPath);
-        if (existing && existing !== bsyPath && !(await this._reapIfStale(existing))) {
-            return false;
-        }
-
-        try {
-            await tryCreate();
-            return true;
-        } catch (err) {
-            if (err.code !== 'EEXIST') throw err;
-        }
-
-        //  EEXIST: lock present. Reap if it looks orphaned and retry once.
-        if (!(await this._reapIfStale(bsyPath))) return false;
-
-        try {
-            await tryCreate();
-            return true;
-        } catch (err) {
-            if (err.code === 'EEXIST') return false;
-            throw err;
-        }
+        return bsoLock.acquire(this._bsyPath(addr), this._lockOpts());
     }
 
     async releaseLock(addr) {
-        await fsp.unlink(this._bsyPath(addr)).catch(() => {});
+        await bsoLock.release(this._bsyPath(addr));
+    }
+
+    _lockOpts() {
+        return { staleMaxAgeMs: this._staleLockMaxAgeMs, log: Log };
     }
 
     // Sweep every outbound directory for orphaned .bsy lock files. Returns the
@@ -163,28 +138,7 @@ class BsoSpool {
     // and has been removed (or was already gone). Returns false when the file
     // is still fresh, or when stat/unlink errors prevent a confident reap.
     async _reapIfStale(bsyPath) {
-        let stat;
-        try {
-            stat = await fsp.stat(bsyPath);
-        } catch (err) {
-            //  Already gone — caller should treat that as a successful reap
-            //  (the slot is now free).
-            return err.code === 'ENOENT';
-        }
-        const ageMs = Date.now() - stat.mtimeMs;
-        if (ageMs <= this._staleLockMaxAgeMs) return false;
-        try {
-            await fsp.unlink(bsyPath);
-            Log.info({ path: bsyPath, ageMs }, '[BinkP/BSO] Reaped stale .bsy lock');
-            return true;
-        } catch (err) {
-            if (err.code === 'ENOENT') return true;
-            Log.warn(
-                { path: bsyPath, error: err.message },
-                '[BinkP/BSO] Could not reap stale .bsy lock'
-            );
-            return false;
-        }
+        return bsoLock.reapIfStale(bsyPath, this._staleLockMaxAgeMs, Log);
     }
 
     // ── Outbound file enumeration ────────────────────────────────────────────
@@ -442,16 +396,6 @@ class BsoSpool {
             );
         }
         return path.join(dir, `${nodeBaseName(addr)}.bsy`);
-    }
-
-    //  The lock file for |bsyPath|'s node as it actually exists on disk, in
-    //  whatever case it was written, or null when there is none.
-    async _resolveExistingBsy(bsyPath) {
-        const dir = path.dirname(bsyPath);
-        const actual = (await readDirCaseMap(dir)).get(
-            path.basename(bsyPath).toLowerCase()
-        );
-        return actual ? path.join(dir, actual) : null;
     }
 
     async _parseFlowFile(flowPath) {

--- a/core/binkp/bso_spool.js
+++ b/core/binkp/bso_spool.js
@@ -740,9 +740,34 @@ async function attachSpoolToSession(session, spool, remoteAddrs) {
             }
         }
     } else {
-        // Answering side: learn remote addresses from the session handshake
+        //
+        //  Answering side: learn remote addresses from the session handshake,
+        //  then resolve what we have queued for them.
+        //
+        //  holdEOB(), not holdSend(). The two are not interchangeable and the
+        //  difference decides whether the peer gets its mail at all.
+        //
+        //  |_sendHeld| is consulted in exactly one place -- _enterTransfer()'s
+        //  initial _sendNext(). It does not gate _sendNext() itself, and the
+        //  peer's own M_EOB reaches _sendNext() by another route entirely:
+        //  _onEob() sets _remoteEOB and calls it directly. That commonly beats
+        //  this asynchronous lookup. _sendNext() then finds an empty queue,
+        //  sees the answering-side "wait for _remoteEOB" condition already
+        //  satisfied, and sends our M_EOB -- after which releaseSend()'s
+        //  |!this._localEOBSent| guard makes it a no-op and the files we just
+        //  queued are never offered.
+        //
+        //  |_eobHold| is tested inside _sendNext() at the point M_EOB would go
+        //  out, so it holds however _sendNext() was reached. That is what this
+        //  needs. The FREQ resolver already uses it for the same reason.
+        //
+        //  Reported as #747, and it is not TIC-specific: it affects any
+        //  answering session with something queued for the caller. It matters
+        //  especially for file echoes, because a downlink normally polls its
+        //  hub rather than being dialled.
+        //
         session.on('addresses', async addrStrings => {
-            session.holdSend();
+            session.holdEOB();
             try {
                 for (const addrStr of addrStrings) {
                     const addr = Address.fromString(addrStr);
@@ -760,7 +785,7 @@ async function attachSpoolToSession(session, spool, remoteAddrs) {
                     }
                 }
             } finally {
-                session.releaseSend();
+                session.releaseEOB();
             }
         });
     }

--- a/core/bso_lock.js
+++ b/core/bso_lock.js
@@ -1,0 +1,307 @@
+/* jslint node: true */
+'use strict';
+
+const Errors = require('./enig_error.js').Errors;
+
+//  deps
+const fsp = require('fs/promises');
+const paths = require('path');
+
+//
+//  FTS-5005.003 §5.1 ".bsy" control files, shared by everything in this tree
+//  that touches a BSO flow file.
+//
+//  The spec puts the requirement on *software*, not on mailers:
+//
+//      "A bsy is a main control file that must be used by any software
+//       dealing with flow files in BSO. It is named the same way as the
+//       flow file but with the extension '.bsy'.
+//
+//       Any software must check this file before doing any changes in flow
+//       files. If a bsy file exists all changes are prohibited in any
+//       corresponding flow files. [...] If a bsy file does not exist
+//       software must create it, ensure that it was successfully created,
+//       and then work with the flow files. After completing the job,
+//       software must delete the bsy file."
+//
+//  Two subsystems here qualify, and both must use *this* module rather than
+//  their own copy -- see issue #719 for what happens when the writer and the
+//  reader each carry a private implementation of a BSO convention:
+//
+//    * core/scanner_tossers/ftn_bso.js -- appends refs to flow files
+//    * core/binkp/bso_spool.js         -- rewrites them as entries are sent
+//
+//  Getting this right also buys interoperation with *external* mailers for
+//  free. binkd and friends implement the same spec under the same filenames,
+//  so a correct implementation interlocks with them without either side
+//  knowing about the other. Note that the pre-existing "enigma.bsy" flag in
+//  ftn_bso.js is NOT this: it is a non-FTS-5005 name in the outbound *root*,
+//  so no external mailer has reason to interpret it.
+//
+
+//
+//  Default age past which an unreleased lock is treated as orphaned.
+//
+//  FTS-5005.003 §5.1: "It is reasonable to ignore and delete bsy files with
+//  an age more than the maximum estimated time of session multiplied on 2."
+//  30 minutes is 6x our BinkP session timeout, which satisfies that with
+//  room to spare.
+//
+const DEFAULT_STALE_LOCK_MAX_AGE_MS = 30 * 60 * 1000;
+
+//
+//  How long a *writer* waits for a lock before giving up.
+//
+//  Contention is normally a sub-second flow file rewrite by a session that is
+//  finishing an entry. It can also be a whole session, which may run minutes
+//  -- and in that case deferring is the correct answer, not waiting: the spec
+//  prohibits the change outright while the lock is held.
+//
+const DEFAULT_ACQUIRE_TIMEOUT_MS = 5000;
+const ACQUIRE_RETRY_MS = 100;
+
+//  Distinguishes "the node is busy, try later" from a real failure, so callers
+//  can log it as a deferral rather than as corruption.
+const ReasonCodes = {
+    Busy: 'BSO_LOCK_BUSY',
+};
+
+//
+//  The ".bsy" path for a flow file, per §5.1's "named the same way as the flow
+//  file but with the extension '.bsy'".
+//
+//  This is deliberately derived from the flow file rather than rebuilt from an
+//  address: it cannot drift from whatever naming the caller actually used, and
+//  it lands in the same directory -- including a point's NNNNnnnn.pnt/
+//  subdirectory, where the point's lock belongs.
+//
+function bsyPathForFlowFile(flowFilePath) {
+    const ext = paths.extname(flowFilePath);
+    const bsyExt =
+        ext === ext.toUpperCase() && ext !== ext.toLowerCase() ? '.BSY' : '.bsy';
+    return `${flowFilePath.slice(0, flowFilePath.length - ext.length)}${bsyExt}`;
+}
+
+//
+//  The lock as it actually exists on disk, in whatever case it was written, or
+//  null when there is none.
+//
+//  FTS-5005.003 §2 asks software to handle both upper and lower case BSO
+//  filenames. An external mailer sharing this spool may have written the lock
+//  under the other spelling; an exclusive create on our own spelling would not
+//  collide with it and we would both believe we held it.
+//
+async function resolveExisting(bsyPath) {
+    const dir = paths.dirname(bsyPath);
+    const wanted = paths.basename(bsyPath).toLowerCase();
+
+    let names;
+    try {
+        names = await fsp.readdir(dir);
+    } catch (err) {
+        if ('ENOENT' !== err.code) {
+            throw err;
+        }
+        return null;
+    }
+
+    const actual = names.find(n => n.toLowerCase() === wanted);
+    return actual ? paths.join(dir, actual) : null;
+}
+
+//
+//  True when the lock at |bsyPath| was older than |staleMaxAgeMs| and has been
+//  removed -- or was already gone, since either way the slot is now free.
+//  False when it is still fresh, or when we could not confidently reap it.
+//
+async function reapIfStale(bsyPath, staleMaxAgeMs, log) {
+    let stat;
+    try {
+        stat = await fsp.stat(bsyPath);
+    } catch (err) {
+        return 'ENOENT' === err.code;
+    }
+
+    const ageMs = Date.now() - stat.mtimeMs;
+    if (ageMs <= staleMaxAgeMs) {
+        return false;
+    }
+
+    try {
+        await fsp.unlink(bsyPath);
+        log && log.info({ path: bsyPath, ageMs }, 'Reaped stale .bsy lock');
+        return true;
+    } catch (err) {
+        if ('ENOENT' === err.code) {
+            return true;
+        }
+        log &&
+            log.warn(
+                { path: bsyPath, error: err.message },
+                'Could not reap stale .bsy lock'
+            );
+        return false;
+    }
+}
+
+//
+//  Take the lock at |bsyPath|. Resolves true on success, false when it is held
+//  by someone else; rejects only on unexpected filesystem errors.
+//
+//  §5.1 warns specifically about this:
+//
+//      "The most common way to create a file in many languages (eg. ReWrite,
+//       fopen) also quietly overwrites an existing file, so there's a race
+//       condition between checking, creating and checking. Care must be taken
+//       to use the right function and/or the right options."
+//
+//  Hence 'wx' -- exclusive create -- and never a plain write.
+//
+async function acquire(bsyPath, options = {}) {
+    const staleMaxAgeMs = _staleMaxAgeMs(options);
+    const log = options.log;
+
+    await fsp.mkdir(paths.dirname(bsyPath), { recursive: true });
+
+    const tryCreate = async () => {
+        const fh = await fsp.open(bsyPath, 'wx');
+        await fh.writeFile(String(process.pid)); //  §5.1: "may contain one line of PID information"
+        await fh.close();
+    };
+
+    //  Someone else's spelling of the same lock counts as held.
+    const existing = await resolveExisting(bsyPath);
+    if (
+        existing &&
+        existing !== bsyPath &&
+        !(await reapIfStale(existing, staleMaxAgeMs, log))
+    ) {
+        return false;
+    }
+
+    try {
+        await tryCreate();
+        return true;
+    } catch (err) {
+        if ('EEXIST' !== err.code) {
+            throw err;
+        }
+    }
+
+    //  Present. Reap if it looks orphaned, then retry once.
+    if (!(await reapIfStale(bsyPath, staleMaxAgeMs, log))) {
+        return false;
+    }
+
+    try {
+        await tryCreate();
+        return true;
+    } catch (err) {
+        if ('EEXIST' === err.code) {
+            return false;
+        }
+        throw err;
+    }
+}
+
+//  Release the lock. Never throws: a lock we cannot remove is reaped later by
+//  age, and failing a completed job over it would be worse.
+async function release(bsyPath) {
+    await fsp.unlink(bsyPath).catch(() => {});
+}
+
+//
+//  Acquire with bounded retry, for callers that want to *do* something rather
+//  than poll. Resolves true if taken, false if still held when time ran out.
+//
+async function acquireWithRetry(bsyPath, options = {}) {
+    const timeoutMs = _finite(options.timeoutMs, DEFAULT_ACQUIRE_TIMEOUT_MS);
+    const deadline = Date.now() + timeoutMs;
+
+    for (;;) {
+        if (await acquire(bsyPath, options)) {
+            return true;
+        }
+
+        if (Date.now() >= deadline) {
+            return false;
+        }
+
+        await new Promise(r => setTimeout(r, ACQUIRE_RETRY_MS));
+    }
+}
+
+//
+//  Callback-style "do this while holding the flow file's lock", for ftn_bso.
+//
+//  |work| is called as work(done). The lock is released on every path,
+//  including a throw out of |work|.
+//
+//  Calls back Errors.General(..., ReasonCodes.Busy) when the lock could not be
+//  taken in time. That is a deferral, not corruption: the caller's refs were
+//  not written and the spec says they must not be.
+//
+function withFlowFileLock(flowFilePath, options, work, cb) {
+    if ('function' === typeof options) {
+        cb = work;
+        work = options;
+        options = {};
+    }
+
+    const bsyPath = bsyPathForFlowFile(flowFilePath);
+
+    acquireWithRetry(bsyPath, options).then(
+        got => {
+            if (!got) {
+                return cb(
+                    Errors.General(
+                        `Flow file ${paths.basename(flowFilePath)} is locked by another session`,
+                        ReasonCodes.Busy
+                    )
+                );
+            }
+
+            let finished = false;
+            const done = err => {
+                if (finished) {
+                    return; //  |work| called back twice; ignore the second
+                }
+                finished = true;
+                release(bsyPath).then(() => cb(err));
+            };
+
+            try {
+                work(done);
+            } catch (err) {
+                done(err);
+            }
+        },
+        err => cb(err)
+    );
+}
+
+function isBusyError(err) {
+    return !!err && ReasonCodes.Busy === err.reasonCode;
+}
+
+function _finite(value, fallback) {
+    return 'number' === typeof value && isFinite(value) && value >= 0 ? value : fallback;
+}
+
+function _staleMaxAgeMs(options) {
+    return _finite(options.staleMaxAgeMs, DEFAULT_STALE_LOCK_MAX_AGE_MS);
+}
+
+module.exports = {
+    DEFAULT_STALE_LOCK_MAX_AGE_MS,
+    DEFAULT_ACQUIRE_TIMEOUT_MS,
+    ReasonCodes,
+    bsyPathForFlowFile,
+    resolveExisting,
+    reapIfStale,
+    acquire,
+    acquireWithRetry,
+    release,
+    withFlowFileLock,
+    isBusyError,
+};

--- a/core/config_default.js
+++ b/core/config_default.js
@@ -1043,6 +1043,20 @@ module.exports = () => {
                 //  Actual sizes may be slightly larger when we must place a full
                 //  PKT contents *somewhere*
                 //
+                //
+                //  How long to wait for a flow file's FTS-5005 .bsy lock
+                //  before giving up and deferring the queue to a later pass.
+                //
+                //  A flow file must not be modified while its .bsy exists
+                //  (FTS-5005.003 §5.1), and that lock is held for the length of
+                //  a mail session -- by our own BinkP mailer and by external
+                //  ones such as binkd alike. Contention is normally momentary;
+                //  raise this on a busy hub with long sessions, where the
+                //  alternative is a "Flow file busy" warning and the outbound
+                //  waiting for the next export cycle.
+                //
+                flowLockTimeoutMs: 5000,
+
                 packetTargetByteSize: 512000, //  512k, before placing messages in a new pkt
                 bundleTargetByteSize: 2048000, //  2M, before creating another archive
                 packetMsgEncoding: 'cp437', //  default packet encoding. Override per node if desired.

--- a/core/scanner_tossers/ftn_bso.js
+++ b/core/scanner_tossers/ftn_bso.js
@@ -40,6 +40,7 @@ const {
     legacyOutboundDirName,
     validateOutboundConfig,
 } = require('../bso_util.js');
+const { withFlowFileLock, isBusyError } = require('../bso_lock.js');
 const autoAreaCreate = require('../auto_area_create.js');
 const areaInfoPack = require('../area_info_pack.js');
 const { AreaFixStatus, parseAreaFixReply } = require('../areafix_reply.js');
@@ -312,7 +313,30 @@ function FTNMessageScanTossModule() {
         return paths.join(basePath, pointDir, `${controlFileBaseName}.${ext}`);
     };
 
+    //
+    //  Append reference records to a BSO flow file.
+    //
+    //  |fileRefs| entries may be a plain path -- taking |directive| as their
+    //  disposition prefix, the long-standing behaviour -- or an object
+    //  { directive, path } carrying its own. A single call may therefore mix
+    //  dispositions, which matters because some pairings must be written
+    //  *together*: forwarding a file echo queues the payload with no prefix
+    //  ("send and keep", it lives in the file base) immediately followed by
+    //  its generated TIC with '^' ("delete after send"). FSC-0087 requires the
+    //  payload to precede its TIC, and adjacency only holds within one write,
+    //  since the exporter appends to these same files on its own schedule.
+    //
+    //  The whole append is done under the flow file's FTS-5005 .bsy lock. See
+    //  core/bso_lock.js for why that is mandatory rather than defensive, and
+    //  why it is the same lock BinkP sessions and external mailers take.
+    //
     this.flowFileAppendRefs = function (filePath, fileRefs, directive, destAddress, cb) {
+        const appendLines = fileRefs.reduce((content, ref) => {
+            const refDirective = _.isObject(ref) ? ref.directive || '' : directive;
+            const refPath = _.isObject(ref) ? ref.path : ref;
+            return content + `${refDirective}${refPath}\n`;
+        }, '');
+
         //
         //  We have to ensure the *directory* of |filePath| exists here esp.
         //  for cases such as point destinations where a subdir may be
@@ -320,24 +344,60 @@ function FTNMessageScanTossModule() {
         //
         const flowFileDir = paths.dirname(filePath);
         fse.mkdirs(flowFileDir, () => {
-            //  note not checking err; let's try appendFile
-            const appendLines = fileRefs.reduce((content, ref) => {
-                return content + `${directive}${ref}\n`;
-            }, '');
+            //  note not checking err; let's try to take the lock anyway
+            withFlowFileLock(
+                filePath,
+                {
+                    staleMaxAgeMs: _.get(
+                        Config(),
+                        'scannerTossers.ftn_bso.binkp.staleLockMaxAgeMs'
+                    ),
+                    timeoutMs: _.get(
+                        Config(),
+                        'scannerTossers.ftn_bso.flowLockTimeoutMs'
+                    ),
+                    log: Log,
+                },
+                done => {
+                    fs.appendFile(filePath, appendLines, done);
+                },
+                err => {
+                    if (err) {
+                        //
+                        //  A busy node is a deferral, not a failure: FTS-5005
+                        //  §5.1 prohibits touching a flow file while its .bsy
+                        //  exists, so *not* writing was the correct outcome.
+                        //  Say so distinctly -- the refs did not get queued and
+                        //  the caller may want to retry.
+                        //
+                        if (isBusyError(err)) {
+                            Log.warn(
+                                {
+                                    path: filePath,
+                                    refs: fileRefs.length,
+                                    address: destAddress
+                                        ? destAddress.toString()
+                                        : undefined,
+                                },
+                                'Flow file busy; outbound not queued this pass'
+                            );
+                        }
+                        return cb(err);
+                    }
 
-            fs.appendFile(filePath, appendLines, err => {
-                //  Successful append == new outbound is queued and ready to
-                //  ship. Emit so the native BinkP module can dial |destAddress|
-                //  immediately (crashmail) instead of waiting for the next
-                //  pull cycle. External mailers (binkd) are unaffected — they
-                //  poll the spool directly.
-                if (!err && destAddress) {
-                    Events.emit(Events.getSystemEvents().NewOutboundBSO, {
-                        address: destAddress,
-                    });
+                    //  Successful append == new outbound is queued and ready to
+                    //  ship. Emit so the native BinkP module can dial |destAddress|
+                    //  immediately (crashmail) instead of waiting for the next
+                    //  pull cycle. External mailers (binkd) are unaffected — they
+                    //  poll the spool directly.
+                    if (destAddress) {
+                        Events.emit(Events.getSystemEvents().NewOutboundBSO, {
+                            address: destAddress,
+                        });
+                    }
+                    return cb(null);
                 }
-                return cb(err);
-            });
+            );
         });
     };
 

--- a/docs/_docs/messageareas/binkp.md
+++ b/docs/_docs/messageareas/binkp.md
@@ -154,6 +154,28 @@ When ENiGMA½ acquires a node lock (`.bsy` file in the outbound directory), it e
 
 The default is 6× the internal session timeout (5 minutes), giving a generous safety margin without making post-crash recovery slow. If you ever raise the session timeout, raise this in proportion.
 
+The same `.bsy` files are honoured by external mailers such as Binkd, and by the ENiGMA½ *tosser* when it queues outbound — see [`flowLockTimeoutMs`](#flowlocktimeoutms) below.
+
+#### `flowLockTimeoutMs`
+
+> :information_source: This one lives at `scannerTossers.ftn_bso.flowLockTimeoutMs`, **not** under `binkp` — it governs the tosser (the writer), not the mailer.
+
+[FTS-5005.003](http://ftsc.org/docs/fts-5005.003) §5.1 requires that *any* software touching a BSO flow file first take that file's `.bsy` lock, and prohibits changes entirely while the lock is held:
+
+> A bsy is a main control file that must be used by any software dealing with flow files in BSO. […] Any software must check this file before doing any changes in flow files. If a bsy file exists all changes are prohibited in any corresponding flow files.
+
+That applies to ENiGMA½ queueing outbound just as much as to a mailer sending it. Because the lock is a standard, per-node `NNNNnnnn.bsy` in the node's own outbound directory, honouring it interlocks correctly with the **native BinkP mailer and external mailers alike** — Binkd takes the very same lock, so neither side needs to know about the other.
+
+`flowLockTimeoutMs` (default `5000`, i.e. 5 seconds) is how long the tosser waits for a busy node's lock before giving up. Contention is normally momentary — a session finishing an entry — but the lock is held for the length of a whole session, and during that time the spec says the flow file must not be modified.
+
+If the wait expires the outbound is **not** queued this pass, and you'll see:
+
+```
+Flow file busy; outbound not queued this pass
+```
+
+Nothing is lost or corrupted — the write simply did not happen, which is what the spec requires. Raise this on a busy hub with long sessions.
+
 #### `binkp.inboundTempMaxAgeMs`
 
 Inbound files are buffered in `tempDir` (defaults to the OS temp dir) under names like `binkp_in_*.dt`, then renamed into the inbound spool on successful receipt. Two layers protect against leaks if a peer drops mid-transfer:
@@ -278,6 +300,7 @@ Both sides decide this the same way, by counting the command frames sent and rec
 | `freq` | next inbound session | Immediately |
 | `crashmailDebounceMs` | next crashmail burst | Immediately |
 | `tempDir`, `staleLockMaxAgeMs` | next session | Immediately |
+| `flowLockTimeoutMs` (under `ftn_bso`) | next outbound queue | Immediately |
 | `ftn_bso` `paths` and `messageNetworks.ftn.networks` | next session or poll | Immediately |
 | `pullSchedule` | the pull timer | On reload — the timer is rebuilt |
 | `inbound.enabled`, `inbound.port`, `inbound.address`, `inbound.tls.*` | the listening socket | **Restart required** |

--- a/test/binkp_bso_spool.test.js
+++ b/test/binkp_bso_spool.test.js
@@ -1028,6 +1028,93 @@ describe('attachSpoolToSession', () => {
         });
     });
 
+    it("offers queued files even when the peer's M_EOB wins the race (#747)", done => {
+        //
+        //  An answering session resolves what it has for the caller
+        //  asynchronously, after M_ADR. If the caller's own M_EOB arrives
+        //  first -- which it routinely does, since the lookup touches the
+        //  filesystem -- the session must still offer what that lookup finds.
+        //
+        //  It did not. attachSpoolToSession used holdSend()/releaseSend(), and
+        //  |_sendHeld| is consulted in exactly one place: _enterTransfer()'s
+        //  initial _sendNext(). It does not gate _sendNext() itself, and
+        //  _onEob() calls _sendNext() directly once _remoteEOB is set. That
+        //  found an empty queue, saw the answering-side "wait for the remote's
+        //  M_EOB" condition already satisfied, and sent our M_EOB -- after
+        //  which releaseSend()'s |!_localEOBSent| guard made it a no-op and the
+        //  files were never offered.
+        //
+        //  |_eobHold| is tested inside _sendNext() where M_EOB would go out, so
+        //  it holds however _sendNext() was reached. The delay below just makes
+        //  the race deterministic; without the fix this fails every time.
+        //
+        //  Not TIC-specific -- it affects any answering session with mail
+        //  queued for the caller -- but it matters most for file echoes,
+        //  because a downlink polls its hub rather than being dialled.
+        //
+        //  Its own payload, not the shared |refFile|: a sibling test queues
+        //  that one with '^' (delete after send), so reusing it here makes this
+        //  test pass alone and fail in the suite.
+        const ownFile = path.join(tmpDir, 'eob_race.pkt');
+        const flowPath = path.join(outboundDir(tmpDir), '00020002.flo'); // net=2,node=2
+        fsp.writeFile(ownFile, 'EOB_RACE_DATA').then(() => {
+            fsp.writeFile(flowPath, `^${ownFile}\n`).then(() => {
+                //  Lose the race on purpose: make the spool lookup slower than the
+                //  client's M_EOB.
+                const slowSpool = Object.create(spool);
+                slowSpool.getOutboundFilesForNode = async addr => {
+                    await new Promise(r => setTimeout(r, 120));
+                    return spool.getOutboundFilesForNode(addr);
+                };
+
+                const server = net.createServer(serverSocket => {
+                    const serverSess = new BinkpSession(serverSocket, {
+                        role: 'answering',
+                        addresses: ['1:1/1@testnet'],
+                        getPassword: () => null,
+                        tempDir: os.tmpdir(),
+                    });
+                    attachSpoolToSession(serverSess, slowSpool, null).then(() => {
+                        serverSess.start();
+                    });
+                });
+
+                server.listen(0, '127.0.0.1', () => {
+                    const { port } = server.address();
+                    const clientSocket = net.createConnection(port, '127.0.0.1');
+                    const clientSess = new BinkpSession(clientSocket, {
+                        role: 'originating',
+                        addresses: ['1:2/2@testnet'],
+                        getPassword: () => null,
+                        tempDir: os.tmpdir(),
+                    });
+
+                    let received = false;
+                    clientSess.on('file-received', (name, size, ts, tmpPath) => {
+                        received = true;
+                        fsp.unlink(tmpPath).catch(() => {});
+                    });
+
+                    clientSess.on('session-end', () => {
+                        server.close();
+                        try {
+                            assert.ok(
+                                received,
+                                'the caller must be offered its mail even though its M_EOB arrived first'
+                            );
+                            done();
+                        } catch (e) {
+                            done(e);
+                        }
+                    });
+
+                    clientSess.on('error', done);
+                    clientSess.start();
+                });
+            });
+        });
+    });
+
     it('holdSend/releaseSend gates sending until async spool load completes', done => {
         const server = net.createServer(serverSocket => {
             const serverSess = new BinkpSession(serverSocket, {

--- a/test/binkp_ftn_bso_integration.test.js
+++ b/test/binkp_ftn_bso_integration.test.js
@@ -1489,4 +1489,216 @@ describe('ftn_bso ↔ BinkP integration', function () {
                 .catch(done);
         });
     });
+
+    //  ── flow file .bsy interlock (FTS-5005.003 §5.1) ─────────────────────────
+    //
+    //  ftn_bso appends refs to flow files; BsoSpool rewrites those same files as
+    //  entries are sent (_applyFlowDisposition reads the whole file, marks a
+    //  line '~' and writes it back). The writer used to take no lock, so an
+    //  append landing between that read and its write was silently discarded --
+    //  the queued file simply never shipped.
+    //
+    //  The race itself is timing-dependent and would make a flaky test. What is
+    //  pinned here is the invariant that removes it, which the spec states
+    //  directly: "If a bsy file exists all changes are prohibited in any
+    //  corresponding flow files."
+
+    describe('ftn_bso — flow file .bsy interlock', () => {
+        const bsoLock = require('../core/bso_lock.js');
+        let modConfig;
+
+        beforeEach(() => {
+            //  The production default waits 5s for a busy node, which is longer
+            //  than mocha's per-test budget. The behaviour under test is the
+            //  refusal, not the patience.
+            const cfg = makeConfig();
+            cfg.scannerTossers.ftn_bso.flowLockTimeoutMs = 200;
+            modConfig = configModule._pushTestConfig(cfg);
+        });
+
+        afterEach(() => {
+            configModule._popTestConfig(modConfig);
+        });
+
+        function newMod() {
+            const { getModule } = require('../core/scanner_tossers/ftn_bso.js');
+            return new getModule();
+        }
+
+        it('refuses to touch a flow file while its .bsy is held', done => {
+            const mod = newMod();
+            const flowPath = path.join(tmpDir, 'outbound', '00da0100.flo');
+            const bsyPath = bsoLock.bsyPathForFlowFile(flowPath);
+
+            fsp.writeFile(flowPath, '^/spool/first.pkt\n')
+                .then(() => fsp.writeFile(bsyPath, '4242')) //  a session holds it
+                .then(() => {
+                    mod.flowFileAppendRefs(
+                        flowPath,
+                        [{ directive: '^', path: '/spool/second.pkt' }],
+                        undefined,
+                        null,
+                        err => {
+                            assert.ok(err, 'a locked node must surface an error');
+                            assert.ok(
+                                bsoLock.isBusyError(err),
+                                'and it must be reported as busy, not as corruption'
+                            );
+                            fsp.readFile(flowPath, 'utf8')
+                                .then(content => {
+                                    assert.equal(
+                                        content,
+                                        '^/spool/first.pkt\n',
+                                        'the flow file must be untouched'
+                                    );
+                                    return fsp.unlink(bsyPath);
+                                })
+                                .then(() => done())
+                                .catch(done);
+                        }
+                    );
+                })
+                .catch(done);
+        });
+
+        it('appends once the holder releases, losing nothing', done => {
+            const mod = newMod();
+            const flowPath = path.join(tmpDir, 'outbound', '00da0101.flo');
+            const bsyPath = bsoLock.bsyPathForFlowFile(flowPath);
+
+            fsp.writeFile(flowPath, '^/spool/first.pkt\n')
+                .then(() => fsp.writeFile(bsyPath, '4242'))
+                .then(() => {
+                    //  Release while the writer is still retrying.
+                    setTimeout(() => fsp.unlink(bsyPath).catch(() => {}), 150);
+
+                    mod.flowFileAppendRefs(
+                        flowPath,
+                        [{ directive: '^', path: '/spool/second.pkt' }],
+                        undefined,
+                        null,
+                        err => {
+                            if (err) return done(err);
+                            fsp.readFile(flowPath, 'utf8')
+                                .then(content => {
+                                    assert.equal(
+                                        content,
+                                        '^/spool/first.pkt\n^/spool/second.pkt\n'
+                                    );
+                                    done();
+                                })
+                                .catch(done);
+                        }
+                    );
+                })
+                .catch(done);
+        });
+
+        it('leaves no .bsy behind after a successful append', done => {
+            const mod = newMod();
+            const flowPath = path.join(tmpDir, 'outbound', '00da0102.flo');
+
+            mod.flowFileAppendRefs(flowPath, ['/spool/x.pkt'], '^', null, err => {
+                if (err) return done(err);
+                assert.ok(
+                    !require('fs').existsSync(bsoLock.bsyPathForFlowFile(flowPath)),
+                    'the lock must be released'
+                );
+                done();
+            });
+        });
+
+        it('takes the same lock a BinkP session would', async () => {
+            //  If these two disagreed the interlock would be decorative. The
+            //  writer derives the lock from the flow file (§5.1); the spool
+            //  derives it from the address.
+            const { BsoSpool } = require('../core/binkp/bso_spool.js');
+            const Address = require('../core/ftn_address.js');
+
+            const spool = new BsoSpool({
+                paths: { outbound: tmpDir },
+                networks: { testnet: { localAddress: '1:218/700', defaultZone: 1 } },
+            });
+
+            const mod = newMod();
+
+            for (const addrStr of ['1:218/750', '1:218/750.4']) {
+                const addr = Address.fromString(addrStr);
+                const flowPath = mod.getOutgoingFlowFileName(
+                    mod.getOutgoingEchoMailPacketDir('testnet', addr),
+                    addr,
+                    'ref',
+                    'crash',
+                    'lower'
+                );
+                assert.equal(
+                    bsoLock.bsyPathForFlowFile(flowPath),
+                    spool._bsyPath(addr),
+                    `writer and spool must agree on the lock for ${addrStr}`
+                );
+            }
+        });
+    });
+
+    //  ── per-ref flow file directives ─────────────────────────────────────────
+    //
+    //  Forwarding a file echo queues two refs that must travel together and in
+    //  order: the payload with no prefix ("send and keep" -- it lives in the
+    //  file base and is not ours to delete) immediately followed by its
+    //  generated TIC with '^'. FSC-0087 requires the payload to precede its
+    //  TIC, and adjacency only holds within a single write.
+
+    describe('ftn_bso — per-ref flow file directives', () => {
+        let modConfig;
+
+        beforeEach(() => {
+            modConfig = configModule._pushTestConfig(makeConfig());
+        });
+
+        afterEach(() => {
+            configModule._popTestConfig(modConfig);
+        });
+
+        function appendRefs(name, refs, directive) {
+            const { getModule } = require('../core/scanner_tossers/ftn_bso.js');
+            const mod = new getModule();
+            const flowPath = path.join(tmpDir, 'outbound', name);
+            return new Promise((resolve, reject) => {
+                mod.flowFileAppendRefs(flowPath, refs, directive, null, err => {
+                    if (err) return reject(err);
+                    fsp.readFile(flowPath, 'utf8').then(resolve, reject);
+                });
+            });
+        }
+
+        it('writes a mixed-disposition pair in order, in one append', async () => {
+            const content = await appendRefs('00da0200.flo', [
+                { directive: '', path: '/files/fsxnet/NODELIST.Z21' },
+                { directive: '^', path: '/outbound/a1b2c3d4.tic' },
+            ]);
+
+            assert.equal(
+                content,
+                '/files/fsxnet/NODELIST.Z21\n^/outbound/a1b2c3d4.tic\n',
+                'payload first with no prefix, then its TIC with ^'
+            );
+        });
+
+        it('treats a missing per-ref directive as no prefix', async () => {
+            const content = await appendRefs('00da0201.flo', [
+                { path: '/files/keep-me.zip' },
+            ]);
+            assert.equal(content, '/files/keep-me.zip\n');
+        });
+
+        it('still honours the shared directive for plain string refs', async () => {
+            //  The long-standing mail path passes strings plus one directive.
+            const content = await appendRefs(
+                '00da0202.flo',
+                ['/outbound/a.pkt', '/outbound/b.pkt'],
+                '^'
+            );
+            assert.equal(content, '^/outbound/a.pkt\n^/outbound/b.pkt\n');
+        });
+    });
 }); // describe('ftn_bso ↔ BinkP integration')

--- a/test/bso_lock.test.js
+++ b/test/bso_lock.test.js
@@ -1,0 +1,267 @@
+'use strict';
+
+//
+//  Coverage for the FTS-5005.003 §5.1 ".bsy" flow file lock.
+//
+//  Background: core/scanner_tossers/ftn_bso.js appends reference records to BSO
+//  flow files, and core/binkp/bso_spool.js rewrites those same files as entries
+//  are sent -- _applyFlowDisposition reads the whole file, marks a line '~' and
+//  writes it back. The writer took no lock, so an append landing between that
+//  read and its write was *silently discarded*: no error, no log, the queued
+//  file simply never shipped and its companion .tic orphaned in the outbound.
+//
+//  §5.1 puts the requirement on software, not on mailers:
+//
+//      "A bsy is a main control file that must be used by any software dealing
+//       with flow files in BSO. [...] Any software must check this file before
+//       doing any changes in flow files. If a bsy file exists all changes are
+//       prohibited in any corresponding flow files."
+//
+//  Because NNNNnnnn.bsy is the standard name, honouring it also interlocks with
+//  external mailers (binkd) for free -- they take the same lock. The older
+//  "enigma.bsy" flag is a non-FTS-5005 name in the outbound *root* and cannot
+//  serve this purpose.
+//
+
+const { strict: assert } = require('assert');
+const fs = require('fs');
+const fsp = require('fs/promises');
+const os = require('os');
+const paths = require('path');
+
+const bsoLock = require('../core/bso_lock.js');
+
+describe('BSO .bsy flow file lock', function () {
+    let tmpDir;
+    let flowPath;
+    let bsyPath;
+
+    beforeEach(async () => {
+        tmpDir = await fsp.mkdtemp(paths.join(os.tmpdir(), 'enigma_bsolock_'));
+        flowPath = paths.join(tmpDir, '00da02bc.flo');
+        bsyPath = paths.join(tmpDir, '00da02bc.bsy');
+        await fsp.writeFile(flowPath, '^/spool/existing.pkt\n');
+    });
+
+    afterEach(async () => {
+        await fsp.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    describe('bsyPathForFlowFile', () => {
+        it('names the lock after the flow file, per §5.1', () => {
+            assert.equal(bsoLock.bsyPathForFlowFile(flowPath), bsyPath);
+        });
+
+        it('handles every flow and direct-attach extension', () => {
+            ['flo', 'clo', 'hlo', 'dlo', 'ilo', 'out', 'cut', 'hut'].forEach(ext => {
+                assert.equal(
+                    bsoLock.bsyPathForFlowFile(paths.join(tmpDir, `00da02bc.${ext}`)),
+                    bsyPath
+                );
+            });
+        });
+
+        it("keeps a point's lock inside its .pnt subdirectory", () => {
+            //  FTS-5005.003 §2: a point's files live under NNNNnnnn.pnt/, and
+            //  deriving from the flow file keeps the lock beside them rather
+            //  than in the boss node's directory.
+            const pointFlow = paths.join(tmpDir, '00da02bc.pnt', '00000004.flo');
+            assert.equal(
+                bsoLock.bsyPathForFlowFile(pointFlow),
+                paths.join(tmpDir, '00da02bc.pnt', '00000004.bsy')
+            );
+        });
+
+        it('matches the case of the flow file extension', () => {
+            assert.equal(
+                bsoLock.bsyPathForFlowFile(paths.join(tmpDir, '00DA02BC.FLO')),
+                paths.join(tmpDir, '00DA02BC.BSY')
+            );
+        });
+    });
+
+    describe('acquire / release', () => {
+        it('creates the lock and reports success', async () => {
+            assert.ok(await bsoLock.acquire(bsyPath));
+            assert.ok(fs.existsSync(bsyPath));
+        });
+
+        it('records our pid, as §5.1 permits', async () => {
+            await bsoLock.acquire(bsyPath);
+            assert.equal(
+                (await fsp.readFile(bsyPath, 'utf8')).trim(),
+                String(process.pid)
+            );
+        });
+
+        it('refuses a lock already held, and does not disturb it', async () => {
+            await fsp.writeFile(bsyPath, '4242');
+            assert.equal(await bsoLock.acquire(bsyPath), false);
+            //  §5.1 warns that a careless create "quietly overwrites an
+            //  existing file" -- the holder's pid must survive.
+            assert.equal((await fsp.readFile(bsyPath, 'utf8')).trim(), '4242');
+        });
+
+        it("detects another mailer's lock written in a different case", async () => {
+            //  FTS-5005.003 §2 asks software to handle both cases. An exclusive
+            //  create on our own spelling would not collide, and both sides
+            //  would believe they held the lock.
+            await fsp.writeFile(paths.join(tmpDir, '00DA02BC.BSY'), '4242');
+            assert.equal(await bsoLock.acquire(bsyPath), false);
+        });
+
+        it('releases, allowing a subsequent acquire', async () => {
+            await bsoLock.acquire(bsyPath);
+            await bsoLock.release(bsyPath);
+            assert.ok(!fs.existsSync(bsyPath));
+            assert.ok(await bsoLock.acquire(bsyPath));
+        });
+
+        it('releases idempotently when there is no lock', async () => {
+            await bsoLock.release(bsyPath); //  must not throw
+        });
+
+        it('creates the lock directory when it does not exist yet', async () => {
+            const pointBsy = paths.join(tmpDir, '00da02bc.pnt', '00000004.bsy');
+            assert.ok(await bsoLock.acquire(pointBsy));
+            assert.ok(fs.existsSync(pointBsy));
+        });
+    });
+
+    describe('stale lock reaping', () => {
+        it('reaps a lock older than the window and takes it', async () => {
+            await fsp.writeFile(bsyPath, '4242');
+            const old = new Date(Date.now() - 60 * 60 * 1000);
+            await fsp.utimes(bsyPath, old, old);
+
+            assert.ok(await bsoLock.acquire(bsyPath, { staleMaxAgeMs: 30 * 60 * 1000 }));
+            assert.equal(
+                (await fsp.readFile(bsyPath, 'utf8')).trim(),
+                String(process.pid)
+            );
+        });
+
+        it('leaves a fresh lock alone', async () => {
+            await fsp.writeFile(bsyPath, '4242');
+            assert.equal(
+                await bsoLock.acquire(bsyPath, { staleMaxAgeMs: 30 * 60 * 1000 }),
+                false
+            );
+            assert.equal((await fsp.readFile(bsyPath, 'utf8')).trim(), '4242');
+        });
+    });
+
+    describe('withFlowFileLock', () => {
+        it('runs the work holding the lock, and releases afterwards', done => {
+            let heldDuringWork = false;
+            bsoLock.withFlowFileLock(
+                flowPath,
+                work => {
+                    heldDuringWork = fs.existsSync(bsyPath);
+                    work(null);
+                },
+                err => {
+                    assert.ifError(err);
+                    assert.ok(heldDuringWork, 'lock must be held while work runs');
+                    assert.ok(!fs.existsSync(bsyPath), 'lock must be released');
+                    done();
+                }
+            );
+        });
+
+        it('releases the lock when the work reports an error', done => {
+            bsoLock.withFlowFileLock(
+                flowPath,
+                work => work(new Error('nope')),
+                err => {
+                    assert.equal(err.message, 'nope');
+                    assert.ok(!fs.existsSync(bsyPath));
+                    done();
+                }
+            );
+        });
+
+        it('releases the lock when the work throws', done => {
+            bsoLock.withFlowFileLock(
+                flowPath,
+                () => {
+                    throw new Error('boom');
+                },
+                err => {
+                    assert.equal(err.message, 'boom');
+                    assert.ok(!fs.existsSync(bsyPath), 'a throw must not leak the lock');
+                    done();
+                }
+            );
+        });
+
+        it('reports Busy, and never runs the work, when the node is locked', done => {
+            fs.writeFileSync(bsyPath, '4242');
+            let ran = false;
+            bsoLock.withFlowFileLock(
+                flowPath,
+                { timeoutMs: 150 },
+                work => {
+                    ran = true;
+                    work(null);
+                },
+                err => {
+                    assert.ok(err, 'a held lock must surface an error');
+                    assert.ok(bsoLock.isBusyError(err), 'and it must be distinguishable');
+                    assert.ok(!ran, 'work must not run while another party holds it');
+                    //  The holder's lock must survive our failed attempt.
+                    assert.equal(fs.readFileSync(bsyPath, 'utf8').trim(), '4242');
+                    done();
+                }
+            );
+        });
+
+        it('waits out a short-lived holder rather than failing', done => {
+            //  The common case is not a whole session but a sub-second flow
+            //  file rewrite by a session finishing an entry.
+            fs.writeFileSync(bsyPath, '4242');
+            setTimeout(() => fs.unlinkSync(bsyPath), 120);
+
+            bsoLock.withFlowFileLock(
+                flowPath,
+                { timeoutMs: 3000 },
+                work => work(null),
+                err => {
+                    assert.ifError(err);
+                    done();
+                }
+            );
+        });
+
+        it('serializes concurrent writers', done => {
+            //  Two appenders racing on one flow file must not interleave.
+            let active = 0;
+            let maxActive = 0;
+            let completed = 0;
+
+            const one = () =>
+                bsoLock.withFlowFileLock(
+                    flowPath,
+                    { timeoutMs: 3000 },
+                    work => {
+                        active++;
+                        maxActive = Math.max(maxActive, active);
+                        setTimeout(() => {
+                            active--;
+                            work(null);
+                        }, 30);
+                    },
+                    err => {
+                        assert.ifError(err);
+                        if (++completed === 2) {
+                            assert.equal(maxActive, 1, 'only one writer at a time');
+                            done();
+                        }
+                    }
+                );
+
+            one();
+            one();
+        });
+    });
+});


### PR DESCRIPTION
Three related outbound-spool defects, all of which lose mail **today**,
independent of any feature. Split out from the TIC forwarding work in #743
(which is stacked on this branch) because they stand on their own.

## 1. Nothing took the `.bsy` lock before modifying a flow file

`flowFileAppendRefs()` appended reference records to BSO flow files without
taking any lock, while `core/binkp/bso_spool.js` rewrites those same files as
entries are sent — `_applyFlowDisposition()` reads the whole file, marks a line
`~`, and writes it back. An append landing between that read and its write was
**silently discarded**. No error, no log: the queued file simply never shipped,
and with nothing referencing it, its packet sat in the outbound forever.

[FTS-5005.003](http://ftsc.org/docs/fts-5005.003) §5.1 puts the requirement on
*software*, not on mailers:

> A bsy is a main control file that must be used by any software dealing with
> flow files in BSO. […] If a bsy file exists all changes are prohibited in any
> corresponding flow files.

The tosser queueing outbound is exactly that. Both BinkP session paths already
took the per-node lock, so the writer was the only unprotected party.

Because `NNNNnnnn.bsy` is the standard name, honouring it interlocks with
**external mailers** for free — Binkd takes the same lock, so neither side needs
to know about the other. The protocol now lives in one place (`core/bso_lock.js`)
and is shared by the writer and the mailer instead of being reimplemented on
each side; see #719 for what happens when those two drift apart.

> [!note]
> The pre-existing `enigma.bsy` flag is **not** this, and may protect nothing.
> It is a non-FTS-5005 name in the outbound *root*, and nothing in the tree
> reads it — its comment claims it signals external mailers, but Binkd has no
> reason to interpret that name. Unverified against Binkd's actual behaviour;
> flagging it here rather than filing it, since this is the right audience.

## 2. A session shipping several files marked only one of them sent

`_applyFlowDisposition()` is a whole-file read-modify-write and a session runs
one per file, **concurrently**. Each read the flow file with every line still
unmarked, marked its own, and wrote its own copy back — last writer wins, and
every other line silently lost its `~`.

For mail the symptom is mild: those entries carry `^`, so the file is gone by
the next pass and the reference merely dangles. For a forwarded file echo —
where the payload stays in the file base and must not be deleted — it looked
unsent and went out **again on every subsequent session**. Found by running two
live instances against each other; confirmed by reading the flow file after a
real session and then asking the spool what it would send next.

The per-node `.bsy` cannot help here: the session holds it for its whole
duration, so both rewrites are inside it. Rewrites are now serialised per flow
file.

## 3. Answering sessions never sent queued mail back (#747)

Reported and diagnosed by @jriethoven in #747 — the analysis there is correct
and this is that fix.

`attachSpoolToSession` gated its asynchronous spool lookup with
`holdSend()`/`releaseSend()`. Those are the wrong pair: `_sendHeld` is consulted
in exactly one place — `_enterTransfer()`'s initial `_sendNext()` — and does not
gate `_sendNext()` itself. The caller's own `M_EOB` reaches `_sendNext()` by
another route (`_onEob()` sets `_remoteEOB` and calls it directly), which
routinely beats a lookup that touches the filesystem. `_sendNext()` then finds
an empty queue, sees the answering-side wait condition already satisfied, and
sends our `M_EOB` — after which `releaseSend()`'s `!_localEOBSent` guard makes
it a no-op.

`_eobHold` is tested inside `_sendNext()` where `M_EOB` would go out, so it
holds however `_sendNext()` was reached. The FREQ resolver already uses it for
the same reason.

## Also here

`flowFileAppendRefs()` gains **per-ref directives**, so one call can mix
dispositions and write them in a single append. Plain strings plus a shared
directive behave exactly as before. This is needed by #743, where a payload is
queued with no prefix ("send and keep" — it lives in the file base) and must
immediately precede its generated TIC with `^`: FSC-0087 requires the payload to
go first, and adjacency only holds within one write.

New: `scannerTossers.ftn_bso.flowLockTimeoutMs` (default 5s) bounds how long the
tosser waits for a busy node's lock. A refused append is reported as a
distinguishable *busy* condition rather than a failure — not writing is what the
spec requires, and the next export cycle picks it up.

## Testing

- 19 new unit tests for the lock protocol, plus integration coverage asserting
  the writer and the spool resolve the same lock path for a node **and** a point.
- The concurrent-disposition and `M_EOB`-race tests were each verified to fail
  with the fix reverted.
- Full suite green (1849 passing). Verified end to end between two live
  instances over real BinkP.

## Upgrade notes

No action required; `flowLockTimeoutMs` has a default. Worth knowing if you run
an external mailer against the same spool: ENiGMA now *waits* on a lock your
mailer holds, so a **stale `.bsy`** left by a mailer that crashed mid-session
will hold up queueing for that node until it is reaped by age
(`binkp.staleLockMaxAgeMs`, 30 min default). If one node's outbound sits still,
check its outbound directory for an orphaned `.bsy`.

Closes #747

🤖 Generated with [Claude Code](https://claude.com/claude-code)