### PR TITLE
fix(binkp): finish an inbound file on its declared size, not on a frame binkd never sends

### DIFF
--- a/core/binkp/session.js
+++ b/core/binkp/session.js
@@ -1087,8 +1087,16 @@ class BinkpSession extends EventEmitter {
     //  comes back on every poll from then on with nothing to show why.
     //
     _onInflateError(cr, err) {
-        if (this._currentRecv !== cr) {
-            return; //  already torn down
+        //  Settled means acknowledged, postponed or already torn down --
+        //  there is nothing left to answer for. What this must NOT do is
+        //  bail because |cr| is no longer the current receive: decompression
+        //  is asynchronous, so a batch moves on to the next file long before
+        //  a failure on this one surfaces, and returning here would leave the
+        //  sender waiting on an M_GOT that is never coming. Nor may it bail
+        //  on _finalizing -- a corrupt stream raises its error during
+        //  inflate.end(), which is exactly when the NZ recovery is needed.
+        if (cr._settled) {
+            return;
         }
 
         Log.warn(
@@ -1119,6 +1127,7 @@ class BinkpSession extends EventEmitter {
 
     //  Drop a partial receive and everything holding on to it.
     _abandonReceive(cr) {
+        cr._settled = true;
         for (const key of ['inflate', 'writeStream']) {
             const stream = cr[key];
             if (!stream) continue;
@@ -1127,7 +1136,12 @@ class BinkpSession extends EventEmitter {
             stream.destroy();
             cr[key] = null;
         }
-        this._currentRecv = null;
+        //  Only if it is still ours to clear. Tearing one receive down says
+        //  nothing about whichever file the batch has moved on to, and
+        //  clearing that one strands every frame still arriving for it.
+        if (this._currentRecv === cr) {
+            this._currentRecv = null;
+        }
         this._inboundTempPaths.delete(cr.tempPath);
         fsp.unlink(cr.tempPath).catch(err => {
             if ('ENOENT' !== err.code) {
@@ -1153,6 +1167,7 @@ class BinkpSession extends EventEmitter {
         //  tracking entry so _destroy() doesn't unlink it from under
         //  the consumer.
         const handOff = () => {
+            cr._settled = true;
             this._inboundTempPaths.delete(cr.tempPath);
             this._sendCmd(Commands.M_GOT, `${cr.name} ${cr.size} ${cr.timestamp}`);
             this.emit('file-received', cr.name, cr.size, cr.timestamp, cr.tempPath);

--- a/core/binkp/session.js
+++ b/core/binkp/session.js
@@ -953,22 +953,22 @@ class BinkpSession extends EventEmitter {
         if (cr.bytesReceived >= cr.size) {
             return this._finalizeReceive(cr);
         }
-        this._abandonShortReceive(cr);
+        this._postponeReceive(
+            cr,
+            '[BinkP] Inbound file ended short; leaving it with the sender'
+        );
     }
 
     //
-    //  A file the sender walked away from mid-transfer. Silence would strand
-    //  it: the sender is waiting on an M_GOT that is never coming and will
+    //  Give up on an inbound file without claiming it. Silence would strand
+    //  the sender: it is waiting on an M_GOT that is never coming and will
     //  sit there to its own timeout. M_SKIP is the FTS-1026 answer -- a
     //  non-destructive postpone that leaves the file with the sender for
     //  another session and lets this batch finish -- and is what
     //  _onInflateError already does when it gives up on a file.
     //
-    _abandonShortReceive(cr) {
-        Log.warn(
-            { name: cr.name, got: cr.bytesReceived, want: cr.size },
-            '[BinkP] Inbound file ended short; leaving it with the sender'
-        );
+    _postponeReceive(cr, why) {
+        Log.warn({ name: cr.name, got: cr.bytesReceived, want: cr.size }, why);
         this._abandonReceive(cr);
         this._sendCmd(Commands.M_SKIP, `${cr.name} ${cr.size} ${cr.timestamp}`);
         this._checkDone();
@@ -1129,6 +1129,17 @@ class BinkpSession extends EventEmitter {
         //  premature _checkDone would close the session before M_GOT is sent
         //  and the client would wait forever.
 
+        //  File handed off to the listener; ownership of the temp file
+        //  passes to whatever moves it into the inbound spool. Drop our
+        //  tracking entry so _destroy() doesn't unlink it from under
+        //  the consumer.
+        const handOff = () => {
+            this._inboundTempPaths.delete(cr.tempPath);
+            this._sendCmd(Commands.M_GOT, `${cr.name} ${cr.size} ${cr.timestamp}`);
+            this.emit('file-received', cr.name, cr.size, cr.timestamp, cr.tempPath);
+            this._checkDone();
+        };
+
         const finish = () => {
             if (this._currentRecv === cr) {
                 this._currentRecv = null;
@@ -1138,18 +1149,40 @@ class BinkpSession extends EventEmitter {
             //  copy and let it apply its disposition, so stay quiet and let
             //  it offer the file again next session.
             if (cr.bytesReceived < cr.size) {
-                this._abandonShortReceive(cr);
+                this._postponeReceive(
+                    cr,
+                    '[BinkP] Inbound file ended short; leaving it with the sender'
+                );
                 return;
             }
 
-            //  File handed off to the listener; ownership of the temp file
-            //  passes to whatever moves it into the inbound spool. Drop our
-            //  tracking entry so _destroy() doesn't unlink it from under
-            //  the consumer.
-            this._inboundTempPaths.delete(cr.tempPath);
-            this._sendCmd(Commands.M_GOT, `${cr.name} ${cr.size} ${cr.timestamp}`);
-            this.emit('file-received', cr.name, cr.size, cr.timestamp, cr.tempPath);
-            this._checkDone();
+            //  Longer than announced. The clear path never gets here -- it
+            //  caps each chunk against the declared size -- but a compressed
+            //  stream is only measurable once decompressed, by which point
+            //  the surplus is already on disk. Cut it back so both paths
+            //  hand on exactly the file the sender described. (binkd instead
+            //  treats a surplus as fatal and drops the session.)
+            if (cr.bytesReceived > cr.size) {
+                Log.warn(
+                    { name: cr.name, got: cr.bytesReceived, want: cr.size },
+                    '[BinkP] Inbound file longer than announced; truncating'
+                );
+                return fsp
+                    .truncate(cr.tempPath, cr.size)
+                    .then(handOff)
+                    .catch(err => {
+                        Log.warn(
+                            { name: cr.name, error: err.message },
+                            '[BinkP] Could not truncate oversized inbound file'
+                        );
+                        this._postponeReceive(
+                            cr,
+                            '[BinkP] Oversized inbound file left with the sender'
+                        );
+                    });
+            }
+
+            handOff();
         };
 
         if (cr.inflate) {

--- a/core/binkp/session.js
+++ b/core/binkp/session.js
@@ -911,6 +911,7 @@ class BinkpSession extends EventEmitter {
     //
     _beginReceive({ name, size, timestamp, useGZ }) {
         this._pendingOffsetReq = null;
+        this._closeOutstandingReceive();
 
         const tempPath = path.join(
             this._opts.tempDir || os.tmpdir(),
@@ -933,6 +934,44 @@ class BinkpSession extends EventEmitter {
         //  handler uses this to call holdEOB() before the async file write
         //  completes — earlier than the 'file-received' event.
         this.emit('incoming-file', name, size, timestamp);
+    }
+
+    //
+    //  FTS-1026: "Until the next M_FILE command is received, all data frames
+    //  must carry data from this file". So an M_FILE -- or an M_EOB -- is the
+    //  sender telling us the previous file is over, whether or not it also
+    //  sent a zero-length data frame. binkd never sends one.
+    //
+    _closeOutstandingReceive() {
+        const cr = this._currentRecv;
+        if (!cr || cr._finalizing) return;
+        if (cr.inflate) {
+            //  Decompression is async, so the byte count is not final yet;
+            //  ending the inflate stream settles it and finish() checks.
+            return this._finalizeReceive(cr);
+        }
+        if (cr.bytesReceived >= cr.size) {
+            return this._finalizeReceive(cr);
+        }
+        this._abandonShortReceive(cr);
+    }
+
+    //
+    //  A file the sender walked away from mid-transfer. Silence would strand
+    //  it: the sender is waiting on an M_GOT that is never coming and will
+    //  sit there to its own timeout. M_SKIP is the FTS-1026 answer -- a
+    //  non-destructive postpone that leaves the file with the sender for
+    //  another session and lets this batch finish -- and is what
+    //  _onInflateError already does when it gives up on a file.
+    //
+    _abandonShortReceive(cr) {
+        Log.warn(
+            { name: cr.name, got: cr.bytesReceived, want: cr.size },
+            '[BinkP] Inbound file ended short; leaving it with the sender'
+        );
+        this._abandonReceive(cr);
+        this._sendCmd(Commands.M_SKIP, `${cr.name} ${cr.size} ${cr.timestamp}`);
+        this._checkDone();
     }
 
     _onDataFrame(data) {
@@ -983,16 +1022,29 @@ class BinkpSession extends EventEmitter {
                 cr.inflate = zlib.createUnzip();
                 cr.inflate.on('error', err => this._onInflateError(cr, err));
                 cr.inflate.pipe(cr.writeStream);
+
+                //  Count what comes *out* of the decompressor, so the GZ path
+                //  finishes on the declared size the same way the clear one
+                //  does. |cr| is captured rather than read back off the
+                //  session: zlib is async, so by the time these land the
+                //  batch may already have moved on to another file.
+                cr.inflate.on('data', chunk => {
+                    cr.bytesReceived += chunk.length;
+                    if (cr.bytesReceived >= cr.size) {
+                        this._finalizeReceive(cr);
+                    }
+                });
             }
 
             this._inboundTempPaths.add(cr.tempPath);
         }
 
         if (cr.useGZ) {
-            //  GZ: wire carries compressed bytes whose count differs from the
-            //  declared (uncompressed) file size. Pass the full chunk through
-            //  to gunzip — do NOT cap against cr.size — and rely solely on the
-            //  EOF frame (data.length === 0 path above) to trigger finalize.
+            //  GZ: the wire carries compressed bytes whose count has nothing
+            //  to do with the declared (uncompressed) size, so the chunk goes
+            //  through whole — capping it here would truncate the stream.
+            //  Finalizing is driven by the decompressed count instead; see
+            //  the 'data' handler above.
             cr.inflate.write(data);
         } else {
             //  Non-GZ: cap to declared size and finalize early if we've
@@ -1068,8 +1120,7 @@ class BinkpSession extends EventEmitter {
         });
     }
 
-    _finalizeReceive() {
-        const cr = this._currentRecv;
+    _finalizeReceive(cr = this._currentRecv) {
         if (!cr || cr._finalizing) return;
         cr._finalizing = true;
         //  Do NOT clear this._currentRecv yet. _checkDone must not consider
@@ -1079,7 +1130,18 @@ class BinkpSession extends EventEmitter {
         //  and the client would wait forever.
 
         const finish = () => {
-            this._currentRecv = null;
+            if (this._currentRecv === cr) {
+                this._currentRecv = null;
+            }
+            //  Short of the size the sender announced: something ended the
+            //  transfer early. M_GOT would tell the sender we hold a good
+            //  copy and let it apply its disposition, so stay quiet and let
+            //  it offer the file again next session.
+            if (cr.bytesReceived < cr.size) {
+                this._abandonShortReceive(cr);
+                return;
+            }
+
             //  File handed off to the listener; ownership of the temp file
             //  passes to whatever moves it into the inbound spool. Drop our
             //  tracking entry so _destroy() doesn't unlink it from under
@@ -1117,6 +1179,7 @@ class BinkpSession extends EventEmitter {
 
     _onEob() {
         this._remoteEOB = true;
+        this._closeOutstandingReceive();
         //  The remote is done sending; anything we asked an offset for is
         //  not coming this session.
         this._pendingOffsetReq = null;

--- a/core/binkp/session.js
+++ b/core/binkp/session.js
@@ -863,6 +863,15 @@ class BinkpSession extends EventEmitter {
         //  is the re-announcement we asked for or the sender moving on.
         this._pendingOffsetReq = null;
 
+        //  ...and ends whatever file was being received, before we decide
+        //  anything about this one. It has to happen on every path out of
+        //  here, not just the one that starts a new receive: a duplicate we
+        //  answer with M_GOT, or an offset request we answer with M_GET,
+        //  would otherwise leave the previous file open, and a sender that
+        //  pipelines has this file's data frames already on the wire behind
+        //  the M_FILE. They would be fed to the previous file's stream.
+        this._closeOutstandingReceive();
+
         const [name, sizeStr, tsStr, offsetStr] = parts;
         const size = parseInt(sizeStr, 10);
         const timestamp = parseInt(tsStr, 10);
@@ -911,7 +920,6 @@ class BinkpSession extends EventEmitter {
     //
     _beginReceive({ name, size, timestamp, useGZ }) {
         this._pendingOffsetReq = null;
-        this._closeOutstandingReceive();
 
         const tempPath = path.join(
             this._opts.tempDir || os.tmpdir(),
@@ -988,6 +996,17 @@ class BinkpSession extends EventEmitter {
         if (!cr) {
             // Zero-length frame with no active receive can happen if sender
             // is in NR mode and we already sent M_GOT for this file
+            return;
+        }
+
+        //  Already over: an M_FILE ended it and we are only waiting on the
+        //  flush, which for a compressed file is asynchronous. Anything still
+        //  arriving belongs to a file we are not receiving -- a duplicate we
+        //  answered with M_GOT, say, whose data a pipelining sender had
+        //  already put on the wire. Writing it here would append one file's
+        //  bytes to another's stream. binkd discards data blocks that arrive
+        //  with no file open in exactly the same way.
+        if (cr._finalizing) {
             return;
         }
 

--- a/test/binkp_gz.test.js
+++ b/test/binkp_gz.test.js
@@ -350,14 +350,17 @@ describe('BinkpSession — inbound with no terminator frame', function () {
 
     //  Receive |filesToSend| from a binkd-shaped peer and hand back what
     //  arrived, keyed by name, along with the peer for M_GOT assertions.
-    async function receiveFrom(filesToSend, peerOpts = {}) {
+    async function receiveFrom(filesToSend, peerOpts = {}, sessionOpts = {}) {
         const paths = [];
-        const { session, peer } = await makeScriptedPair({
-            opts: ['EXTCMD', 'GZ'],
-            noEofFrame: true,
-            filesToSend,
-            ...peerOpts,
-        });
+        const { session, peer } = await makeScriptedPair(
+            {
+                opts: ['EXTCMD', 'GZ'],
+                noEofFrame: true,
+                filesToSend,
+                ...peerOpts,
+            },
+            sessionOpts
+        );
         session.on('file-received', (name, size, ts, p) => paths.push({ name, p }));
 
         await runSession(session);
@@ -467,6 +470,93 @@ describe('BinkpSession — inbound with no terminator frame', function () {
         assert.equal(files['short.pkt'], undefined, 'the partial is not handed on');
         assert.deepEqual(peer.skipsReceived, ['short.pkt'], 'and is postponed');
         assert.equal(files['good.pkt'].toString(), COMPRESSIBLE);
+    });
+
+    it('does not feed a file we refuse into the one before it', async () => {
+        //  A pipelining sender has a file's data on the wire behind its
+        //  M_FILE, so a duplicate we answer with M_GOT still arrives. The
+        //  M_FILE has to end the previous receive on that path too -- it
+        //  returns before _beginReceive -- or those bytes are appended to
+        //  the previous file's decompressor, one file's contents decoded as
+        //  part of another's.
+        //
+        //  Asserted on where each data frame lands rather than on the bytes
+        //  that come out: whether the damage surfaces depends on how zlib
+        //  happens to be scheduled, and the size cap hides it whenever the
+        //  surplus lands past the declared size. The routing is what is
+        //  actually wrong, and it is deterministic.
+        const wanted = Buffer.alloc(20000, 0x41);
+        const dupe = Buffer.alloc(20000, 0x5a);
+
+        const stray = [];
+        const filesToSend = [
+            {
+                name: 'wanted.pkt',
+                size: wanted.length,
+                timestamp: 1700000000,
+                data: wanted,
+                gzContainer: 'zlib',
+            },
+            {
+                name: 'dupe.pkt',
+                size: dupe.length,
+                timestamp: 1700000001,
+                data: dupe,
+                gzContainer: 'zlib',
+            },
+        ];
+
+        const paths = [];
+        const { session, peer } = await makeScriptedPair(
+            {
+                opts: ['EXTCMD', 'GZ'],
+                noEofFrame: true,
+                pipeline: true,
+                filesToSend,
+            },
+            { hasFile: name => 'dupe.pkt' === name }
+        );
+
+        //  Every data frame that reaches an open receive belonging to some
+        //  other file is a frame written into the wrong stream.
+        let sawDupeHeader = false;
+        const onData = session._onDataFrame.bind(session);
+        session._onDataFrame = data => {
+            const cr = session._currentRecv;
+            if (sawDupeHeader && data.length && cr && !cr._finalizing) {
+                stray.push(cr.name);
+            }
+            return onData(data);
+        };
+        const onFile = session._onFile.bind(session);
+        session._onFile = arg => {
+            if (arg.startsWith('dupe.pkt ')) {
+                sawDupeHeader = true;
+            }
+            return onFile(arg);
+        };
+
+        session.on('file-received', (name, size, ts, p) => paths.push({ name, p }));
+        await runSession(session);
+
+        const files = {};
+        for (const { name, p } of paths) {
+            files[name] = await fsp.readFile(p);
+            await fsp.unlink(p).catch(() => {});
+        }
+
+        assert.deepEqual(stray, [], "the dupe's frames went into an open receive");
+        assert.ok(files['wanted.pkt'], 'the file we wanted was never received');
+        assert.deepEqual(files['wanted.pkt'], wanted, 'and must not carry the dupe');
+        assert.equal(files['dupe.pkt'], undefined, 'the dupe is not handed on');
+        //  Both are acknowledged: the dupe because we already hold it.
+        assert.deepEqual(
+            peer.framesIn
+                .filter(f => f.cmd === Commands.M_GOT)
+                .map(f => f.arg.split(' ')[0])
+                .sort(),
+            ['dupe.pkt', 'wanted.pkt']
+        );
     });
 
     it('cuts a file that runs past its announced size back to it', async () => {

--- a/test/binkp_gz.test.js
+++ b/test/binkp_gz.test.js
@@ -334,6 +334,142 @@ describe('BinkpSession — GZ opt-out', function () {
     });
 });
 
+// ── Finishing without a terminator frame — issue #745 ─────────────────
+
+//
+//  ENiGMA ends every file it sends with a zero-length data frame, and until
+//  #745 the GZ receive path treated that frame as the only thing that could
+//  finish a file. It is not part of the protocol: FTS-1026 gives the size in
+//  M_FILE and binkd's receive loop finishes on that count alone
+//  (`ftello(state->in.f) == state->in.size`), never sending a terminator of
+//  its own. Both halves of this describe run against |noEofFrame|, so a
+//  regression here is the five-minute hang the issue reported.
+//
+describe('BinkpSession — inbound with no terminator frame', function () {
+    this.timeout(10000);
+
+    //  Receive |filesToSend| from a binkd-shaped peer and hand back what
+    //  arrived, keyed by name, along with the peer for M_GOT assertions.
+    async function receiveFrom(filesToSend, peerOpts = {}) {
+        const paths = [];
+        const { session, peer } = await makeScriptedPair({
+            opts: ['EXTCMD', 'GZ'],
+            noEofFrame: true,
+            filesToSend,
+            ...peerOpts,
+        });
+        session.on('file-received', (name, size, ts, p) => paths.push({ name, p }));
+
+        await runSession(session);
+
+        const files = {};
+        for (const { name, p } of paths) {
+            files[name] = await fsp.readFile(p);
+            await fsp.unlink(p).catch(() => {});
+        }
+        return { files, peer };
+    }
+
+    function gotNames(peer) {
+        return peer.framesIn
+            .filter(f => f.cmd === Commands.M_GOT)
+            .map(f => f.arg.split(' ')[0]);
+    }
+
+    it('finishes a GZ file on the size M_FILE declared', async () => {
+        const body = Buffer.from(COMPRESSIBLE);
+        const { files, peer } = await receiveFrom([
+            {
+                name: 'noeof.pkt',
+                size: body.length,
+                timestamp: 1700000000,
+                data: body,
+                gzContainer: 'zlib',
+            },
+        ]);
+
+        assert.equal(files['noeof.pkt'].toString(), COMPRESSIBLE);
+        assert.deepEqual(gotNames(peer), ['noeof.pkt']);
+    });
+
+    it('still finishes an uncompressed one', async () => {
+        const body = Buffer.from(COMPRESSIBLE);
+        const { files, peer } = await receiveFrom([
+            { name: 'clear.pkt', size: body.length, timestamp: 1700000000, data: body },
+        ]);
+
+        assert.equal(files['clear.pkt'].toString(), COMPRESSIBLE);
+        assert.deepEqual(gotNames(peer), ['clear.pkt']);
+    });
+
+    //
+    //  The one that the obvious fix gets wrong. Counting decompressed bytes
+    //  is necessary but not sufficient: zlib is asynchronous, so in a
+    //  pipelined batch every M_FILE is parsed before a single byte comes
+    //  back out of the decompressor. Finishing has to key off the file the
+    //  bytes belong to, and a fresh M_FILE has to close the one before it,
+    //  or files are quietly dropped while the session still reports success.
+    //
+    it('keeps every file of a pipelined batch apart', async () => {
+        const bodies = {};
+        const filesToSend = [0, 1, 2, 3].map(i => {
+            const name = `batch${i}.pkt`;
+            //  Sizes either side of a frame boundary, and distinct contents
+            //  so a mix-up cannot pass as a coincidence.
+            const data = Buffer.alloc(1 + i * 30000, 0x41 + i);
+            bodies[name] = data;
+            return {
+                name,
+                size: data.length,
+                timestamp: 1700000000 + i,
+                data,
+                gzContainer: 'zlib',
+            };
+        });
+
+        const { files, peer } = await receiveFrom(filesToSend, { pipeline: true });
+
+        for (const name of Object.keys(bodies)) {
+            assert.ok(files[name], `${name} was never received`);
+            assert.deepEqual(files[name], bodies[name], `${name} came back wrong`);
+        }
+        assert.deepEqual(gotNames(peer).sort(), Object.keys(bodies).sort());
+    });
+
+    it('does not acknowledge a file that stops short', async () => {
+        //  The peer announces more than it sends and then moves on to the
+        //  next file. M_GOT would tell it we hold a good copy and let it
+        //  apply its disposition, so the truncated one has to go
+        //  unacknowledged -- postponed with M_SKIP -- while the batch
+        //  carries on and the good file still arrives.
+        const good = Buffer.from(COMPRESSIBLE);
+        const { files, peer } = await receiveFrom(
+            [
+                {
+                    name: 'short.pkt',
+                    size: good.length + 4096,
+                    timestamp: 1700000000,
+                    data: good,
+                    gzContainer: 'zlib',
+                },
+                {
+                    name: 'good.pkt',
+                    size: good.length,
+                    timestamp: 1700000001,
+                    data: good,
+                    gzContainer: 'zlib',
+                },
+            ],
+            { pipeline: true }
+        );
+
+        assert.deepEqual(gotNames(peer), ['good.pkt'], 'only the whole file');
+        assert.equal(files['short.pkt'], undefined, 'the partial is not handed on');
+        assert.deepEqual(peer.skipsReceived, ['short.pkt'], 'and is postponed');
+        assert.equal(files['good.pkt'].toString(), COMPRESSIBLE);
+    });
+});
+
 // ── Sanity: the fixture really is asymmetric ──────────────────────────────────
 
 describe('zlib containers are not interchangeable', () => {

--- a/test/binkp_gz.test.js
+++ b/test/binkp_gz.test.js
@@ -559,6 +559,116 @@ describe('BinkpSession — inbound with no terminator frame', function () {
         );
     });
 
+    it('tearing one receive down does not cancel the next', async () => {
+        //  Ending a receive is asynchronous for a compressed file, so the
+        //  teardown lands after the batch has already opened the file behind
+        //  it. _abandonReceive used to clear _currentRecv unconditionally,
+        //  cancelling that one -- every frame still arriving for it was then
+        //  discarded and the batch hung.
+        //
+        //  Whether any frames are actually stranded depends on how the
+        //  sender's writes happen to be split, so the assertion is on the
+        //  invariant rather than on the fallout: tearing down one file may
+        //  never cancel a different one.
+        const short = Buffer.alloc(20000, 0x41);
+        const rest = Buffer.alloc(256 * 1024, 0x42);
+
+        const stolen = [];
+        const filesToSend = [
+            {
+                name: 'short.pkt',
+                size: short.length + 4096, //  more than it will send
+                timestamp: 1700000000,
+                data: short,
+                gzContainer: 'zlib',
+            },
+            {
+                name: 'rest.pkt',
+                size: rest.length,
+                timestamp: 1700000001,
+                data: rest,
+                gzContainer: 'zlib',
+            },
+        ];
+
+        const paths = [];
+        const { session, peer } = await makeScriptedPair({
+            opts: ['EXTCMD', 'GZ'],
+            noEofFrame: true,
+            pipeline: true,
+            filesToSend,
+        });
+
+        const abandon = session._abandonReceive.bind(session);
+        session._abandonReceive = cr => {
+            const before = session._currentRecv;
+            abandon(cr);
+            if (before && before !== cr && null === session._currentRecv) {
+                stolen.push({ dropped: cr.name, cancelled: before.name });
+            }
+        };
+
+        session.on('file-received', (name, size, ts, p) => paths.push({ name, p }));
+        await runSession(session);
+
+        const files = {};
+        for (const { name, p } of paths) {
+            files[name] = await fsp.readFile(p);
+            await fsp.unlink(p).catch(() => {});
+        }
+
+        assert.deepEqual(stolen, [], 'a teardown cancelled an unrelated receive');
+        assert.ok(files['rest.pkt'], 'the file behind it was never received');
+        assert.equal(files['rest.pkt'].length, rest.length);
+        assert.equal(files['short.pkt'], undefined, 'the short one is not handed on');
+        assert.deepEqual(
+            peer.framesIn
+                .filter(f => f.cmd === Commands.M_GOT)
+                .map(f => f.arg.split(' ')[0]),
+            ['rest.pkt']
+        );
+    });
+
+    it('still asks for a clear retransmit once the batch has moved on', async () => {
+        //  Decompression fails asynchronously, so by the time it does the
+        //  sender is already several files further along. Answering only for
+        //  the file that happens to be current drops this one on the floor:
+        //  no M_GET, no M_SKIP, and a sender left waiting on an M_GOT that is
+        //  never coming. FTS-1029's NZ recovery has to work here too.
+        const bad = Buffer.alloc(20000, 0x41);
+        const good = Buffer.alloc(20000, 0x42);
+
+        const { files, peer } = await receiveFrom(
+            [
+                {
+                    name: 'bad.pkt',
+                    size: bad.length,
+                    timestamp: 1700000000,
+                    data: bad,
+                    gzContainer: 'corrupt',
+                },
+                {
+                    name: 'good.pkt',
+                    size: good.length,
+                    timestamp: 1700000001,
+                    data: good,
+                    gzContainer: 'zlib',
+                },
+            ],
+            { pipeline: true }
+        );
+
+        const nz = peer.framesIn.filter(
+            f => f.cmd === Commands.M_GET && f.arg.endsWith(' NZ')
+        );
+        assert.equal(nz.length, 1, 'the uncompressed retransmit was never asked for');
+        assert.ok(nz[0].arg.startsWith('bad.pkt '), 'and must name the file that failed');
+
+        //  The retransmit arrives in the clear, so both files land.
+        assert.deepEqual(files['bad.pkt'], bad, 'the retransmit was not recovered');
+        assert.deepEqual(files['good.pkt'], good);
+    });
+
     it('cuts a file that runs past its announced size back to it', async () => {
         //  The clear path caps every chunk against the declared size, but a
         //  compressed one cannot be measured until it is decompressed, so

--- a/test/binkp_gz.test.js
+++ b/test/binkp_gz.test.js
@@ -468,6 +468,28 @@ describe('BinkpSession — inbound with no terminator frame', function () {
         assert.deepEqual(peer.skipsReceived, ['short.pkt'], 'and is postponed');
         assert.equal(files['good.pkt'].toString(), COMPRESSIBLE);
     });
+
+    it('cuts a file that runs past its announced size back to it', async () => {
+        //  The clear path caps every chunk against the declared size, but a
+        //  compressed one cannot be measured until it is decompressed, so
+        //  the surplus reaches the disk before anyone can object. Both paths
+        //  have to hand on the file the sender described, no more.
+        const body = Buffer.from(COMPRESSIBLE);
+        const declared = body.length - 100;
+        const { files, peer } = await receiveFrom([
+            {
+                name: 'over.pkt',
+                size: declared,
+                timestamp: 1700000000,
+                data: body,
+                gzContainer: 'zlib',
+            },
+        ]);
+
+        assert.deepEqual(gotNames(peer), ['over.pkt']);
+        assert.equal(files['over.pkt'].length, declared, 'trimmed to the declared size');
+        assert.deepEqual(files['over.pkt'], body.slice(0, declared));
+    });
 });
 
 // ── Sanity: the fixture really is asymmetric ──────────────────────────────────

--- a/test/binkp_peer.js
+++ b/test/binkp_peer.js
@@ -410,7 +410,17 @@ class ScriptedPeer {
     _onGet(arg) {
         const parts = arg.split(' ');
         const [name, , , offsetStr] = parts;
-        const cs = this.currentSend;
+        let cs = this.currentSend;
+        //  FTS-1026 requires a sender to honour an M_GET naming a file it has
+        //  already put on the wire and is still waiting to have acknowledged.
+        //  A pipelining peer is always in that position -- it holds nothing
+        //  in currentSend -- and binkd answers from its sent list.
+        if (this.opts.pipeline && (!cs || cs.name !== name)) {
+            cs = (this.opts.filesToSend || []).find(f => f.name === name);
+            if (cs) {
+                this.currentSend = cs;
+            }
+        }
         if (!cs || cs.name !== name) {
             return;
         }

--- a/test/binkp_peer.js
+++ b/test/binkp_peer.js
@@ -58,6 +58,11 @@ class ScriptedPeer {
     //    onComplete : (peer, file) => 'got'|'get'|'skip'|'none'
     //                             — what to answer a fully received file with
     //    filesToSend: [{ name, size, timestamp, data, nr, reannounce }]
+    //    noEofFrame : boolean   — end a file with its last data frame and
+    //                             nothing else, the way binkd does (issue #745)
+    //    pipeline   : boolean   — offer every file back to back without
+    //                             waiting for M_GOT, the way binkd does
+    //                             whenever ND mode is not in play
     constructor(socket, opts = {}) {
         this.opts = opts;
         this.socket = socket;
@@ -81,6 +86,10 @@ class ScriptedPeer {
         this.closed = false;
         this.nzRequests = []; //  files we were asked to resend in the clear
         this.skipsReceived = [];
+        //  binkd's sent_fls: files offered but not yet acknowledged. It holds
+        //  M_EOB until this drains (protocol.c:3234), so the last file of a
+        //  pipelined batch has to complete on its own.
+        this.awaitingGot = 0;
 
         socket.on('error', () => {});
         socket.on('data', chunk => this.parser.push(chunk));
@@ -358,6 +367,16 @@ class ScriptedPeer {
         const { body, gz } = this._encode(file, 0);
         this._sendFileHeader(file, 0, gz);
         this._pump(body);
+
+        //  binkd only parks on M_GOT in ND mode, which it enters on the bare
+        //  "ND" token -- and ENiGMA offers NDA only. So against us binkd
+        //  starts the next M_FILE the moment the last block is queued, and
+        //  the whole batch can land in one read. |pipeline| models that.
+        if (this.opts.pipeline) {
+            ++this.awaitingGot;
+            this.currentSend = null;
+            this._sendNext();
+        }
     }
 
     _sendFileHeader(file, offset, gz) {
@@ -416,10 +435,19 @@ class ScriptedPeer {
         for (let i = 0; i < body.length; i += 0x4000) {
             this.socket.write(buildDataFrame(body.slice(i, i + 0x4000)));
         }
-        this.socket.write(EOF_FRAME);
+        //  binkd has no terminator frame: send_block() marks the file sent
+        //  once the last block is queued, and the receiver is expected to
+        //  count bytes against the size M_FILE announced. |noEofFrame|
+        //  models that; ENiGMA's own sender always writes one.
+        if (!this.opts.noEofFrame) {
+            this.socket.write(EOF_FRAME);
+        }
     }
 
     _onGot() {
+        if (this.awaitingGot > 0) {
+            --this.awaitingGot;
+        }
         this.currentSend = null;
         this._sendNext();
     }
@@ -429,6 +457,11 @@ class ScriptedPeer {
     _onSkip(arg) {
         const [name] = arg.split(' ');
         this.skipsReceived.push(name);
+        //  Postponed, so it is no longer outstanding -- binkd drops it from
+        //  sent_fls the same way an M_GOT would, and can then send M_EOB.
+        if (this.awaitingGot > 0) {
+            --this.awaitingGot;
+        }
         if (this.currentSend && this.currentSend.name === name) {
             this.currentSend = null;
         }
@@ -437,6 +470,10 @@ class ScriptedPeer {
 
     _maybeEob() {
         if (this.eobSent || this.currentSend || this.sendQueue.length) {
+            return;
+        }
+        //  Nothing may be outstanding either -- see |awaitingGot|.
+        if (this.awaitingGot > 0) {
             return;
         }
         //  The answering side holds its M_EOB until the caller's arrives;


### PR DESCRIPTION
Fixes #745.

Inbound GZ transfers from binkd hung until `SESSION_TIMEOUT_MS` and were never
received. Reported by @jriethoven against binkd/1.1a-115, confirmed on `master`.

## The bug

`_onDataFrame`'s GZ branch finished a file only when the sender followed it with
a zero-length data frame. That frame is ours, not the protocol's — FTS-1026 puts
the size in `M_FILE`, and binkd's receive loop finishes on that count alone:

```c
if (ftello (state->in.f) == state->in.size)   /* protocol.c */
```

Its sender marks a file done as soon as the last block is queued
(`current_file_was_sent`) and never emits a terminator. We write `EOF_FRAME`
after every file unconditionally, so ENiGMA↔ENiGMA agreed with itself. The clear
receive path already counted bytes, which is why only GZ peers saw it.

## Why counting decompressed bytes is not enough on its own

The obvious fix — count what comes out of the decompressor, finish at the
declared size — repairs a one-file session and **silently drops files in a
batch**. Node's zlib is asynchronous while frame parsing is synchronous, so
every `M_FILE` in a pipelined batch is parsed before a single byte comes back
out. `_beginReceive` replaced `_currentRecv` with no finalize, and the late
`data` handlers then finished whichever file happened to be current.

Measured on a five-file GZ batch, 4096-byte blocks, no terminator frames:

| | outcome | received | `M_GOT`s |
|---|---|---|---|
| `master` | hangs to timeout | 0/5 | 0 |
| count-bytes alone | reports `session-end` | 1/5 | 1 |
| this branch | `session-end` | 5/5, SHA1 verified | 5 |

The middle row is the dangerous one: the session *reports success* while four
files are never acknowledged, so they return on every poll forever with nothing
logged. And it is live against binkd rather than theoretical — binkd only parks
on `M_GOT` in ND mode, which it enters on the bare `ND` token, and we advertise
`NDA` only, so it pipelines against us.

## Commits

1. **finish an inbound file on its declared size** — `_finalizeReceive(cr)` bound
   to a specific receive; GZ counts decompressed bytes; a fresh `M_FILE` or
   `M_EOB` closes the one before it, which is what FTS-1026 means by *"until the
   next M_FILE command is received, all data frames must carry data from this
   file"*; a file that ends short is postponed with `M_SKIP` rather than
   acknowledged. Previously the terminator frame finished a receive no matter how
   few bytes had arrived, so a truncated transfer could be handed to the tosser
   and `M_GOT`'d as complete.
2. **cut a GZ file back to its announced size** — the clear path caps every chunk
   against the declared size; a compressed one cannot be measured until it is
   decompressed, so the surplus reached the disk untrimmed.
3. **let every `M_FILE` end the file before it** — the close sat in
   `_beginReceive`, which two paths out of `_onFile` never reach (a duplicate
   answered with `M_GOT`, an offset request answered with `M_GET`). Traced 43
   bytes of a duplicate's payload written into the preceding file's inflate
   stream.
4. **make a failed or abandoned receive answer for itself** —
   `_abandonReceive` cleared `_currentRecv` unconditionally, so dropping one file
   cancelled the file behind it (a short GZ file followed by a 6 MB one: neither
   arrives, session hangs). And `_onInflateError` returned early unless the
   failing receive was the current one, which after a batch moves on is never
   true, so a late decompression failure was swallowed whole — no NZ retransmit,
   no `M_SKIP`.

We still send our own terminator frame: an un-upgraded ENiGMA still requires one,
and binkd ignores it.

## Tests

The suite could not have caught any of this. `test/binkp_peer.js` always wrote
the terminator frame and waited for `M_GOT` before offering the next file — it
modelled our own sender, not binkd. Same blind spot that hid #723 and #724.

It now takes `noEofFrame` and `pipeline`, holds `M_EOB` until outstanding files
are acknowledged the way binkd's `sent_fls` does, and honours an `M_GET` for a
file it has already sent (FTS-1026 requires that of a sender).

Eight new cases. Each was verified to fail on the commit before its fix and pass
after; the two ownership ones were run three times each way, because whether the
damage surfaces depends on how the sender's writes happen to be split. Where that
made an outcome-based assertion flaky, the test asserts the invariant instead —
which frame is routed to which receive, and whether a teardown cancels an
unrelated one.

`2098 passing`, against a `2090` baseline on `master`. Lint and prettier clean.

## Not in scope

#760 — an inbound `M_FILE` offset is parsed and then ignored, so a resumed file
never transfers. Not reachable from anything we do today, and commit 1 already
turns its dangerous half (silently accepting a short file as complete) into a
refusal.

## Note for anyone refining this

Do **not** add a `cr._finalizing` guard to `_onInflateError`. It looks right, but
a corrupt stream raises its error during `inflate.end()`, which is exactly when
the FTS-1029 NZ recovery is needed — it costs three `binkp_gz.test.js` failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
