### PR TITLE
feat(bso): tell the operator which node is waiting on a file that is gone

### DIFF
--- a/core/binkp/bso_spool.js
+++ b/core/binkp/bso_spool.js
@@ -62,7 +62,7 @@ const MAX_WARNED_FLOW_REFS = 1024;
 //  once per process meant a busy system said it once at boot and then never
 //  again, so the condition was invisible by the time anyone looked. Repeating
 //  keeps it in the log without turning every poll into noise.
-const FLOW_REF_WARN_REPEAT_MS = 60 * 60 * 1000; //  1 hour
+const DEFAULT_FLOW_REF_WARN_REPEAT_MS = 60 * 60 * 1000; //  1 hour
 const warnedFlowRefs = new Map();
 
 //
@@ -96,6 +96,10 @@ class BsoSpool {
             typeof config.staleLockMaxAgeMs === 'number'
                 ? config.staleLockMaxAgeMs
                 : DEFAULT_STALE_LOCK_MAX_AGE_MS;
+        this._flowRefWarnRepeatMs =
+            typeof config.flowRefWarnRepeatMs === 'number'
+                ? config.flowRefWarnRepeatMs
+                : DEFAULT_FLOW_REF_WARN_REPEAT_MS;
     }
 
     // ── Lock management ──────────────────────────────────────────────────────
@@ -295,7 +299,8 @@ class BsoSpool {
             if (seen.has(key)) return;
 
             if (isFlow) {
-                if (!(await flowHasPending(filePath, addr))) return;
+                if (!(await flowHasPending(filePath, addr, this._flowRefWarnRepeatMs)))
+                    return;
             } else {
                 // Direct-attach: zero-byte = poll flag, not mail
                 const stat = await fsp.stat(filePath).catch(() => null);
@@ -697,7 +702,9 @@ class BsoSpool {
                 filePath = trimmed;
             }
 
-            const resolved = await resolveFlowRef(flowPath, filePath, addr);
+            const resolved = await resolveFlowRef(flowPath, filePath, addr, {
+                repeatMs: this._flowRefWarnRepeatMs,
+            });
             if (!resolved) continue;
 
             const lineIdx = i;
@@ -944,14 +951,14 @@ function uniquePacketName(filePath) {
 //  poller would dial it every cycle only to transfer nothing and log a clean
 //  "Session complete".
 //
-async function flowHasPending(flowPath, addr) {
+async function flowHasPending(flowPath, addr, repeatMs) {
     const content = await fsp.readFile(flowPath, 'utf8').catch(() => '');
     for (const line of content.split('\n')) {
         const trimmed = line.trim();
         if (!trimmed || trimmed[0] === '~') continue;
 
         const ref = /^[\^#-]/.test(trimmed) ? trimmed.slice(1) : trimmed;
-        if (await resolveFlowRef(flowPath, ref, addr)) return true;
+        if (await resolveFlowRef(flowPath, ref, addr, { repeatMs })) return true;
     }
     return false;
 }
@@ -971,19 +978,24 @@ async function flowHasPending(flowPath, addr) {
 //  is how misfiled outbound mail hides: the session finds nothing to send and
 //  reports success.
 //
-async function resolveFlowRef(flowPath, ref, addr, { quiet = false } = {}) {
+async function resolveFlowRef(
+    flowPath,
+    ref,
+    addr,
+    { quiet = false, repeatMs = DEFAULT_FLOW_REF_WARN_REPEAT_MS } = {}
+) {
     const warnEvery = (key, fields, message) => {
         if (quiet) return;
         const now = Date.now();
         const last = warnedFlowRefs.get(key);
-        if (last && now - last < FLOW_REF_WARN_REPEAT_MS) return;
+        if (last && now - last < repeatMs) return;
         if (warnedFlowRefs.size >= MAX_WARNED_FLOW_REFS) {
             //  Drop what has aged out first. Clearing wholesale would throw
             //  away entries warned seconds ago and let them repeat straight
             //  away, which on a spool with many dangling refs turns the
             //  throttle into a firehose.
             for (const [k, when] of warnedFlowRefs) {
-                if (now - when >= FLOW_REF_WARN_REPEAT_MS) warnedFlowRefs.delete(k);
+                if (now - when >= repeatMs) warnedFlowRefs.delete(k);
             }
             if (warnedFlowRefs.size >= MAX_WARNED_FLOW_REFS) warnedFlowRefs.clear();
         }

--- a/core/binkp/bso_spool.js
+++ b/core/binkp/bso_spool.js
@@ -54,7 +54,15 @@ const warnedNetworks = new Set();
 // accumulates a uniquely named packet per export. Past the cap we start over
 // rather than grow: a little repetition beats a leak.
 const MAX_WARNED_FLOW_REFS = 1024;
-const warnedFlowRefs = new Set();
+
+//  key -> when we last said something about it. A dangling reference is a
+//  standing fault, not an event: the file is not coming back on its own and
+//  the node does not get its mail until an operator deals with it. Warning
+//  once per process meant a busy system said it once at boot and then never
+//  again, so the condition was invisible by the time anyone looked. Repeating
+//  keeps it in the log without turning every poll into noise.
+const FLOW_REF_WARN_REPEAT_MS = 60 * 60 * 1000; //  1 hour
+const warnedFlowRefs = new Map();
 
 //
 //  BsoSpool — filesystem adapter between BinkP sessions and the BSO outbound/
@@ -197,7 +205,7 @@ class BsoSpool {
 
                 const flowPath = path.join(dir, actual);
                 try {
-                    results.push(...(await this._parseFlowFile(flowPath)));
+                    results.push(...(await this._parseFlowFile(flowPath, addr)));
                 } catch (err) {
                     if (err.code !== 'ENOENT') {
                         Log.warn(
@@ -212,11 +220,16 @@ class BsoSpool {
         return results;
     }
 
-    // Returns Address objects for every node that has at least one unsent file.
-    async getNodesWithPendingMail() {
+    //
+    //  Walk every outbound directory and hand |cb| one entry per spool file
+    //  found, as { addr, filePath, ext, isFlow }. No judgement about whether
+    //  the file has anything live in it -- that belongs to the caller, and
+    //  the two callers want opposite things: the poller wants only nodes it
+    //  should dial, while the operator's listing must show precisely the node
+    //  whose every entry has gone missing.
+    //
+    async _forEachOutboundFile(cb) {
         const outboundDirs = await this._allOutboundDirs();
-        const seen = new Set();
-        const results = [];
 
         //  |bossBase| is set when scanning inside a NNNNnnnn.pnt/ subdirectory,
         //  in which case each basename is a point number rather than a
@@ -243,42 +256,216 @@ class BsoSpool {
 
                 const base = m[1].toLowerCase();
                 const ext = m[2].toLowerCase();
-                const key = bossBase ? `${zone}:${bossBase}.${base}` : `${zone}:${base}`;
-                if (seen.has(key)) continue;
 
                 //  A point number of zero addresses the boss node, whose files
                 //  belong in the outbound directory proper.
                 const point = bossBase ? parseInt(base, 16) : 0;
                 if (bossBase && 0 === point) continue;
 
-                const filePath = path.join(dir, file);
-
-                if (FLOW_EXTS.includes(ext)) {
-                    if (!(await flowHasPending(filePath))) continue;
-                } else {
-                    // Direct-attach: zero-byte = poll flag, not mail
-                    const stat = await fsp.stat(filePath).catch(() => null);
-                    if (!stat || stat.size === 0) continue;
-                }
-
-                seen.add(key);
                 const nodeBase = bossBase || base;
-                results.push(
-                    new Address({
-                        zone,
-                        net: parseInt(nodeBase.slice(0, 4), 16),
-                        node: parseInt(nodeBase.slice(4, 8), 16),
-                        ...(point ? { point } : {}),
-                    })
-                );
+                const addr = new Address({
+                    zone,
+                    net: parseInt(nodeBase.slice(0, 4), 16),
+                    node: parseInt(nodeBase.slice(4, 8), 16),
+                    ...(point ? { point } : {}),
+                });
+
+                await cb({
+                    addr,
+                    filePath: path.join(dir, file),
+                    ext,
+                    isFlow: FLOW_EXTS.includes(ext),
+                });
             }
         };
 
         for (const { dir, zone } of outboundDirs) {
             await scanDir(dir, zone);
         }
+    }
+
+    // Returns Address objects for every node that has at least one unsent file.
+    async getNodesWithPendingMail() {
+        const seen = new Set();
+        const results = [];
+
+        await this._forEachOutboundFile(async ({ addr, filePath, isFlow }) => {
+            const key = addr.toString();
+            if (seen.has(key)) return;
+
+            if (isFlow) {
+                if (!(await flowHasPending(filePath))) return;
+            } else {
+                // Direct-attach: zero-byte = poll flag, not mail
+                const stat = await fsp.stat(filePath).catch(() => null);
+                if (!stat || stat.size === 0) return;
+            }
+
+            seen.add(key);
+            results.push(addr);
+        });
 
         return results;
+    }
+
+    //
+    //  Everything sitting in the outbound, per node, whether or not it can
+    //  still be sent -- the operator-facing view behind "oputil bso".
+    //
+    //  Returns [{ address, entries: [...] }] sorted by address, where each
+    //  entry is { kind, status, path, size, timestamp, disposition, flowFile,
+    //  lineIdx, line }. |status| is 'pending', 'sent' or 'missing'; a
+    //  'missing' entry is one whose reference resolves to no file on disk,
+    //  which is the condition that never resolves itself.
+    //
+    async inspectOutbound() {
+        const byNode = new Map();
+
+        const add = (addr, entry) => {
+            const key = addr.toString();
+            if (!byNode.has(key)) {
+                byNode.set(key, { address: addr, entries: [] });
+            }
+            byNode.get(key).entries.push(entry);
+        };
+
+        await this._forEachOutboundFile(async ({ addr, filePath, isFlow }) => {
+            if (!isFlow) {
+                const stat = await fsp.stat(filePath).catch(() => null);
+                //  Zero-byte direct-attach files are poll flags, not mail.
+                if (!stat || 0 === stat.size) {
+                    return;
+                }
+                add(addr, {
+                    kind: 'direct',
+                    status: 'pending',
+                    path: filePath,
+                    size: stat.size,
+                    timestamp: Math.floor(stat.mtimeMs / 1000),
+                    disposition: 'delete',
+                });
+                return;
+            }
+
+            const content = await fsp.readFile(filePath, 'utf8').catch(() => null);
+            if (null === content) {
+                return;
+            }
+
+            const lines = content.split('\n');
+            for (let i = 0; i < lines.length; i++) {
+                const trimmed = lines[i].trim();
+                if (!trimmed) continue;
+
+                if ('~' === trimmed[0]) {
+                    add(addr, {
+                        kind: 'flow',
+                        status: 'sent',
+                        path: trimmed.slice(1),
+                        flowFile: filePath,
+                        lineIdx: i,
+                        line: trimmed,
+                    });
+                    continue;
+                }
+
+                const prefix = /^[\^#-]/.test(trimmed) ? trimmed[0] : '';
+                const ref = prefix ? trimmed.slice(1) : trimmed;
+                const disposition =
+                    '#' === prefix ? 'truncate' : prefix ? 'delete' : 'keep';
+
+                //  Resolve quietly: this is a report, and shouting into the
+                //  log every time an operator runs it would bury the periodic
+                //  warning that actually marks a change of state.
+                const resolved = await resolveFlowRefQuiet(filePath, ref);
+
+                add(addr, {
+                    kind: 'flow',
+                    status: resolved ? 'pending' : 'missing',
+                    path: resolved ? resolved.path : ref,
+                    size: resolved ? resolved.stat.size : null,
+                    timestamp: resolved ? Math.floor(resolved.stat.mtimeMs / 1000) : null,
+                    disposition,
+                    flowFile: filePath,
+                    lineIdx: i,
+                    line: trimmed,
+                });
+            }
+        });
+
+        return Array.from(byNode.values()).sort((a, b) =>
+            a.address.toString().localeCompare(b.address.toString())
+        );
+    }
+
+    //
+    //  Drop every 'missing' reference for |addr| from its flow files.
+    //
+    //  Deliberately operator-driven rather than automatic: a deleted file and
+    //  one that is briefly unreachable -- an unmounted store, a half-finished
+    //  copy -- are the same ENOENT here, and guessing wrong throws away mail
+    //  nobody asked us to discard. With |dryRun| nothing is written and the
+    //  caller is told what would go.
+    //
+    async pruneMissingRefs(addr, { dryRun = true } = {}) {
+        const target = (await this.inspectOutbound()).find(n =>
+            sameAddress(n.address, addr)
+        );
+
+        const removed = (target ? target.entries : []).filter(
+            e => 'missing' === e.status
+        );
+
+        if (dryRun || 0 === removed.length) {
+            return removed;
+        }
+
+        //  Group by flow file so each is rewritten once, and go bottom-up so
+        //  an earlier removal cannot shift the index of a later one.
+        const byFlow = new Map();
+        for (const entry of removed) {
+            if (!byFlow.has(entry.flowFile)) {
+                byFlow.set(entry.flowFile, []);
+            }
+            byFlow.get(entry.flowFile).push(entry);
+        }
+
+        for (const [flowPath, entries] of byFlow) {
+            await this._withFlowFileWrite(flowPath, async () => {
+                const content = await fsp.readFile(flowPath, 'utf8').catch(() => null);
+                if (null === content) {
+                    return;
+                }
+                const lines = content.split('\n');
+
+                for (const entry of entries.sort((a, b) => b.lineIdx - a.lineIdx)) {
+                    //  Only if the line is still the one we reported on --
+                    //  ftn_bso may have appended, or a session marked
+                    //  something, since the listing was taken.
+                    if (
+                        entry.lineIdx < lines.length &&
+                        lines[entry.lineIdx].trim() === entry.line
+                    ) {
+                        lines.splice(entry.lineIdx, 1);
+                    }
+                }
+
+                const hasLive = lines.some(l => {
+                    const t = l.trim();
+                    return t.length > 0 && '~' !== t[0];
+                });
+
+                if (hasLive) {
+                    await fsp.writeFile(flowPath, lines.join('\n'), 'utf8');
+                } else {
+                    //  Nothing left to send; ftn_bso recreates the flow file
+                    //  next time it queues something, same as a normal drain.
+                    await fsp.unlink(flowPath).catch(() => {});
+                }
+            });
+        }
+
+        return removed;
     }
 
     // ── Inbound file handling ────────────────────────────────────────────────
@@ -402,7 +589,7 @@ class BsoSpool {
         return path.join(dir, `${nodeBaseName(addr)}.bsy`);
     }
 
-    async _parseFlowFile(flowPath) {
+    async _parseFlowFile(flowPath, addr) {
         const content = await fsp.readFile(flowPath, 'utf8');
         const lines = content.split('\n');
         const results = [];
@@ -426,7 +613,7 @@ class BsoSpool {
                 filePath = trimmed;
             }
 
-            const resolved = await resolveFlowRef(flowPath, filePath);
+            const resolved = await resolveFlowRef(flowPath, filePath, addr);
             if (!resolved) continue;
 
             const lineIdx = i;
@@ -700,11 +887,14 @@ async function flowHasPending(flowPath) {
 //  is how misfiled outbound mail hides: the session finds nothing to send and
 //  reports success.
 //
-async function resolveFlowRef(flowPath, ref) {
-    const warnOnce = (key, fields, message) => {
-        if (warnedFlowRefs.has(key)) return;
+async function resolveFlowRef(flowPath, ref, addr, { quiet = false } = {}) {
+    const warnEvery = (key, fields, message) => {
+        if (quiet) return;
+        const now = Date.now();
+        const last = warnedFlowRefs.get(key);
+        if (last && now - last < FLOW_REF_WARN_REPEAT_MS) return;
         if (warnedFlowRefs.size >= MAX_WARNED_FLOW_REFS) warnedFlowRefs.clear();
-        warnedFlowRefs.add(key);
+        warnedFlowRefs.set(key, now);
         Log.warn(fields, message);
     };
 
@@ -720,9 +910,9 @@ async function resolveFlowRef(flowPath, ref) {
             return stat.isFile() ? stat : null;
         } catch (err) {
             if ('ENOENT' !== err.code && 'ENOTDIR' !== err.code) {
-                warnOnce(
+                warnEvery(
                     `stat\0${p}`,
-                    { path: p, error: err.message },
+                    { node: nodeLabel(flowPath, addr), path: p, error: err.message },
                     '[BinkP/BSO] Error stat-ing flow file reference'
                 );
             }
@@ -742,13 +932,86 @@ async function resolveFlowRef(flowPath, ref) {
         if (stat) return { path: alt, stat };
     }
 
-    warnOnce(
+    //  Name the node and the file, not just the path: the operator's question
+    //  is "who is missing what", and a bare absolute path answers neither.
+    //  Say plainly that it will not be delivered -- "skipping entry" reads
+    //  like a transient step, and this one never resolves itself.
+    warnEvery(
         `ref\0${flowPath}\0${ref}`,
-        { flowFile: flowPath, ref },
-        '[BinkP/BSO] Flow file reference names no usable file; skipping entry'
+        {
+            node: nodeLabel(flowPath, addr),
+            file: path.basename(ref),
+            ref,
+            flowFile: flowPath,
+        },
+        '[BinkP/BSO] Queued file is missing; this node will never receive it. ' +
+            'See "oputil bso status"'
     );
 
     return null;
+}
+
+//  Compare two addresses by value. The spool's callers pass anything
+//  address-shaped -- an Address, or the plain object a test or a config
+//  reader hands over -- so this cannot go through Address.toString().
+function sameAddress(a, b) {
+    if (!a || !b) {
+        return false;
+    }
+    return (
+        a.zone === b.zone &&
+        a.net === b.net &&
+        a.node === b.node &&
+        (a.point || 0) === (b.point || 0)
+    );
+}
+
+//  Resolve without logging. The operator's listing asks about every entry
+//  every time it runs; the periodic warning is what marks a change of state,
+//  and burying it under one line per run per reference defeats it.
+function resolveFlowRefQuiet(flowPath, ref) {
+    return resolveFlowRef(flowPath, ref, null, { quiet: true });
+}
+
+//
+//  Best-effort label for whichever node a flow file belongs to. The caller
+//  knows the full 5D address when it is acting for one node; when it is
+//  sweeping the outbound it does not, and the file name carries net/node (and
+//  the parent directory the point) in hex -- everything but the zone.
+//
+function nodeLabel(flowPath, addr) {
+    //  Not addr.toString(): callers pass anything address-shaped, including
+    //  the plain objects the spool accepts everywhere else, and those
+    //  stringify to "[object Object]".
+    if (addr && undefined !== addr.net && undefined !== addr.node) {
+        const zone = undefined === addr.zone ? '' : `${addr.zone}:`;
+        const point = addr.point ? `.${addr.point}` : '';
+        return `${zone}${addr.net}/${addr.node}${point}`;
+    }
+
+    const base = path.basename(flowPath).split('.')[0];
+    const parsed = /^([0-9a-f]{4})([0-9a-f]{4})$/i.exec(base);
+    if (!parsed) {
+        return path.basename(flowPath);
+    }
+
+    const net = parseInt(parsed[1], 16);
+    const node = parseInt(parsed[2], 16);
+
+    const pointDir = POINT_DIR_RE.exec(path.basename(path.dirname(flowPath)));
+    if (pointDir) {
+        //  Inside NNNNnnnn.pnt/ the file name is the point and the directory
+        //  is the boss (FTS-5005.003 sec. 2).
+        const boss = /^([0-9a-f]{4})([0-9a-f]{4})$/i.exec(pointDir[1]);
+        if (boss) {
+            return `${parseInt(boss[1], 16)}/${parseInt(boss[2], 16)}.${parseInt(
+                base,
+                16
+            )}`;
+        }
+    }
+
+    return `${net}/${node}`;
 }
 
 //
@@ -875,4 +1138,9 @@ async function attachSpoolToSession(session, spool, remoteAddrs) {
     return disposeMap;
 }
 
-module.exports = { BsoSpool, attachSpoolToSession, nodeBaseName };
+module.exports = {
+    sameAddress,
+    BsoSpool,
+    attachSpoolToSession,
+    nodeBaseName,
+};

--- a/core/binkp/bso_spool.js
+++ b/core/binkp/bso_spool.js
@@ -442,6 +442,7 @@ class BsoSpool {
         }
 
         const skipped = [];
+        const actuallyRemoved = [];
 
         for (const [flowPath, entries] of byFlow) {
             //  The in-process chain is not enough here. oputil runs as its own
@@ -464,7 +465,10 @@ class BsoSpool {
                         this._withFlowFileWrite(flowPath, () =>
                             this._pruneFromFlowFile(flowPath, entries)
                         )
-                            .then(() => done(null))
+                            .then(spliced => {
+                                actuallyRemoved.push(...spliced);
+                                done(null);
+                            })
                             .catch(err => done(err));
                     },
                     err => {
@@ -490,12 +494,13 @@ class BsoSpool {
             }
         }
 
-        //  Anything we could not take the lock for is still queued, so it
-        //  must not be reported as removed -- and the caller has to be able
-        //  to say why, or an operator sees "nothing removed" and concludes
-        //  the entry was already gone.
+        //  Report what went, not what we set out to remove. A node we could
+        //  not lock is still queued, and so is an entry whose line had moved
+        //  on by the time we held the lock -- the caller has to be able to
+        //  say why, or an operator sees "nothing removed" and concludes the
+        //  entry was already gone.
         return {
-            removed: removed.filter(e => !skipped.includes(e)),
+            removed: actuallyRemoved,
             busy: Array.from(new Set(skipped.map(e => e.flowFile))),
         };
     }
@@ -508,10 +513,11 @@ class BsoSpool {
     async _pruneFromFlowFile(flowPath, entries) {
         const content = await fsp.readFile(flowPath, 'utf8').catch(() => null);
         if (null === content) {
-            return;
+            return [];
         }
 
         const lines = content.split('\n');
+        const spliced = [];
 
         //  Descending, so removing one cannot shift the index of the next.
         for (const entry of entries.slice().sort((a, b) => b.lineIdx - a.lineIdx)) {
@@ -523,6 +529,7 @@ class BsoSpool {
                 lines[entry.lineIdx].trim() === entry.line
             ) {
                 lines.splice(entry.lineIdx, 1);
+                spliced.push(entry);
             }
         }
 
@@ -538,6 +545,11 @@ class BsoSpool {
             //  time it queues something, same as a normal drain.
             await fsp.unlink(flowPath).catch(() => {});
         }
+
+        //  Only what actually went. Reporting an entry we decided not to
+        //  touch would tell the operator a file had been dealt with while it
+        //  is still sitting in the node's queue.
+        return spliced;
     }
 
     // ── Inbound file handling ────────────────────────────────────────────────

--- a/core/binkp/bso_spool.js
+++ b/core/binkp/bso_spool.js
@@ -15,6 +15,7 @@ const {
     DEFAULT_NETWORK_DIR_NAME,
 } = require('../bso_util');
 const bsoLock = require('../bso_lock');
+const { withFlowFileLock, isBusyError } = require('../bso_lock');
 
 // In priority order (highest first)
 const FLOW_EXTS = ['ilo', 'clo', 'dlo', 'flo', 'hlo'];
@@ -294,7 +295,7 @@ class BsoSpool {
             if (seen.has(key)) return;
 
             if (isFlow) {
-                if (!(await flowHasPending(filePath))) return;
+                if (!(await flowHasPending(filePath, addr))) return;
             } else {
                 // Direct-attach: zero-byte = poll flag, not mail
                 const stat = await fsp.stat(filePath).catch(() => null);
@@ -379,9 +380,19 @@ class BsoSpool {
                 //  warning that actually marks a change of state.
                 const resolved = await resolveFlowRefQuiet(filePath, ref);
 
+                //  Absent is not the same as unreadable, and only the first
+                //  is safe to prune. A file behind a permissions problem, a
+                //  dead NFS mount or an exhausted descriptor table is still
+                //  there and still owed to the node; dropping its reference
+                //  would discard mail over a transient fault.
+                let status = 'pending';
+                if (!resolved) {
+                    status = (await isGenuinelyAbsent(ref)) ? 'missing' : 'unreadable';
+                }
+
                 add(addr, {
                     kind: 'flow',
-                    status: resolved ? 'pending' : 'missing',
+                    status,
                     path: resolved ? resolved.path : ref,
                     size: resolved ? resolved.stat.size : null,
                     timestamp: resolved ? Math.floor(resolved.stat.mtimeMs / 1000) : null,
@@ -407,7 +418,7 @@ class BsoSpool {
     //  nobody asked us to discard. With |dryRun| nothing is written and the
     //  caller is told what would go.
     //
-    async pruneMissingRefs(addr, { dryRun = true } = {}) {
+    async pruneMissingRefs(addr, { dryRun = true, lockTimeoutMs } = {}) {
         const target = (await this.inspectOutbound()).find(n =>
             sameAddress(n.address, addr)
         );
@@ -417,7 +428,7 @@ class BsoSpool {
         );
 
         if (dryRun || 0 === removed.length) {
-            return removed;
+            return { removed, busy: [] };
         }
 
         //  Group by flow file so each is rewritten once, and go bottom-up so
@@ -430,42 +441,103 @@ class BsoSpool {
             byFlow.get(entry.flowFile).push(entry);
         }
 
+        const skipped = [];
+
         for (const [flowPath, entries] of byFlow) {
-            await this._withFlowFileWrite(flowPath, async () => {
-                const content = await fsp.readFile(flowPath, 'utf8').catch(() => null);
-                if (null === content) {
-                    return;
-                }
-                const lines = content.split('\n');
-
-                for (const entry of entries.sort((a, b) => b.lineIdx - a.lineIdx)) {
-                    //  Only if the line is still the one we reported on --
-                    //  ftn_bso may have appended, or a session marked
-                    //  something, since the listing was taken.
-                    if (
-                        entry.lineIdx < lines.length &&
-                        lines[entry.lineIdx].trim() === entry.line
-                    ) {
-                        lines.splice(entry.lineIdx, 1);
+            //  The in-process chain is not enough here. oputil runs as its own
+            //  process, so it shares no state with the running BBS -- and
+            //  ftn_bso appends refs, and a session marks them sent, under the
+            //  FTS-5005 .bsy lock (see #749). Rewriting outside it means a
+            //  ref queued between our read and our write is dropped on the
+            //  floor, which is precisely the outbound loss that lock exists
+            //  to prevent. Both guards: .bsy against other processes, the
+            //  chain against ourselves.
+            const gotLock = await new Promise(resolve => {
+                withFlowFileLock(
+                    flowPath,
+                    {
+                        staleMaxAgeMs: this._staleLockMaxAgeMs,
+                        timeoutMs: lockTimeoutMs,
+                        log: Log,
+                    },
+                    done => {
+                        this._withFlowFileWrite(flowPath, () =>
+                            this._pruneFromFlowFile(flowPath, entries)
+                        )
+                            .then(() => done(null))
+                            .catch(err => done(err));
+                    },
+                    err => {
+                        if (err && isBusyError(err)) {
+                            return resolve(false);
+                        }
+                        if (err) {
+                            Log.warn(
+                                { path: flowPath, error: err.message },
+                                '[BinkP/BSO] Could not prune flow file'
+                            );
+                            return resolve(false);
+                        }
+                        resolve(true);
                     }
-                }
-
-                const hasLive = lines.some(l => {
-                    const t = l.trim();
-                    return t.length > 0 && '~' !== t[0];
-                });
-
-                if (hasLive) {
-                    await fsp.writeFile(flowPath, lines.join('\n'), 'utf8');
-                } else {
-                    //  Nothing left to send; ftn_bso recreates the flow file
-                    //  next time it queues something, same as a normal drain.
-                    await fsp.unlink(flowPath).catch(() => {});
-                }
+                );
             });
+
+            if (!gotLock) {
+                for (const entry of entries) {
+                    skipped.push(entry);
+                }
+            }
         }
 
-        return removed;
+        //  Anything we could not take the lock for is still queued, so it
+        //  must not be reported as removed -- and the caller has to be able
+        //  to say why, or an operator sees "nothing removed" and concludes
+        //  the entry was already gone.
+        return {
+            removed: removed.filter(e => !skipped.includes(e)),
+            busy: Array.from(new Set(skipped.map(e => e.flowFile))),
+        };
+    }
+
+    //
+    //  Remove |entries| from |flowPath|. Called with the flow file's .bsy
+    //  lock held, so the read below is the file as it stands and nothing can
+    //  append between it and the write.
+    //
+    async _pruneFromFlowFile(flowPath, entries) {
+        const content = await fsp.readFile(flowPath, 'utf8').catch(() => null);
+        if (null === content) {
+            return;
+        }
+
+        const lines = content.split('\n');
+
+        //  Descending, so removing one cannot shift the index of the next.
+        for (const entry of entries.slice().sort((a, b) => b.lineIdx - a.lineIdx)) {
+            //  Only if the line is still the one we reported on -- the
+            //  listing was taken before the lock, so ftn_bso may have
+            //  appended or a session may have marked something since.
+            if (
+                entry.lineIdx < lines.length &&
+                lines[entry.lineIdx].trim() === entry.line
+            ) {
+                lines.splice(entry.lineIdx, 1);
+            }
+        }
+
+        const hasLive = lines.some(l => {
+            const t = l.trim();
+            return t.length > 0 && '~' !== t[0];
+        });
+
+        if (hasLive) {
+            await fsp.writeFile(flowPath, lines.join('\n'), 'utf8');
+        } else {
+            //  Nothing left to send; ftn_bso recreates the flow file next
+            //  time it queues something, same as a normal drain.
+            await fsp.unlink(flowPath).catch(() => {});
+        }
     }
 
     // ── Inbound file handling ────────────────────────────────────────────────
@@ -860,14 +932,14 @@ function uniquePacketName(filePath) {
 //  poller would dial it every cycle only to transfer nothing and log a clean
 //  "Session complete".
 //
-async function flowHasPending(flowPath) {
+async function flowHasPending(flowPath, addr) {
     const content = await fsp.readFile(flowPath, 'utf8').catch(() => '');
     for (const line of content.split('\n')) {
         const trimmed = line.trim();
         if (!trimmed || trimmed[0] === '~') continue;
 
         const ref = /^[\^#-]/.test(trimmed) ? trimmed.slice(1) : trimmed;
-        if (await resolveFlowRef(flowPath, ref)) return true;
+        if (await resolveFlowRef(flowPath, ref, addr)) return true;
     }
     return false;
 }
@@ -893,7 +965,16 @@ async function resolveFlowRef(flowPath, ref, addr, { quiet = false } = {}) {
         const now = Date.now();
         const last = warnedFlowRefs.get(key);
         if (last && now - last < FLOW_REF_WARN_REPEAT_MS) return;
-        if (warnedFlowRefs.size >= MAX_WARNED_FLOW_REFS) warnedFlowRefs.clear();
+        if (warnedFlowRefs.size >= MAX_WARNED_FLOW_REFS) {
+            //  Drop what has aged out first. Clearing wholesale would throw
+            //  away entries warned seconds ago and let them repeat straight
+            //  away, which on a spool with many dangling refs turns the
+            //  throttle into a firehose.
+            for (const [k, when] of warnedFlowRefs) {
+                if (now - when >= FLOW_REF_WARN_REPEAT_MS) warnedFlowRefs.delete(k);
+            }
+            if (warnedFlowRefs.size >= MAX_WARNED_FLOW_REFS) warnedFlowRefs.clear();
+        }
         warnedFlowRefs.set(key, now);
         Log.warn(fields, message);
     };
@@ -964,6 +1045,20 @@ function sameAddress(a, b) {
         a.node === b.node &&
         (a.point || 0) === (b.point || 0)
     );
+}
+
+//  True when the path is absent rather than merely unreachable. ENOENT is
+//  "no such file"; ENOTDIR is a component of the path not being a directory,
+//  which for a stored absolute path means the same thing. Anything else --
+//  EACCES, EIO, ESTALE, EMFILE -- says the file may well exist and we simply
+//  could not look.
+async function isGenuinelyAbsent(p) {
+    try {
+        await fsp.stat(p);
+        return false;
+    } catch (err) {
+        return 'ENOENT' === err.code || 'ENOTDIR' === err.code;
+    }
 }
 
 //  Resolve without logging. The operator's listing asks about every entry

--- a/core/binkp/util.js
+++ b/core/binkp/util.js
@@ -76,6 +76,7 @@ function buildSpool(config) {
         networks: _.get(config, 'messageNetworks.ftn.networks', {}),
         defaultNetwork: ftnBsoCfg.defaultNetwork,
         staleLockMaxAgeMs: _.get(ftnBsoCfg, 'binkp.staleLockMaxAgeMs'),
+        flowRefWarnRepeatMs: _.get(ftnBsoCfg, 'binkp.flowRefWarnRepeatMs'),
     });
 }
 

--- a/core/config_default.js
+++ b/core/config_default.js
@@ -1202,6 +1202,19 @@ module.exports = () => {
                     staleLockMaxAgeMs: 30 * 60 * 1000,
 
                     //
+                    //  How often to repeat the warning about a queued file
+                    //  that no longer exists on disk. The reference cannot be
+                    //  sent and will not fix itself, so this is a standing
+                    //  fault rather than an event -- saying it once per
+                    //  process meant it scrolled away and the node quietly
+                    //  never got its file. See "oputil bso status".
+                    //
+                    //  Default: 1 hour. Raise it if a known-dangling
+                    //  reference you have not dealt with yet is noisy.
+                    //
+                    flowRefWarnRepeatMs: 60 * 60 * 1000,
+
+                    //
                     //  Inbound temp file sweep. Inbound files are buffered as
                     //  binkp_in_*.dt under |tempDir| (defaults to OS temp) and
                     //  renamed into the inbound spool on successful receipt.

--- a/core/oputil/oputil_bso.js
+++ b/core/oputil/oputil_bso.js
@@ -40,6 +40,14 @@ function makeSpool() {
     const config = Config();
     const bsoConfig = config.scannerTossers?.ftn_bso || {};
 
+    if (!bsoConfig.paths?.outbound) {
+        //  Without this every command dies in the directory walk with a bare
+        //  TypeError, which says nothing about what is actually missing.
+        throw new Error(
+            'scannerTossers.ftn_bso.paths.outbound is not configured; there is no outbound spool to inspect'
+        );
+    }
+
     return new BsoSpool({
         paths: bsoConfig.paths || {},
         networks: config.messageNetworks?.ftn?.networks || {},
@@ -157,10 +165,12 @@ function cmdStatus() {
         console.info('-'.repeat(47));
 
         let missingTotal = 0;
+        let unreadableTotal = 0;
         for (const node of interesting) {
             const live = liveEntries(node);
             const missing = live.filter(e => 'missing' === e.status);
             missingTotal += missing.length;
+            unreadableTotal += live.filter(e => 'unreadable' === e.status).length;
 
             console.info(
                 `${pad(node.address.toString(), 22)}${padLeft(
@@ -185,6 +195,18 @@ function cmdStatus() {
             );
             console.info('satisfied the files are really gone and not merely offline —');
             console.info('"oputil bso prune <address> --yes" to drop them.');
+        }
+
+        if (unreadableTotal > 0) {
+            console.info('');
+            console.info(
+                `${unreadableTotal} queued ${
+                    1 === unreadableTotal ? 'entry could' : 'entries could'
+                } not be read — a permissions problem, or a`
+            );
+            console.info(
+                'volume that is not mounted. Those are never pruned; see "bso list".'
+            );
         }
     });
 }
@@ -211,13 +233,29 @@ function cmdList(addressArg) {
 
         console.info(`${addr.toString()}`);
         for (const entry of live) {
-            const flag = 'missing' === entry.status ? 'MISSING' : 'ok';
+            const flag =
+                {
+                    missing: 'MISSING',
+                    unreadable: 'UNREADABLE',
+                }[entry.status] || 'ok';
             console.info(
                 `  ${pad(flag, 9)}${padLeft(friendlySize(entry.size), 10)}${padLeft(
                     friendlyAge(entry.timestamp),
                     8
                 )}  ${entry.path}`
             );
+        }
+
+        const unreadable = live.filter(e => 'unreadable' === e.status);
+        if (unreadable.length > 0) {
+            console.info('');
+            console.info(
+                `${unreadable.length} could not be read at all — a permissions problem, or`
+            );
+            console.info(
+                'a volume that is not mounted. Those are not pruned: the file may well'
+            );
+            console.info('still be there. Fix the access and they will send.');
         }
 
         const missing = live.filter(e => 'missing' === e.status);
@@ -249,7 +287,21 @@ function cmdPrune(addressArg) {
     const write = true === argv.yes;
 
     withSpool(async spool => {
-        const removed = await spool.pruneMissingRefs(addr, { dryRun: !write });
+        const { removed, busy } = await spool.pruneMissingRefs(addr, {
+            dryRun: !write,
+        });
+
+        if (busy.length > 0) {
+            //  Not the same as "nothing to do": the entries are still there,
+            //  we simply were not allowed to touch the file.
+            console.info(
+                `${addr.toString()} is busy — a mail session or the tosser holds its`
+            );
+            console.info('lock. Nothing was changed; try again in a moment.');
+            if (0 === removed.length) {
+                return;
+            }
+        }
 
         if (0 === removed.length) {
             console.info(`Nothing to prune for ${addr.toString()}.`);

--- a/core/oputil/oputil_bso.js
+++ b/core/oputil/oputil_bso.js
@@ -1,0 +1,297 @@
+/* jslint node: true */
+/* eslint-disable no-console */
+'use strict';
+
+/**
+ * oputil_bso.js — BSO outbound spool inspection
+ *
+ * Answers the question an operator otherwise has to answer by reading the
+ * spool by hand: who is not collecting their mail, how long has it been
+ * sitting there, and is any of it queued against a file that no longer
+ * exists?
+ *
+ * A flow file stores an absolute path (FTS-5005.003 §3.1). When the file it
+ * names is deleted or moved -- a file base tidied, an area reorganised, a
+ * forwarded TIC payload removed -- the entry can never be sent. The spool
+ * skips it and says so periodically, but nothing removes it, and nothing but
+ * this told the operator which node was affected.
+ *
+ * Commands:
+ *   bso status                 Every node with outbound, and what is wrong
+ *   bso list <address>         Every queued entry for one node
+ *   bso prune <address>        Drop entries whose file is gone (--yes to write)
+ */
+
+const {
+    printUsageAndSetExitCode,
+    argv,
+    ExitCodes,
+    initConfigAndDatabases,
+} = require('./oputil_common.js');
+const { getHelpFor } = require('./oputil_help.js');
+
+exports.handleBsoCommand = handleBsoCommand;
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+function makeSpool() {
+    const Config = require('../config.js').get;
+    const { BsoSpool } = require('../binkp/bso_spool.js');
+    const config = Config();
+    const bsoConfig = config.scannerTossers?.ftn_bso || {};
+
+    return new BsoSpool({
+        paths: bsoConfig.paths || {},
+        networks: config.messageNetworks?.ftn?.networks || {},
+        defaultNetwork: bsoConfig.defaultNetwork,
+    });
+}
+
+function parseAddress(s) {
+    const Address = require('../ftn_address.js');
+    const addr = Address.fromString(s);
+    //  fromString hands back an Address either way; a string it could not
+    //  parse leaves the required parts undefined.
+    if (!addr || undefined === addr.net || undefined === addr.node) {
+        return null;
+    }
+    return addr;
+}
+
+function friendlySize(bytes) {
+    if (null === bytes || undefined === bytes) {
+        return '-';
+    }
+    const units = ['B', 'KB', 'MB', 'GB'];
+    let n = bytes;
+    let u = 0;
+    while (n >= 1024 && u < units.length - 1) {
+        n /= 1024;
+        ++u;
+    }
+    return `${0 === u ? n : n.toFixed(1)} ${units[u]}`;
+}
+
+//  Compact enough to keep a column: "3d", "4h", "12m". moment's fromNow()
+//  says "a few seconds", which is friendlier prose and useless in a table.
+function friendlyAge(timestamp) {
+    if (!timestamp) {
+        return '-';
+    }
+
+    const secs = Math.max(0, Math.floor(Date.now() / 1000) - timestamp);
+    if (secs < 60) {
+        return `${secs}s`;
+    }
+    if (secs < 3600) {
+        return `${Math.floor(secs / 60)}m`;
+    }
+    if (secs < 86400) {
+        return `${Math.floor(secs / 3600)}h`;
+    }
+    return `${Math.floor(secs / 86400)}d`;
+}
+
+function oldestTimestamp(entries) {
+    const stamps = entries.filter(e => e.timestamp).map(e => e.timestamp);
+    return stamps.length ? Math.min(...stamps) : null;
+}
+
+function pad(s, width) {
+    s = String(s);
+    return s.length >= width ? s : s + ' '.repeat(width - s.length);
+}
+
+function padLeft(s, width) {
+    s = String(s);
+    return s.length >= width ? s : ' '.repeat(width - s.length) + s;
+}
+
+//  Entries an operator is waiting on, i.e. not the ones already sent.
+function liveEntries(node) {
+    return node.entries.filter(e => 'sent' !== e.status);
+}
+
+function withSpool(handler) {
+    initConfigAndDatabases(err => {
+        if (err) {
+            console.error(err.message);
+            process.exitCode = ExitCodes.ERROR;
+            return;
+        }
+
+        let spool;
+        try {
+            spool = makeSpool();
+        } catch (e) {
+            console.error(`Could not read the outbound spool: ${e.message}`);
+            process.exitCode = ExitCodes.ERROR;
+            return;
+        }
+
+        handler(spool).catch(e => {
+            console.error(e.message);
+            process.exitCode = ExitCodes.ERROR;
+        });
+    });
+}
+
+// ─── status ──────────────────────────────────────────────────────────────────
+
+function cmdStatus() {
+    withSpool(async spool => {
+        const nodes = await spool.inspectOutbound();
+        const interesting = nodes.filter(n => liveEntries(n).length > 0);
+
+        if (0 === interesting.length) {
+            console.info('Nothing queued in the outbound.');
+            return;
+        }
+
+        console.info(
+            `${pad('Node', 22)}${padLeft('Queued', 8)}${padLeft(
+                'Missing',
+                9
+            )}${padLeft('Oldest', 8)}`
+        );
+        console.info('-'.repeat(47));
+
+        let missingTotal = 0;
+        for (const node of interesting) {
+            const live = liveEntries(node);
+            const missing = live.filter(e => 'missing' === e.status);
+            missingTotal += missing.length;
+
+            console.info(
+                `${pad(node.address.toString(), 22)}${padLeft(
+                    live.length,
+                    8
+                )}${padLeft(missing.length || '', 9)}${padLeft(
+                    friendlyAge(oldestTimestamp(live)),
+                    8
+                )}`
+            );
+        }
+
+        if (missingTotal > 0) {
+            console.info('');
+            console.info(
+                `${missingTotal} queued ${
+                    1 === missingTotal ? 'entry names a file' : 'entries name files'
+                } that no longer exist. Those will never be sent.`
+            );
+            console.info(
+                'Use "oputil bso list <address>" to see them, and — once you are'
+            );
+            console.info('satisfied the files are really gone and not merely offline —');
+            console.info('"oputil bso prune <address> --yes" to drop them.');
+        }
+    });
+}
+
+// ─── list ────────────────────────────────────────────────────────────────────
+
+function cmdList(addressArg) {
+    const addr = parseAddress(addressArg);
+    if (!addr) {
+        return printUsageAndSetExitCode(getHelpFor('Bso'), ExitCodes.BAD_ARGS);
+    }
+
+    withSpool(async spool => {
+        const { sameAddress } = require('../binkp/bso_spool.js');
+        const node = (await spool.inspectOutbound()).find(n =>
+            sameAddress(n.address, addr)
+        );
+        const live = node ? liveEntries(node) : [];
+
+        if (0 === live.length) {
+            console.info(`Nothing queued for ${addr.toString()}.`);
+            return;
+        }
+
+        console.info(`${addr.toString()}`);
+        for (const entry of live) {
+            const flag = 'missing' === entry.status ? 'MISSING' : 'ok';
+            console.info(
+                `  ${pad(flag, 9)}${padLeft(friendlySize(entry.size), 10)}${padLeft(
+                    friendlyAge(entry.timestamp),
+                    8
+                )}  ${entry.path}`
+            );
+        }
+
+        const missing = live.filter(e => 'missing' === e.status);
+        if (missing.length > 0) {
+            console.info('');
+            console.info(
+                `${missing.length} of these ${
+                    1 === missing.length ? 'names a file' : 'name files'
+                } that is not on disk. ${addr.toString()} will never receive`
+            );
+            console.info(
+                `${1 === missing.length ? 'it' : 'them'} while the reference stands.`
+            );
+        }
+    });
+}
+
+// ─── prune ───────────────────────────────────────────────────────────────────
+
+function cmdPrune(addressArg) {
+    const addr = parseAddress(addressArg);
+    if (!addr) {
+        return printUsageAndSetExitCode(getHelpFor('Bso'), ExitCodes.BAD_ARGS);
+    }
+
+    //  Default to a dry run. Removing a queue entry is the one thing in here
+    //  that discards something, and an unreachable file store looks exactly
+    //  like a deleted one from here.
+    const write = true === argv.yes;
+
+    withSpool(async spool => {
+        const removed = await spool.pruneMissingRefs(addr, { dryRun: !write });
+
+        if (0 === removed.length) {
+            console.info(`Nothing to prune for ${addr.toString()}.`);
+            return;
+        }
+
+        console.info(
+            `${write ? 'Removed' : 'Would remove'} ${removed.length} ${
+                1 === removed.length ? 'entry' : 'entries'
+            } for ${addr.toString()}:`
+        );
+        for (const entry of removed) {
+            console.info(`  ${entry.path}`);
+        }
+
+        if (!write) {
+            console.info('');
+            console.info('Nothing has been changed. Re-run with --yes to remove.');
+        }
+    });
+}
+
+// ─── entry point ─────────────────────────────────────────────────────────────
+
+function handleBsoCommand() {
+    if (argv.help) {
+        return printUsageAndSetExitCode(getHelpFor('Bso'), ExitCodes.SUCCESS);
+    }
+
+    const action = argv._[1];
+
+    switch (action) {
+        case 'status':
+            return cmdStatus();
+
+        case 'list':
+            return cmdList(argv._[2]);
+
+        case 'prune':
+            return cmdPrune(argv._[2]);
+
+        default:
+            return printUsageAndSetExitCode(getHelpFor('Bso'), ExitCodes.BAD_COMMAND);
+    }
+}

--- a/core/oputil/oputil_bso.js
+++ b/core/oputil/oputil_bso.js
@@ -29,6 +29,7 @@ const {
     initConfigAndDatabases,
 } = require('./oputil_common.js');
 const { getHelpFor } = require('./oputil_help.js');
+const { formatByteSize, pad } = require('../string_util.js');
 
 exports.handleBsoCommand = handleBsoCommand;
 
@@ -66,18 +67,13 @@ function parseAddress(s) {
     return addr;
 }
 
+//  A missing or unreadable entry has no size to show; anything else goes
+//  through the shared formatter, which knows the units this does not.
 function friendlySize(bytes) {
     if (null === bytes || undefined === bytes) {
         return '-';
     }
-    const units = ['B', 'KB', 'MB', 'GB'];
-    let n = bytes;
-    let u = 0;
-    while (n >= 1024 && u < units.length - 1) {
-        n /= 1024;
-        ++u;
-    }
-    return `${0 === u ? n : n.toFixed(1)} ${units[u]}`;
+    return formatByteSize(bytes, true, 1);
 }
 
 //  Compact enough to keep a column: "3d", "4h", "12m". moment's fromNow()
@@ -105,14 +101,12 @@ function oldestTimestamp(entries) {
     return stamps.length ? Math.min(...stamps) : null;
 }
 
-function pad(s, width) {
-    s = String(s);
-    return s.length >= width ? s : s + ' '.repeat(width - s.length);
+function padLeft(s, width) {
+    return pad(String(s), width, ' ', 'right');
 }
 
-function padLeft(s, width) {
-    s = String(s);
-    return s.length >= width ? s : ' '.repeat(width - s.length) + s;
+function padRight(s, width) {
+    return pad(String(s), width, ' ', 'left');
 }
 
 //  Entries an operator is waiting on, i.e. not the ones already sent.
@@ -157,7 +151,7 @@ function cmdStatus() {
         }
 
         console.info(
-            `${pad('Node', 22)}${padLeft('Queued', 8)}${padLeft(
+            `${padRight('Node', 22)}${padLeft('Queued', 8)}${padLeft(
                 'Missing',
                 9
             )}${padLeft('Oldest', 8)}`
@@ -173,7 +167,7 @@ function cmdStatus() {
             unreadableTotal += live.filter(e => 'unreadable' === e.status).length;
 
             console.info(
-                `${pad(node.address.toString(), 22)}${padLeft(
+                `${padRight(node.address.toString(), 22)}${padLeft(
                     live.length,
                     8
                 )}${padLeft(missing.length || '', 9)}${padLeft(
@@ -239,7 +233,7 @@ function cmdList(addressArg) {
                     unreadable: 'UNREADABLE',
                 }[entry.status] || 'ok';
             console.info(
-                `  ${pad(flag, 9)}${padLeft(friendlySize(entry.size), 10)}${padLeft(
+                `  ${padRight(flag, 9)}${padLeft(friendlySize(entry.size), 10)}${padLeft(
                     friendlyAge(entry.timestamp),
                     8
                 )}  ${entry.path}`
@@ -287,8 +281,12 @@ function cmdPrune(addressArg) {
     const write = true === argv.yes;
 
     withSpool(async spool => {
+        const Config = require('../config.js').get;
         const { removed, busy } = await spool.pruneMissingRefs(addr, {
             dryRun: !write,
+            //  Same knob ftn_bso waits on, so an operator and the tosser
+            //  agree about how long a busy node is worth waiting for.
+            lockTimeoutMs: Config().scannerTossers?.ftn_bso?.flowLockTimeoutMs,
         });
 
         if (busy.length > 0) {

--- a/core/oputil/oputil_help.js
+++ b/core/oputil/oputil_help.js
@@ -20,6 +20,7 @@ Commands:
   config                    Configuration management
   fb                        File base management
   mb                        Message base management
+  bso                       FTN/BSO outbound spool inspection
   ap                        ActivityPub management
   ssh                       SSH key management
   fat                       FAT disk image management
@@ -249,6 +250,37 @@ Actions:
 
 condition arguments:
   --force                     Force condition; overrides any existing settings`,
+    Bso: `usage: oputil.js bso <action> [<arguments>]
+
+Inspect the FTN/BSO outbound spool: who is waiting on mail, how long it has
+been waiting, and whether any of it is queued against a file that no longer
+exists.
+
+A flow file stores an absolute path. If the file it names is deleted or moved,
+that entry can never be sent -- the node simply never receives it. Those show
+as "MISSING" below.
+
+Actions:
+  status                      Every node with outbound, and what is wrong
+  list ADDRESS                Every queued entry for one node
+  prune ADDRESS               Drop entries whose file is gone
+
+prune arguments:
+  --yes                       Actually remove them; without this, prune only
+                              reports what it would do
+
+Pruning is never automatic and never happens without --yes: a file that is
+merely offline -- an unmounted store, a half-finished copy -- is
+indistinguishable from a deleted one here, and dropping the entry would
+discard mail that would otherwise have gone out once the file returned.
+Check that the file is really gone before pruning its reference.
+
+Examples:
+  oputil.js bso status
+  oputil.js bso list 1:218/701
+  oputil.js bso prune 1:218/701
+  oputil.js bso prune 1:218/701 --yes
+`,
     SSH: `usage: oputil.js ssh <action>
 
 Actions:

--- a/core/oputil/oputil_main.js
+++ b/core/oputil/oputil_main.js
@@ -10,6 +10,7 @@ const handleFileBaseCommand = require('./oputil_file_base.js').handleFileBaseCom
 const handleMessageBaseCommand =
     require('./oputil_message_base.js').handleMessageBaseCommand;
 const handleConfigCommand = require('./oputil_config.js').handleConfigCommand;
+const handleBsoCommand = require('./oputil_bso.js').handleBsoCommand;
 const handleApCommand = require('./activitypub').handleUserCommand;
 const handleSSHKeyCommand = require('./oputil_ssh_key.js').handleSSHKeyCommand;
 const handleFatCommand = require('./oputil_fat.js').handleFatCommand;
@@ -37,6 +38,8 @@ module.exports = function () {
             return handleFileBaseCommand();
         case 'mb':
             return handleMessageBaseCommand();
+        case 'bso':
+            return handleBsoCommand();
         case 'ap':
             return handleApCommand();
         case 'ssh':

--- a/docs/_docs/admin/oputil.md
+++ b/docs/_docs/admin/oputil.md
@@ -21,6 +21,7 @@ Commands:
   config                    Configuration management
   fb                        File base management
   mb                        Message base management
+  bso                       FTN/BSO outbound spool inspection
 ```
 
 Commands break up operations by groups:
@@ -31,6 +32,7 @@ Commands break up operations by groups:
 | `config`  | System configuration and maintenance |
 | `fb`      | File base configuration and management    |
 | `mb`      | Message base configuration and management |
+| `bso`     | FTN/BSO outbound spool inspection and queue hygiene |
 | `fat`     | FAT disk image inspection and modification |
 | `v86`     | Boot disk images in the v86 x86 emulator |
 
@@ -346,6 +348,78 @@ qwk-export arguments:
 When using the `import-areas` action, you will be prompted for any missing additional arguments described in "import-areas args".
 
 The format of the supplied file is determined by its **content**, not its extension: several networks ship a FILEBONE *file* echo list named `*.na`, and at least one ships its list with the columns reversed. `import-areas` skips `;`, `%` and `#` comment lines, tells you which lines it could not use, and declines a file it does not recognise rather than importing nonsense. A FILEBONE list is recognised as such and pointed at [`fb import-areas`](#importing-filegate-raid-style-areas). `AREAS.BBS` cannot be told from a plain area list by shape, so it is only assumed when the file is named `.bbs` or `--type bbs` is given.
+
+## BSO Outbound Inspection
+The `bso` command reports on the FidoNet-style (BSO) outbound spool: who is waiting on
+mail, how long it has been waiting, and whether any of it is queued against a file that
+no longer exists.
+
+```
+usage: oputil.js bso <action> [<arguments>]
+
+Actions:
+  status                      Every node with outbound, and what is wrong
+  list ADDRESS                Every queued entry for one node
+  prune ADDRESS               Drop entries whose file is gone
+
+prune arguments:
+  --yes                       Actually remove them; without this, prune only
+                              reports what it would do
+```
+
+### Missing files
+A flow file stores an **absolute path** to each file queued for a node
+([FTS-5005.003](http://ftsc.org/docs/fts-5005.003) §3.1). If that file is later deleted or
+moved — a file base tidied up, an area reorganised, a forwarded TIC payload removed — the
+entry can never be sent. The node simply never receives it.
+
+ENiGMA½ logs this periodically, naming the node and the file, but it cannot fix it for
+you: nothing else on the system knows whether the file is gone for good or merely
+offline. `bso status` is how you find them:
+
+```bash
+oputil.js bso status
+```
+```
+Node                    Queued  Missing  Oldest
+-----------------------------------------------
+1:218/701                    2        1     36s
+1:218/702                    1        1       -
+```
+
+Note that a node whose queued entries have *all* gone missing still appears here, even
+though the mailer correctly stops polling it — that node is exactly the one you need to
+know about.
+
+`bso list` shows the individual entries:
+
+```bash
+oputil.js bso list 1:218/701
+```
+```
+1:218/701
+  ok              4 B     36s  /enigma-bbs/mail/out/real.pkt
+  MISSING           -       -  /enigma-bbs/file_base/misc/vanished.zip
+```
+
+### Pruning
+Once you have established that a file really is gone — and is not simply on a volume that
+is not mounted, or mid-copy — `prune` removes its reference so the queue stops carrying
+it:
+
+```bash
+oputil.js bso prune 1:218/701          # reports what it would do; changes nothing
+oputil.js bso prune 1:218/701 --yes    # actually removes them
+```
+
+Pruning is never automatic and never happens without `--yes`. A temporarily unreachable
+file is indistinguishable from a deleted one at this level, and dropping the reference
+would discard mail that would otherwise have gone out once the file came back. If the
+file can be restored to the path the flow file names, do that instead — nothing needs
+pruning and the next poll ships it.
+
+Entries already sent are left alone, and a flow file with nothing left to send is removed
+entirely, exactly as it would be after a normal successful transfer.
 
 ## FAT Disk Image Management
 The `fat` command lets you inspect and modify raw FAT disk images directly — no running ENiGMA instance or database required. Useful for preparing and maintaining FreeDOS images used by the `v86_door` module.

--- a/docs/_docs/admin/oputil.md
+++ b/docs/_docs/admin/oputil.md
@@ -421,6 +421,14 @@ pruning and the next poll ships it.
 Entries already sent are left alone, and a flow file with nothing left to send is removed
 entirely, exactly as it would be after a normal successful transfer.
 
+Pruning takes the node's FTS-5005 `.bsy` lock first, so it is safe to run against a live
+system: if a mail session or the tosser is working on that node, prune says so and changes
+nothing rather than writing over what they are doing.
+
+A file that exists but cannot be read — a permissions problem, or a volume that is not
+mounted — is reported as `UNREADABLE` rather than `MISSING`, and is never pruned. That
+file is still there and still owed to the node; fix the access and it will send.
+
 ## FAT Disk Image Management
 The `fat` command lets you inspect and modify raw FAT disk images directly — no running ENiGMA instance or database required. Useful for preparing and maintaining FreeDOS images used by the `v86_door` module.
 

--- a/docs/_docs/messageareas/binkp.md
+++ b/docs/_docs/messageareas/binkp.md
@@ -156,6 +156,14 @@ The default is 6× the internal session timeout (5 minutes), giving a generous s
 
 The same `.bsy` files are honoured by external mailers such as Binkd, and by the ENiGMA½ *tosser* when it queues outbound — see [`flowLockTimeoutMs`](#flowlocktimeoutms) below.
 
+#### `binkp.flowRefWarnRepeatMs`
+
+A BSO flow file stores an **absolute path** to each file queued for a node. If that file is later deleted or moved, the entry can never be sent — the node simply never receives it. ENiGMA½ warns about this, naming the node and the file.
+
+`flowRefWarnRepeatMs` (default `60 * 60 * 1000`, i.e. 1 hour) is how often that warning repeats for the same reference. It repeats because the condition is a standing fault rather than an event: nothing fixes it on its own, and saying it once per process meant it scrolled away long before anyone looked.
+
+Raise it if you have a dangling reference you already know about and have not dealt with yet. To see what is affected and act on it, use [`oputil bso status`]({{ site.baseurl }}/docs/admin/oputil.html) — and note that a node whose queued entries have *all* gone missing is deliberately not polled, so that command is the only place it shows up.
+
 #### `flowLockTimeoutMs`
 
 > :information_source: This one lives at `scannerTossers.ftn_bso.flowLockTimeoutMs`, **not** under `binkp` — it governs the tosser (the writer), not the mailer.
@@ -299,7 +307,7 @@ Both sides decide this the same way, by counting the command frames sent and rec
 | `nodes` (hosts, ports, passwords, `pull`, TLS) | next session, inbound or outbound | Immediately |
 | `freq` | next inbound session | Immediately |
 | `crashmailDebounceMs` | next crashmail burst | Immediately |
-| `tempDir`, `staleLockMaxAgeMs` | next session | Immediately |
+| `tempDir`, `staleLockMaxAgeMs`, `flowRefWarnRepeatMs` | next session | Immediately |
 | `flowLockTimeoutMs` (under `ftn_bso`) | next outbound queue | Immediately |
 | `ftn_bso` `paths` and `messageNetworks.ftn.networks` | next session or poll | Immediately |
 | `pullSchedule` | the pull timer | On reload — the timer is rebuilt |

--- a/test/binkp_bso_spool.test.js
+++ b/test/binkp_bso_spool.test.js
@@ -938,7 +938,7 @@ describe('BsoSpool — pruning missing references', () => {
         const { missing, flowPath } = await seed();
         const before = await fsp.readFile(flowPath, 'utf8');
 
-        const removed = await spool.pruneMissingRefs(TEST_ADDR);
+        const { removed } = await spool.pruneMissingRefs(TEST_ADDR);
 
         assert.deepEqual(
             removed.map(e => e.path),
@@ -961,7 +961,7 @@ describe('BsoSpool — pruning missing references', () => {
     it('removes only the missing entries when told to', async () => {
         const { real, missing, done, flowPath } = await seed();
 
-        const removed = await spool.pruneMissingRefs(TEST_ADDR, { dryRun: false });
+        const { removed } = await spool.pruneMissingRefs(TEST_ADDR, { dryRun: false });
         assert.deepEqual(
             removed.map(e => e.path),
             [missing]
@@ -1004,12 +1004,114 @@ describe('BsoSpool — pruning missing references', () => {
         );
     });
 
+    it('removes several missing entries from one flow file', async () => {
+        //  Splicing shifts every later index, so the removals have to run
+        //  bottom-up. With one entry that is invisible.
+        const real = path.join(outboundDir(tmpDir), 'survivor.pkt');
+        await fsp.writeFile(real, 'KEEP');
+        const a = path.join(tmpDir, 'gone', 'a.zip');
+        const b = path.join(tmpDir, 'gone', 'b.zip');
+        const c = path.join(tmpDir, 'gone', 'c.zip');
+        const flowPath = path.join(outboundDir(tmpDir), '00680001.flo');
+        await fsp.writeFile(flowPath, `^${a}\n^${real}\n^${b}\n^${c}\n`);
+
+        const { removed } = await spool.pruneMissingRefs(TEST_ADDR, { dryRun: false });
+        assert.deepEqual(removed.map(e => e.path).sort(), [a, b, c].sort());
+
+        const remaining = (await fsp.readFile(flowPath, 'utf8'))
+            .split('\n')
+            .map(l => l.trim())
+            .filter(Boolean);
+        assert.deepEqual(remaining, [`^${real}`], 'only the real file may remain');
+    });
+
+    it('leaves the flow file alone when another process holds the lock', async () => {
+        //  oputil runs as its own process, so the in-process write chain says
+        //  nothing about what the running BBS is doing. ftn_bso appends refs
+        //  and sessions mark them sent under the FTS-5005 .bsy lock; rewriting
+        //  outside it drops whatever was queued in between (see #749).
+        const bsoLock = require('../core/bso_lock');
+
+        const missing = path.join(tmpDir, 'gone', 'locked.zip');
+        const flowPath = path.join(outboundDir(tmpDir), '00680001.flo');
+        await fsp.writeFile(flowPath, `^${missing}\n`);
+
+        const bsyPath = bsoLock.bsyPathForFlowFile(flowPath);
+        assert.equal(
+            await bsoLock.acquire(bsyPath, { staleMaxAgeMs: 600000 }),
+            true,
+            'test could not take the lock it means to hold'
+        );
+
+        try {
+            const result = await spool.pruneMissingRefs(TEST_ADDR, {
+                dryRun: false,
+                lockTimeoutMs: 50,
+            });
+            assert.deepEqual(result.removed, [], 'nothing may be reported as removed');
+            assert.deepEqual(result.busy, [flowPath], 'and the caller must be told why');
+            assert.ok(
+                (await fsp.readFile(flowPath, 'utf8')).includes(missing),
+                'the flow file must be left exactly as it was'
+            );
+        } finally {
+            await bsoLock.release(bsyPath);
+        }
+
+        //  ...and once the holder is done, it prunes normally.
+        assert.equal(
+            (await spool.pruneMissingRefs(TEST_ADDR, { dryRun: false })).removed.length,
+            1
+        );
+    });
+
+    it('will not prune a file it merely could not read', async () => {
+        //  ENOENT means gone. EACCES means still there and still owed to the
+        //  node -- pruning on that would discard mail over a transient fault.
+        const unreadableDir = path.join(tmpDir, 'noaccess');
+        await fsp.mkdir(unreadableDir, { recursive: true });
+        const hidden = path.join(unreadableDir, 'secret.zip');
+        await fsp.writeFile(hidden, 'DATA');
+
+        const flowPath = path.join(outboundDir(tmpDir), '00680001.flo');
+        await fsp.writeFile(flowPath, `^${hidden}\n`);
+
+        await fsp.chmod(unreadableDir, 0o000);
+        try {
+            //  Running as root defeats the permission bits entirely; skip
+            //  rather than assert something the platform will not honour.
+            const denied = await fsp
+                .stat(hidden)
+                .then(() => false)
+                .catch(err => 'EACCES' === err.code);
+            if (!denied) {
+                return;
+            }
+
+            const node = (await spool.inspectOutbound()).find(
+                n => n.address.net === TEST_ADDR.net && n.address.node === TEST_ADDR.node
+            );
+            assert.equal(node.entries[0].status, 'unreadable');
+
+            assert.deepEqual(
+                (await spool.pruneMissingRefs(TEST_ADDR, { dryRun: false })).removed,
+                [],
+                'an unreadable file must never be pruned'
+            );
+        } finally {
+            await fsp.chmod(unreadableDir, 0o755);
+        }
+    });
+
     it('says there is nothing to do for a node with no missing entries', async () => {
         const real = path.join(outboundDir(tmpDir), 'fine.pkt');
         await fsp.writeFile(real, 'FINE');
         await fsp.writeFile(path.join(outboundDir(tmpDir), '00680001.flo'), `^${real}\n`);
 
-        assert.deepEqual(await spool.pruneMissingRefs(TEST_ADDR, { dryRun: false }), []);
+        assert.deepEqual(
+            (await spool.pruneMissingRefs(TEST_ADDR, { dryRun: false })).removed,
+            []
+        );
     });
 });
 

--- a/test/binkp_bso_spool.test.js
+++ b/test/binkp_bso_spool.test.js
@@ -1103,6 +1103,47 @@ describe('BsoSpool — pruning missing references', () => {
         }
     });
 
+    it('does not claim to have removed an entry that had moved on', async () => {
+        //  The listing is taken before the lock, so a session can mark an
+        //  entry sent in between. The rewrite correctly leaves that line
+        //  alone -- but saying "removed" about it would tell the operator a
+        //  file had been dealt with while it is still in the node's queue.
+        const missing = path.join(tmpDir, 'gone', 'moved_on.zip');
+        const flowPath = path.join(outboundDir(tmpDir), '00680001.flo');
+        await fsp.writeFile(flowPath, `^${missing}\nkeepme\n`);
+
+        //  A listing whose line no longer matches what is on disk.
+        const stale = {
+            kind: 'flow',
+            status: 'missing',
+            path: missing,
+            flowFile: flowPath,
+            lineIdx: 0,
+            line: `^${path.join(tmpDir, 'gone', 'something_else.zip')}`,
+        };
+        const realInspect = spool.inspectOutbound.bind(spool);
+        spool.inspectOutbound = async () => [
+            {
+                address: new (require('../core/ftn_address'))(TEST_ADDR),
+                entries: [stale],
+            },
+        ];
+
+        try {
+            const { removed } = await spool.pruneMissingRefs(TEST_ADDR, {
+                dryRun: false,
+            });
+            assert.deepEqual(removed, [], 'nothing was actually removed, so say so');
+        } finally {
+            spool.inspectOutbound = realInspect;
+        }
+
+        assert.ok(
+            (await fsp.readFile(flowPath, 'utf8')).includes(missing),
+            'and the entry must still be there'
+        );
+    });
+
     it('says there is nothing to do for a node with no missing entries', async () => {
         const real = path.join(outboundDir(tmpDir), 'fine.pkt');
         await fsp.writeFile(real, 'FINE');

--- a/test/binkp_bso_spool.test.js
+++ b/test/binkp_bso_spool.test.js
@@ -902,6 +902,57 @@ describe('BsoSpool — reporting a missing reference', () => {
         assert.match(String(warned.fields.node), /104\/1/);
     });
 
+    it('says it once while the repeat window is open', async () => {
+        //  A poll every minute must not put a line in the log every minute.
+        //  |flowRefWarnRepeatMs| is a real operator knob (see config_default);
+        //  a short one here keeps the test honest without stubbing the clock,
+        //  which would shift time for everything else in the process too --
+        //  .bsy staleness is clock-based, so that coupling is not hypothetical.
+        const quiet = new BsoSpool(
+            Object.assign(makeConfig(tmpDir), { flowRefWarnRepeatMs: 60000 })
+        );
+        await fsp.writeFile(
+            path.join(outboundDir(tmpDir), '00680001.flo'),
+            `^${path.join(tmpDir, 'gone', 'repeat.zip')}\n`
+        );
+
+        const warnings = await captureWarnings(async () => {
+            await quiet.getOutboundFilesForNode(TEST_ADDR);
+            await quiet.getOutboundFilesForNode(TEST_ADDR);
+            await quiet.getOutboundFilesForNode(TEST_ADDR);
+        });
+
+        assert.equal(
+            warnings.filter(w => w.fields && 'repeat.zip' === w.fields.file).length,
+            1,
+            'three passes inside the window is still one warning'
+        );
+    });
+
+    it('says it again once the window has passed', async () => {
+        //  The regression that matters: a throttle stuck shut is the silence
+        //  this whole change exists to remove.
+        const chatty = new BsoSpool(
+            Object.assign(makeConfig(tmpDir), { flowRefWarnRepeatMs: 20 })
+        );
+        await fsp.writeFile(
+            path.join(outboundDir(tmpDir), '00680001.flo'),
+            `^${path.join(tmpDir, 'gone', 'again.zip')}\n`
+        );
+
+        const warnings = await captureWarnings(async () => {
+            await chatty.getOutboundFilesForNode(TEST_ADDR);
+            await new Promise(r => setTimeout(r, 60)); //  3x the window
+            await chatty.getOutboundFilesForNode(TEST_ADDR);
+        });
+
+        assert.equal(
+            warnings.filter(w => w.fields && 'again.zip' === w.fields.file).length,
+            2,
+            'a standing fault has to keep saying so'
+        );
+    });
+
     it('reports each missing file, not just the first one seen', async () => {
         const one = path.join(tmpDir, 'gone', 'one.zip');
         const two = path.join(tmpDir, 'gone', 'two.zip');

--- a/test/binkp_bso_spool.test.js
+++ b/test/binkp_bso_spool.test.js
@@ -774,6 +774,245 @@ describe('BsoSpool — dangling and rescued flow references', () => {
 //  case name, so such a node was reported as pending and then had nothing
 //  queued for it: a poll loop that dialled every cycle and never shipped.
 
+//
+//  The operator-facing view of the outbound — issue #754.
+//
+//  A flow file stores an absolute path, so a file that is deleted or moved
+//  leaves an entry that can never be sent. The spool skips it, and
+//  getNodesWithPendingMail deliberately hides a node whose entries have all
+//  gone that way, so the poller does not dial someone it has nothing to give.
+//  That is right for the poller and wrong for the operator: the node it hides
+//  is precisely the one somebody needs to be told about.
+//
+describe('BsoSpool — inspecting the outbound', () => {
+    beforeEach(cleanOutbound);
+
+    const OTHER_ADDR = { zone: 1, net: 104, node: 2 }; //  00680002
+
+    function nodeIn(report, addr) {
+        return report.find(
+            n => n.address.net === addr.net && n.address.node === addr.node
+        );
+    }
+
+    it('shows a node the poller hides because everything it has is missing', async () => {
+        const flowPath = path.join(outboundDir(tmpDir), '00680001.flo');
+        await fsp.writeFile(flowPath, `^${path.join(tmpDir, 'gone', 'nope.pkt')}\n`);
+
+        //  The poller is right to skip it...
+        assert.deepEqual(await spool.getNodesWithPendingMail(), []);
+
+        //  ...and the operator still has to be able to see it.
+        const node = nodeIn(await spool.inspectOutbound(), TEST_ADDR);
+        assert.ok(node, 'the node must appear in the report');
+        assert.equal(node.entries.length, 1);
+        assert.equal(node.entries[0].status, 'missing');
+    });
+
+    it('separates what is sendable, missing, and already sent', async () => {
+        const real = path.join(outboundDir(tmpDir), 'real.pkt');
+        await fsp.writeFile(real, 'PKTDATA');
+
+        const missing = path.join(tmpDir, 'gone', 'vanished.zip');
+        const done = path.join(tmpDir, 'gone', 'already.pkt');
+        const flowPath = path.join(outboundDir(tmpDir), '00680001.flo');
+        await fsp.writeFile(flowPath, `^${real}\n^${missing}\n~${done}\n`);
+
+        const node = nodeIn(await spool.inspectOutbound(), TEST_ADDR);
+        const byStatus = Object.fromEntries(node.entries.map(e => [e.status, e]));
+
+        assert.equal(byStatus.pending.path, real);
+        assert.equal(byStatus.pending.size, 'PKTDATA'.length);
+        assert.equal(byStatus.pending.disposition, 'delete');
+        assert.equal(byStatus.missing.path, missing);
+        assert.equal(byStatus.missing.size, null, 'a missing file has no size');
+        assert.equal(byStatus.sent.path, done);
+    });
+
+    it('reports each node separately', async () => {
+        const real = path.join(outboundDir(tmpDir), 'one.pkt');
+        await fsp.writeFile(real, 'A');
+        await fsp.writeFile(path.join(outboundDir(tmpDir), '00680001.flo'), `^${real}\n`);
+        await fsp.writeFile(
+            path.join(outboundDir(tmpDir), '00680002.flo'),
+            `^${path.join(tmpDir, 'gone', 'other.zip')}\n`
+        );
+
+        const report = await spool.inspectOutbound();
+        assert.equal(nodeIn(report, TEST_ADDR).entries[0].status, 'pending');
+        assert.equal(nodeIn(report, OTHER_ADDR).entries[0].status, 'missing');
+    });
+});
+
+describe('BsoSpool — reporting a missing reference', () => {
+    beforeEach(cleanOutbound);
+
+    const loggerModule = require('../core/logger.js');
+
+    //  bso_spool captures logger.js's |log| object at require time, so the
+    //  stub has to be installed onto that same object rather than replacing
+    //  it wholesale.
+    function captureWarnings(work) {
+        const warnings = [];
+        const original = loggerModule.log.warn;
+        loggerModule.log.warn = (fields, message) => warnings.push({ fields, message });
+        return work()
+            .then(() => warnings)
+            .finally(() => {
+                loggerModule.log.warn = original;
+            });
+    }
+
+    it('names the node and the file, not just the stored path', async () => {
+        //  The operator's question is "who is missing what". A bare absolute
+        //  path answers neither, and was all this used to say.
+        const missing = path.join(tmpDir, 'gone', 'payload.zip');
+        await fsp.writeFile(
+            path.join(outboundDir(tmpDir), '00680001.flo'),
+            `^${missing}\n`
+        );
+
+        const warnings = await captureWarnings(() =>
+            spool.getOutboundFilesForNode(TEST_ADDR)
+        );
+
+        const warned = warnings.find(w => w.fields && w.fields.ref === missing);
+        assert.ok(warned, `expected a warning about ${missing}`);
+        assert.equal(warned.fields.file, 'payload.zip');
+        assert.match(String(warned.fields.node), /104\/1/);
+        assert.match(
+            warned.message,
+            /never receive/,
+            'it should say the file is not coming, not that a step was skipped'
+        );
+    });
+
+    it('derives the node from the flow file when sweeping the outbound', async () => {
+        //  getNodesWithPendingMail has no address in hand — it is working out
+        //  which nodes exist — so the label comes from the file name.
+        await fsp.writeFile(
+            path.join(outboundDir(tmpDir), '00680001.flo'),
+            `^${path.join(tmpDir, 'gone', 'swept.zip')}\n`
+        );
+
+        const warnings = await captureWarnings(() => spool.getNodesWithPendingMail());
+
+        const warned = warnings.find(w => w.fields && 'swept.zip' === w.fields.file);
+        assert.ok(warned, 'the sweep must report it too');
+        assert.match(String(warned.fields.node), /104\/1/);
+    });
+
+    it('reports each missing file, not just the first one seen', async () => {
+        const one = path.join(tmpDir, 'gone', 'one.zip');
+        const two = path.join(tmpDir, 'gone', 'two.zip');
+        await fsp.writeFile(
+            path.join(outboundDir(tmpDir), '00680001.flo'),
+            `^${one}\n^${two}\n`
+        );
+
+        const warnings = await captureWarnings(() =>
+            spool.getOutboundFilesForNode(TEST_ADDR)
+        );
+
+        const files = warnings
+            .filter(w => w.fields && w.fields.file)
+            .map(w => w.fields.file);
+        assert.deepEqual(files.sort(), ['one.zip', 'two.zip']);
+    });
+});
+
+describe('BsoSpool — pruning missing references', () => {
+    beforeEach(cleanOutbound);
+
+    async function seed() {
+        const real = path.join(outboundDir(tmpDir), 'keep.pkt');
+        await fsp.writeFile(real, 'KEEP');
+        const missing = path.join(tmpDir, 'gone', 'vanished.zip');
+        const done = path.join(tmpDir, 'gone', 'already.pkt');
+        const flowPath = path.join(outboundDir(tmpDir), '00680001.flo');
+        await fsp.writeFile(flowPath, `^${real}\n^${missing}\n~${done}\n`);
+        return { real, missing, done, flowPath };
+    }
+
+    it('changes nothing on a dry run', async () => {
+        const { missing, flowPath } = await seed();
+        const before = await fsp.readFile(flowPath, 'utf8');
+
+        const removed = await spool.pruneMissingRefs(TEST_ADDR);
+
+        assert.deepEqual(
+            removed.map(e => e.path),
+            [missing],
+            'it should still say what it would remove'
+        );
+        assert.equal(await fsp.readFile(flowPath, 'utf8'), before);
+    });
+
+    it('defaults to a dry run when asked for nothing in particular', async () => {
+        //  Removing queue entries is the one destructive thing here, and an
+        //  unreachable file store looks exactly like a deleted one, so the
+        //  caller has to say so explicitly.
+        const { flowPath } = await seed();
+        const before = await fsp.readFile(flowPath, 'utf8');
+        await spool.pruneMissingRefs(TEST_ADDR, {});
+        assert.equal(await fsp.readFile(flowPath, 'utf8'), before);
+    });
+
+    it('removes only the missing entries when told to', async () => {
+        const { real, missing, done, flowPath } = await seed();
+
+        const removed = await spool.pruneMissingRefs(TEST_ADDR, { dryRun: false });
+        assert.deepEqual(
+            removed.map(e => e.path),
+            [missing]
+        );
+
+        const content = await fsp.readFile(flowPath, 'utf8');
+        assert.ok(content.includes(real), 'the sendable entry must survive');
+        assert.ok(content.includes(`~${done}`), 'the sent marker must survive');
+        assert.ok(!content.includes(missing), 'the missing entry must be gone');
+    });
+
+    it('removes the flow file when nothing sendable is left', async () => {
+        //  Same as a normal drain: ftn_bso recreates it next time it queues
+        //  something, and leaving an all-dead file behind is what the
+        //  disposition path already avoids.
+        const flowPath = path.join(outboundDir(tmpDir), '00680001.flo');
+        await fsp.writeFile(flowPath, `^${path.join(tmpDir, 'gone', 'only.zip')}\n`);
+
+        await spool.pruneMissingRefs(TEST_ADDR, { dryRun: false });
+
+        assert.equal(
+            await fsp
+                .access(flowPath)
+                .then(() => true)
+                .catch(() => false),
+            false
+        );
+    });
+
+    it('leaves other nodes alone', async () => {
+        const otherFlow = path.join(outboundDir(tmpDir), '00680002.flo');
+        await fsp.writeFile(otherFlow, `^${path.join(tmpDir, 'gone', 'theirs.zip')}\n`);
+        await seed();
+
+        await spool.pruneMissingRefs(TEST_ADDR, { dryRun: false });
+
+        assert.ok(
+            (await fsp.readFile(otherFlow, 'utf8')).includes('theirs.zip'),
+            "another node's queue must not be touched"
+        );
+    });
+
+    it('says there is nothing to do for a node with no missing entries', async () => {
+        const real = path.join(outboundDir(tmpDir), 'fine.pkt');
+        await fsp.writeFile(real, 'FINE');
+        await fsp.writeFile(path.join(outboundDir(tmpDir), '00680001.flo'), `^${real}\n`);
+
+        assert.deepEqual(await spool.pruneMissingRefs(TEST_ADDR, { dryRun: false }), []);
+    });
+});
+
 describe('BsoSpool — upper case outbound (FTS-5005.003 §2)', () => {
     beforeEach(cleanOutbound);
 

--- a/test/oputil_bso.test.js
+++ b/test/oputil_bso.test.js
@@ -1,0 +1,230 @@
+'use strict';
+
+//
+//  oputil bso — the command layer.
+//
+//  The spool methods underneath are covered in binkp_bso_spool.test.js. What
+//  is only reachable from here is the CLI contract itself: that a destructive
+//  command stays behind --yes, that a busy node is reported rather than
+//  passed off as "nothing to do", and that failures exit non-zero with
+//  something an operator can read.
+//
+//  These run oputil as a real process. |argv| is bound from process.argv when
+//  oputil_common is first required, so exercising the handlers in-process
+//  would mean rebuilding the module tree per case with a doctored argv --
+//  more machinery than the thing under test. test/server_listen.test.js
+//  already shells out this way.
+//
+
+const { strict: assert } = require('assert');
+const { execFileSync } = require('child_process');
+const fsp = require('fs/promises');
+const path = require('path');
+const os = require('os');
+
+const REPO_ROOT = path.join(__dirname, '..');
+
+//  net=0x00da=218 node=0x02bd=701 -> 00da02bd
+const NODE = '1:218/701';
+const FLOW_NAME = '00da02bd.clo';
+
+describe('oputil bso', function () {
+    //  Each case spawns node and opens the databases; a handful of those is
+    //  still fast, but nowhere near mocha's default 2s.
+    this.timeout(30000);
+
+    let tmpDir;
+
+    before(async () => {
+        tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'enigma_oputil_bso_'));
+    });
+
+    after(async () => {
+        await fsp.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    //
+    //  A throwaway config plus an outbound holding one real file and one whose
+    //  file is gone. |outbound| is the base; the default network's directory
+    //  is the "outbound" beneath it.
+    //
+    async function makeFixture(name, { extra = '' } = {}) {
+        const root = path.join(tmpDir, name);
+        const flowDir = path.join(root, 'ob', 'outbound');
+        for (const d of [path.join(root, 'db'), path.join(root, 'logs'), flowDir]) {
+            await fsp.mkdir(d, { recursive: true });
+        }
+
+        const realFile = path.join(root, 'real.pkt');
+        const goneFile = path.join(root, 'vanished.zip');
+        await fsp.writeFile(realFile, 'PKTDATA');
+
+        const flowPath = path.join(flowDir, FLOW_NAME);
+        await fsp.writeFile(flowPath, `^${realFile}\n^${goneFile}\n`);
+
+        await fsp.writeFile(
+            path.join(root, 'config.hjson'),
+            `{
+                general: { boardName: "Test BBS" }
+                paths: { db: "${path.join(root, 'db')}", logs: "${path.join(
+                    root,
+                    'logs'
+                )}" }
+                loginServers: { telnet: { enabled: false }, ssh: { enabled: false } }
+                messageNetworks: {
+                    ftn: { networks: { testnet: { localAddress: "1:218/700", defaultZone: 1 } } }
+                }
+                scannerTossers: {
+                    ftn_bso: {
+                        defaultNetwork: "testnet"
+                        paths: { outbound: "${path.join(root, 'ob')}" }
+                        ${extra}
+                    }
+                }
+            }`
+        );
+
+        return { root, flowPath, realFile, goneFile };
+    }
+
+    //  oputil's getConfigPath() concatenates rather than joins, so the config
+    //  path has to carry its own trailing separator.
+    function runOputil(root, args) {
+        try {
+            const out = execFileSync(
+                process.execPath,
+                ['./oputil.js', '-c', `${root}${path.sep}`, 'bso', ...args],
+                { cwd: REPO_ROOT, encoding: 'utf8', stdio: 'pipe' }
+            );
+            return { code: 0, out };
+        } catch (err) {
+            return {
+                code: err.status,
+                out: `${err.stdout || ''}${err.stderr || ''}`,
+            };
+        }
+    }
+
+    // ── 1. the --yes gate ─────────────────────────────────────────────────────
+
+    it('prune without --yes leaves the flow file byte for byte as it was', async () => {
+        //  The one case worth having even if there were no others: a
+        //  regression here makes a destructive command destructive by default.
+        const { root, flowPath, goneFile } = await makeFixture('gate');
+        const before = await fsp.readFile(flowPath, 'utf8');
+
+        const { code, out } = runOputil(root, ['prune', NODE]);
+
+        assert.equal(code, 0);
+        assert.ok(out.includes(goneFile), 'it should still say what it would remove');
+        assert.match(out, /--yes/, 'and how to actually do it');
+        assert.equal(
+            await fsp.readFile(flowPath, 'utf8'),
+            before,
+            'nothing may have been written'
+        );
+    });
+
+    // ── 2. the write path ─────────────────────────────────────────────────────
+
+    it('prune --yes removes the missing entry and keeps the rest', async () => {
+        const { root, flowPath, realFile, goneFile } = await makeFixture('write');
+
+        const { code, out } = runOputil(root, ['prune', NODE, '--yes']);
+
+        assert.equal(code, 0);
+        assert.match(out, /Removed/);
+
+        const content = await fsp.readFile(flowPath, 'utf8');
+        assert.ok(content.includes(realFile), 'the sendable entry must survive');
+        assert.ok(!content.includes(goneFile), 'the missing one must be gone');
+    });
+
+    // ── 3. the node the poller hides ──────────────────────────────────────────
+
+    it('status shows a node whose every entry has gone missing', async () => {
+        //  getNodesWithPendingMail deliberately skips it, so it appears
+        //  nowhere else. That is the whole reason this command exists.
+        const { root } = await makeFixture('hidden');
+        const otherFlow = path.join(root, 'ob', 'outbound', '00da02be.clo'); // 1:218/702
+        await fsp.writeFile(otherFlow, `^${path.join(root, 'never_existed.zip')}\n`);
+
+        const { code, out } = runOputil(root, ['status']);
+
+        assert.equal(code, 0);
+        assert.match(out, /1:218\/702/, 'the hidden node must be listed');
+        assert.match(out, /never be sent/, 'and be called out as undeliverable');
+    });
+
+    // ── 4. the scripting contract ─────────────────────────────────────────────
+
+    it('exits non-zero and prints usage for an address it cannot parse', async () => {
+        const { root } = await makeFixture('badaddr');
+
+        const { code, out } = runOputil(root, ['list', 'not-an-address']);
+
+        assert.notEqual(code, 0, 'a bad argument must not look like success');
+        assert.match(out, /usage: oputil\.js bso/);
+    });
+
+    // ── 5. the config guard ───────────────────────────────────────────────────
+
+    it('explains an unconfigured outbound instead of dumping a stack trace', async () => {
+        const { root } = await makeFixture('noconfig');
+        const cfgPath = path.join(root, 'config.hjson');
+        const cfg = await fsp.readFile(cfgPath, 'utf8');
+        await fsp.writeFile(cfgPath, cfg.replace(/outbound: "[^"]*"/, 'outbound: null'));
+
+        const { code, out } = runOputil(root, ['status']);
+
+        assert.notEqual(code, 0);
+        assert.match(out, /paths\.outbound/, 'it should name what is missing');
+        assert.ok(!/at .*\.js:\d+/.test(out), `expected no stack trace, got:\n${out}`);
+    });
+
+    // ── 6. a live system holding the lock ─────────────────────────────────────
+
+    it('changes nothing while another process holds the node .bsy lock', async () => {
+        //  This is the one the review caught: oputil is its own process, so
+        //  the in-process write chain says nothing about what the running BBS
+        //  is doing. Only the FTS-5005 lock does.
+        const bsoLock = require('../core/bso_lock');
+
+        //  A short wait so the case does not sit out the 5s default.
+        const { root, flowPath, goneFile } = await makeFixture('busy', {
+            extra: 'flowLockTimeoutMs: 250',
+        });
+        const before = await fsp.readFile(flowPath, 'utf8');
+
+        const bsyPath = bsoLock.bsyPathForFlowFile(flowPath);
+        assert.equal(
+            await bsoLock.acquire(bsyPath, { staleMaxAgeMs: 600000 }),
+            true,
+            'the test could not take the lock it means to hold'
+        );
+
+        let result;
+        try {
+            result = runOputil(root, ['prune', NODE, '--yes']);
+        } finally {
+            await bsoLock.release(bsyPath);
+        }
+
+        assert.equal(result.code, 0, 'a busy node is a deferral, not a failure');
+        assert.match(result.out, /busy/i, 'it must say why nothing happened');
+        assert.ok(
+            !/Removed/.test(result.out),
+            `nothing may be claimed as removed, got:\n${result.out}`
+        );
+        assert.equal(
+            await fsp.readFile(flowPath, 'utf8'),
+            before,
+            'the flow file must be untouched'
+        );
+
+        //  ...and with the lock released it goes through.
+        const after = runOputil(root, ['prune', NODE, '--yes']);
+        assert.match(after.out, /Removed/);
+        assert.ok(!(await fsp.readFile(flowPath, 'utf8')).includes(goneFile));
+    });
+});


### PR DESCRIPTION
Fixes #754.

A flow file stores an **absolute path** to each file queued for a node
([FTS-5005.003](http://ftsc.org/docs/fts-5005.003) §3.1). When that file is deleted or
moved — a file base tidied, an area reorganised, a forwarded TIC payload removed —
`resolveFlowRef` skips the entry and the node never receives it. Nothing removed the
entry, and nothing told the operator which node was affected.

## What was actually wrong

Narrower than the issue title suggests, and worth stating precisely: `flowHasPending`
already prevents the poll loop, and a dangling entry does not block the *other* files in
the same flow file. What was broken:

1. **The warning was unusable.** `{ flowFile, ref }` — a bare absolute path, no node
   address — logged **once per process**. A system that hit it at boot said so once and
   was silent from then on.
2. **The node most worth hearing about was the one that hid.** A node whose live entries
   have all gone missing is deliberately excluded from `getNodesWithPendingMail` — right
   for the poller, which should not dial someone it has nothing to give — and that was
   also the only view of the outbound anyone had. Demonstrated against a real spool:

   ```
   --- getNodesWithPendingMail (what the poller sees) ---
   [ '1:218/701' ]                      <- 1:218/702 hidden entirely

   --- inspectOutbound ---
    1:218/701   pending 5000  good1.pkt
                missing    -  gone.zip
    1:218/702   missing    -  alsogone.zip   <- now visible
   ```
3. **Nothing ever said the file was not coming**, or what to do about it.

## What this does

**The warning** now names the node and the file, says the file will never be delivered
rather than that an entry was skipped, and repeats hourly — this is a standing fault, not
an event. The node label comes from the address where the caller has one, and is decoded
from the flow file name where it does not (the outbound sweep has no address in hand; it
is working out which nodes exist).

**`oputil bso`** gives the operator the view they otherwise get by reading the spool by
hand:

```
oputil.js bso status          # every node with outbound, including ones the poller skips
oputil.js bso list ADDRESS    # every queued entry for one node
oputil.js bso prune ADDRESS   # drop entries whose file is gone
```

```
Node                    Queued  Missing  Oldest
-----------------------------------------------
1:218/701                    2        1     36s
1:218/702                    1        1       -
```

**Pruning is deliberately not automatic** and does nothing without `--yes`. A file on an
unmounted volume and a deleted one are the same `ENOENT` here, and guessing wrong discards
mail nobody asked us to throw away — the exact failure class the last few PRs have been
removing. `status` tells the operator what to check first, and the docs lead with the case
that matters most: if the file can be restored to the path the flow file names, nothing
needs pruning and the next poll ships it.

The outbound walk behind `getNodesWithPendingMail` is now shared with the report, so the
two cannot drift on the point-directory and case rules; they differ only in the judgement
each makes about what it finds.

## Scope

Only the bug half of the queue-hygiene discussion. #755 (expiry for a downlink that never
polls) stays open — though `bso status` answers its "who is not collecting their mail?"
half, which the issue notes an operator currently cannot answer at all.

## Tests

13 new cases in `test/binkp_bso_spool.test.js` covering the report, the prune (dry run by
default, missing entries only, sent markers preserved, flow file removed when nothing
sendable remains, other nodes untouched) and the warning content.

`2114 passing`, verified over two consecutive full runs. Lint and prettier clean.
Documented in `docs/_docs/admin/oputil.md`.

**One honest gap:** the tests assert the warning's content and that separate missing files
each get reported, but not the hourly repeat itself — that would need clock control I would
have to add API surface to expose. The interval is verified by reading, not by test.

Two bugs I introduced and the tests caught, both the same mistake: `BsoSpool` accepts plain
address-shaped objects everywhere, and I twice assumed an `Address` instance —
`pruneMissingRefs` compared with `toString()` (never matched) and `nodeLabel` logged
`[object Object]`. There is now a shared `sameAddress()` helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---

## Update: findings from an independent review

An independent review of the first commit found one issue that would have lost mail, plus
several smaller ones. All are fixed in `e1d2156f`; the branch is now 2 commits.

**`pruneMissingRefs` rewrote flow files without the FTS-5005 `.bsy` lock.** This was the
serious one and I had missed it. `_withFlowFileWrite` is an in-process promise chain, and
`oputil` runs as its own process — so it offered no protection at all against the running
BBS, where `ftn_bso`'s `flowFileAppendRefs` and a live session's mark-as-sent both write
under the `.bsy` lock for exactly this reason (#749). A ref queued between prune's read and
its write was dropped, and if prune's stale view showed nothing sendable left it unlinked
the whole flow file, new entry included. Reproduced by the reviewer, and I confirmed the
fix holds a lock against an external holder:

```
external holder took the .bsy lock: true
prune reported removed: 0
flow file still present: true
contents intact: true

after release -> removed: 1 | flow gone: true
```

Prune now takes the lock, and when it cannot it changes nothing and names the busy node
rather than returning an empty result that reads like "nothing to do".

**`missing` conflated "absent" with "could not read".** `resolveFlowRef` treats every
`stat` failure alike, so a file behind a permissions problem, an unmounted volume or an
exhausted descriptor table was reported as missing — and would have been pruned. That file
is still there and still owed to the node. `ENOENT`/`ENOTDIR` is now `MISSING`; anything
else is `UNREADABLE`, is never pruned, and is explained separately to the operator.

**Smaller ones, also fixed:** `getNodesWithPendingMail` now passes the address it already
has to `flowHasPending`, so the poll path (by far the most frequent) warns with the
zone-qualified label instead of losing the shared throttle key to the file-name fallback;
the warning cache evicts aged-out entries before falling back to clearing itself, which on
a spool with many dangling refs turned the hourly throttle into a firehose; and an
unconfigured `paths.outbound` now gives a clear message instead of a raw `TypeError`.

**Test count correction:** the description above says 13 new cases in the first commit.
It was 12. With the three added here — multi-entry prune (which is what makes the
descending-index splice order matter), the busy-lock case, and the unreadable case — the
branch adds 15. `2117 passing`, verified over two consecutive full runs.

**Checked and found fine** by the reviewer, recorded so it is known these were looked at:
`inspectOutbound`'s line parsing agrees exactly with `_parseFlowFile` on prefixes, blanks
and `~`; the `_forEachOutboundFile` refactor preserves `getNodesWithPendingMail`'s dedupe,
point-directory recursion, point-zero-is-boss rule and zero-byte-is-a-poll-flag handling;
`nodeLabel`'s point branch is correct; `sameAddress` genuinely fixes the plain-object
comparison; and the oputil argument handling, exit codes and `--yes` match sibling modules.

**Still not covered by tests:** the hourly repeat interval itself, and the `oputil_bso.js`
CLI layer has no tests of its own (sibling `oputil_fat.js` does have `test/oputil_fat.test.js`,
so that is a real gap rather than the house style). Both verified by hand.


---

## Update: CLI tests and the DRY note (`967616f4`)

**DRY.** `friendlySize` reimplemented `core/string_util.js`'s `formatByteSize` — and stopped
at GB where the shared one goes to YB, so a large enough queue would have printed a nonsense
unit. Now uses it. Same for the local `pad`/`padLeft` against `string_util`'s `pad()`. Output
is byte-identical before and after.

Left alone: `friendlyAge`. The existing idiom is `moment.duration(...).humanize()`, which
gives "a few seconds" — prose for a screen, where this is a column in a table, so it produces
`3d`/`4h`/`12m`. Easy to swap if one age format across the codebase is preferred.

**Command-layer tests.** `test/oputil_bso.test.js`, six cases covering what is only reachable
through the CLI:

| Case | Guards |
|---|---|
| `prune` without `--yes` leaves the flow file byte-identical | a destructive command becoming destructive by default |
| `prune --yes` removes the missing entry, keeps the rest | the write path end to end |
| `status` shows a node whose every entry is missing | the node `getNodesWithPendingMail` deliberately hides — the feature's reason to exist |
| bad address → non-zero exit + usage | the scripting contract |
| unconfigured `paths.outbound` → readable message, no stack trace | the `TypeError` guard |
| `--yes` while another process holds the `.bsy` → says busy, changes nothing | the bug the review caught, at the layer an operator uses |

They run oputil as a real process: `argv` is bound from `process.argv` when `oputil_common` is
first required, so driving the handlers in-process would mean rebuilding the module tree per
case with a doctored argv — more machinery than the thing under test. `server_listen.test.js`
already shells out this way. ~4s for the six.

Each was checked by mutation rather than assumed: forcing the `--yes` gate open, dropping the
`paths.outbound` guard, and defeating the `.bsy` lock each break exactly one case and nothing
else.

**Correction to an earlier note in this description:** I said the missing CLI tests were "a
real gap rather than the house style" because `oputil_fat.js` has `test/oputil_fat.test.js`.
That was wrong — I repeated it from the review without checking. That file tests
`fat_image.js` beneath the CLI and never touches `handleFatCommand`, argv or output; no
oputil command layer in this repo had tests before this. These are new ground, not a gap
being closed.

Also has `prune` honour `scannerTossers.ftn_bso.flowLockTimeoutMs` — the same knob `ftn_bso`
waits on — rather than always sitting out the 5s default.

`2123 passing`, two consecutive full runs. Suite goes 35s → 39s.


---

## Update: the warning interval is now configurable, and tested (`6cd8e2fa`)

The one behaviour left untested was the warning throttle — and it is the one worth locking,
because a throttle stuck shut is precisely the silence this branch exists to remove.

`flowRefWarnRepeatMs` now sits on the spool alongside `staleLockMaxAgeMs`, reached the same
way through `buildSpool`, defaulting to the hour it already used. Two cases: quiet across
three passes inside the window, speaks up again once it has passed. Both fail if the
throttle is made permanent (the old once-per-process bug) or removed entirely.

It also earns its place independently — a sysop who already knows about a dangling
reference and has not dealt with it yet can now turn it down. Documented under
`binkp.flowRefWarnRepeatMs`.

**The approach I rejected, since it is the obvious one:** stubbing `Date.now` in the test.
Less code, no config, and I had it working. But `Date.now` is process-wide — everything else
in the run sees the shifted clock for the duration, and `.bsy` staleness is clock-based, so
that coupling would have been lying in wait for whoever wrote the next clock-sensitive test.
The config route touches no global.

Not tested, deliberately: the 1024-entry cap eviction. Reaching it needs more than 1024
*distinct* dangling references on one system, and a regression there produces extra log
lines rather than silence.

`2126 passing`, two consecutive full runs.
