### PR TITLE
feat(config): derive a configuration schema from config_default.js

### DIFF
--- a/core/config/meta.js
+++ b/core/config/meta.js
@@ -1,0 +1,151 @@
+/* jslint node: true */
+'use strict';
+
+//
+//  Sparse metadata for the configuration schema.
+//
+//  core/config_default.js already supplies shape, type and default for most of
+//  the tree, mechanically and with no chance of drifting. This file adds only
+//  what a default *value* cannot tell us:
+//
+//    * |openMap|: the keys here are sysop data -- area tags, network names,
+//      node addresses -- not setting names. An unrecognised key in one of
+//      these is content, never a typo, and must not be reported.
+//
+//    * Paths the code reads that config_default.js never declares. Without an
+//      entry, a perfectly legitimate setting reads as an unknown key. These
+//      are not optional polish; see the plan's §0.2.
+//
+//    * |type| for a node whose default is null, {} or [] and so carries no
+//      type at all. Inference deliberately gives up on those rather than
+//      guessing; declaring a type here restores checking.
+//
+//    * |description| / |enum| / |min| / |max| for settings a human has to
+//      reason about. Sparse by design and grown over time -- see the plan.
+//
+//  Keys are dotted paths. A "*" segment matches exactly one open map key, so
+//  "messageConferences.*.areas" describes the areas block of every conference.
+//
+//  Everything here is optional: a node with no entry still gets shape, type
+//  and default from config_default.js. Nothing in this file is required for
+//  the schema to build.
+//
+
+module.exports = {
+    //  ── Message conferences and areas ────────────────────────────────────
+    //  Conference tags and area tags are chosen by the sysop.
+    messageConferences: { openMap: true },
+    'messageConferences.*.areas': { openMap: true },
+
+    //  ── File base ────────────────────────────────────────────────────────
+    'fileBase.storageTags': {
+        openMap: true,
+        value: { type: 'string' },
+        description: 'Maps a storage tag to a directory holding that area\'s files.',
+    },
+    //
+    //  The two areas shipped in config_default.js are exemplars, not a key
+    //  list: a real area also carries acs, hashTags, sort and friends. The
+    //  derived value shape therefore types the keys it knows and tolerates
+    //  the rest.
+    //
+    'fileBase.areas': { openMap: true },
+
+    //  ── Message networks ─────────────────────────────────────────────────
+    //
+    //  Absent from config_default.js in its entirety, so every level has to
+    //  be declared. The key sets below are closed because they are short and
+    //  fully enumerable from the code that reads them -- and because a typo
+    //  in a network name is one of the failure modes this whole effort exists
+    //  to catch.
+    //
+    messageNetworks: { type: 'object', closedKeys: true },
+    'messageNetworks.ftn': { type: 'object', closedKeys: true },
+    'messageNetworks.ftn.networks': { openMap: true },
+    'messageNetworks.ftn.areas': { openMap: true },
+    'messageNetworks.ftn.netMail': { type: 'object', closedKeys: true },
+    'messageNetworks.ftn.netMail.aliases': { openMap: true },
+    'messageNetworks.ftn.areaFixStatusPhrases': { type: 'object' },
+    'messageNetworks.qwk': { type: 'object', closedKeys: true },
+    'messageNetworks.qwk.areas': { openMap: true },
+    'messageNetworks.qwk.bbsID': { type: 'string' },
+
+    //  ── FTN BSO scanner/tosser ───────────────────────────────────────────
+    'scannerTossers.ftn_bso.nodes': { openMap: true },
+    'scannerTossers.ftn_bso.ticAreas': { openMap: true },
+    'scannerTossers.ftn_bso.netMail.routes': { openMap: true },
+    'scannerTossers.ftn_bso.binkp.nodes': { openMap: true },
+    'scannerTossers.ftn_bso.binkp.tempDir': { type: 'string' },
+
+    //  ── Content servers ──────────────────────────────────────────────────
+    //
+    //  Handler names come from modules discovered on disk, so a mod may add
+    //  its own -- see core/web_handler_module.js:17-18. The template's
+    //  restApi block is one of these.
+    //
+    'contentServers.web.handlers': { openMap: true },
+
+    'contentServers.nntp.allowPosts': { type: 'boolean' },
+    //
+    //  Documented at config_default.js:435 as confTag -> [ areaTag, ... ].
+    //  Its default is {}, so it is also one of the untyped nodes below.
+    //
+    'contentServers.nntp.publicMessageConferences': {
+        openMap: true,
+        value: { type: 'array', items: { type: 'string' } },
+        description:
+            'Conferences and areas exposed to anonymous NNTP users, as confTag -> [ areaTag, ... ].',
+    },
+
+    'contentServers.gopher.exposedConfAreas': { openMap: true },
+    'contentServers.gopher.messageConferences': {
+        openMap: true,
+        description: 'Deprecated; use exposedConfAreas.',
+    },
+
+    //  ── Login servers ────────────────────────────────────────────────────
+    'loginServers.webSocket.proxied': {
+        type: 'boolean',
+        description: 'Trust X-Forwarded-For when behind a reverse proxy.',
+    },
+    'loginServers.ssh.privateKeyPass': { type: 'string' },
+
+    //  ── Chat servers ─────────────────────────────────────────────────────
+    //  Present in the config template but not in the defaults.
+    'chatServers.mrc.infoDesc': { type: 'string' },
+    'chatServers.mrc.infoSsh': { type: 'string' },
+    'chatServers.mrc.infoSysop': { type: 'string' },
+    'chatServers.mrc.infoTelnet': { type: 'string' },
+    'chatServers.mrc.infoWeb': { type: 'string' },
+
+    //  ── Miscellaneous open maps ──────────────────────────────────────────
+    fileTypes: { openMap: true }, //  keyed by MIME type
+    'archives.archivers': { openMap: true },
+    fileTransferProtocols: { openMap: true },
+    'eventScheduler.events': { openMap: true },
+    infoExtractUtils: { openMap: true },
+
+    //  ── Untyped nodes (default is null / {} and tells us nothing) ────────
+    //
+    //  null is the documented "unset" sentinel for both of these, so it stays
+    //  legal alongside the declared type -- see core/client_term.js:92 and
+    //  core/scanner_tossers/email.js:172-173.
+    //
+    'term.forceOutputEncoding': {
+        type: 'string',
+        nullable: true,
+        description: 'Force an output encoding rather than autodetecting; null to autodetect.',
+    },
+    'email.outbound.fromDomain': {
+        type: 'string',
+        nullable: true,
+        description: 'Domain used for generated From addresses; null falls back to defaultFrom.',
+    },
+
+    //  ── Root ─────────────────────────────────────────────────────────────
+    includes: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Additional hjson files merged into this configuration.',
+    },
+};

--- a/core/config/schema.js
+++ b/core/config/schema.js
@@ -1,0 +1,436 @@
+/* jslint node: true */
+'use strict';
+
+//  ENiGMA½
+const DefaultConfig = require('../config_default.js');
+const DefaultMeta = require('./meta.js');
+
+//  deps
+const _ = require('lodash');
+
+//
+//  Builds the configuration schema: a tree of SchemaNode derived from
+//  core/config_default.js and overlaid with core/config/meta.js.
+//
+//  The defaults supply shape, type and default value. All of that is
+//  mechanical, so it cannot drift from what the system actually ships.
+//  meta.js supplies only what a value cannot express -- which objects are
+//  keyed by sysop data, which paths have no default at all, and human facing
+//  description/enum/range.
+//
+//  Nothing here validates anything; this module only describes. Both inputs
+//  are static for the life of the process, so a schema is built once and
+//  never invalidated -- a hot reload changes the sysop's data, never the
+//  shape it is checked against.
+//
+//  The guiding rule throughout is to *fail open*. Where a default carries no
+//  information -- null, {}, [] -- inference says 'unknown' and declines to
+//  type check, rather than inventing a type that a correct configuration
+//  would then violate. Likewise an object shape derived from example entries
+//  types the keys it knows without claiming to know them all.
+//
+
+const NodeType = {
+    String: 'string',
+    Number: 'number',
+    Boolean: 'boolean',
+    Object: 'object',
+    Array: 'array',
+    Unknown: 'unknown',
+};
+
+//  A "*" path segment matches exactly one open map key
+const WILDCARD = '*';
+
+//  Fields meta may set directly on a node
+const MetaFields = [
+    'type',
+    'nullable',
+    'closedKeys',
+    'openMap',
+    'value',
+    'items',
+    'enum',
+    'min',
+    'max',
+    'description',
+    'discriminant',
+    'variants',
+];
+
+function childPath(path, key) {
+    return path ? `${path}.${key}` : key;
+}
+
+//
+//  meta keys are dotted paths that may contain "*" segments, so a plain map
+//  lookup is not enough. Compiling them once keeps the per-node cost to a
+//  walk of a short list.
+//
+function compileMeta(meta) {
+    const exact = new Map();
+    const wild = [];
+
+    Object.entries(meta || {}).forEach(([path, entry]) => {
+        if (path.includes(WILDCARD)) {
+            wild.push({ segments: path.split('.'), entry });
+        } else {
+            exact.set(path, entry);
+        }
+    });
+
+    return { exact, wild };
+}
+
+function metaFor(compiled, path) {
+    const exact = compiled.exact.get(path);
+    if (exact) {
+        return exact;
+    }
+
+    const segments = path.split('.');
+    const match = compiled.wild.find(candidate => {
+        if (candidate.segments.length !== segments.length) {
+            return false;
+        }
+        return candidate.segments.every(
+            (seg, i) => WILDCARD === seg || seg === segments[i]
+        );
+    });
+
+    return match ? match.entry : undefined;
+}
+
+//
+//  What a default value tells us about its own type, and nothing more.
+//
+function inferScalar(value) {
+    const type = typeof value;
+    switch (type) {
+        case 'string':
+        case 'number':
+        case 'boolean':
+            return { type, default: value };
+
+        default:
+            //  functions, symbols and friends: say nothing
+            return { type: NodeType.Unknown };
+    }
+}
+
+function isScalar(value) {
+    return (
+        null !== value &&
+        undefined !== value &&
+        !Array.isArray(value) &&
+        !_.isPlainObject(value)
+    );
+}
+
+//
+//  Union several node shapes into one permissive node. Used for the values of
+//  an open map, where config_default.js ships a couple of example entries
+//  that are emphatically not an exhaustive key list.
+//
+function mergeShapes(nodes) {
+    const usable = nodes.filter(Boolean);
+    if (0 === usable.length) {
+        return { type: NodeType.Unknown };
+    }
+
+    const types = new Set(usable.map(n => n.type));
+    if (types.size > 1) {
+        //  the examples disagree; better to say nothing than to pick one
+        return { type: NodeType.Unknown };
+    }
+
+    const type = usable[0].type;
+
+    if (NodeType.Object !== type) {
+        const merged = { type };
+        const items = usable.map(n => n.items).filter(Boolean);
+        if (items.length === usable.length) {
+            merged.items = mergeShapes(items);
+        }
+        return merged;
+    }
+
+    //
+    //  closedKeys is deliberately false here. Two shipped file areas do not
+    //  tell us every key a real one may carry -- acs and hashTags are both
+    //  legitimate and appear in neither example -- so this shape types what
+    //  it recognises and tolerates the rest.
+    //
+    const children = {};
+    usable.forEach(node => {
+        Object.entries(node.children || {}).forEach(([key, child]) => {
+            if (!children[key]) {
+                children[key] = child;
+            }
+        });
+    });
+
+    return { type: NodeType.Object, closedKeys: false, children };
+}
+
+function overlay(node, meta) {
+    if (!meta) {
+        return node;
+    }
+
+    MetaFields.forEach(field => {
+        if (undefined !== meta[field]) {
+            node[field] = meta[field];
+        }
+    });
+
+    return node;
+}
+
+function buildArrayNode(arr, path, compiled) {
+    const node = { type: NodeType.Array, default: arr };
+
+    if (0 === arr.length) {
+        //  an empty array says nothing about its elements
+        return node;
+    }
+
+    if (arr.every(entry => _.isPlainObject(entry))) {
+        //  e.g. fileTypes['application/octet-stream'], two signature entries
+        node.items = mergeShapes(
+            arr.map(entry => buildNode(entry, childPath(path, WILDCARD), compiled))
+        );
+        return node;
+    }
+
+    if (arr.every(isScalar)) {
+        const types = new Set(arr.map(entry => typeof entry));
+        if (1 === types.size) {
+            node.items = { type: types.values().next().value };
+        }
+    }
+
+    return node;
+}
+
+function buildOpenMapNode(value, path, compiled, meta) {
+    const node = {
+        type: NodeType.Object,
+        openMap: true,
+        //  the keys are sysop data, so an unrecognised one is never a typo
+        closedKeys: false,
+    };
+
+    if (meta && meta.value) {
+        node.value = meta.value;
+        return node;
+    }
+
+    const examples = _.isPlainObject(value) ? Object.values(value) : [];
+    node.value = mergeShapes(
+        examples.map(entry => buildNode(entry, childPath(path, WILDCARD), compiled))
+    );
+
+    return node;
+}
+
+function buildNode(value, path, compiled) {
+    const meta = metaFor(compiled, path);
+    let node;
+
+    if (meta && true === meta.openMap) {
+        node = buildOpenMapNode(value, path, compiled, meta);
+    } else if (_.isPlainObject(value) && Object.keys(value).length > 0) {
+        const children = {};
+        Object.keys(value).forEach(key => {
+            children[key] = buildNode(value[key], childPath(path, key), compiled);
+        });
+        node = { type: NodeType.Object, closedKeys: true, children };
+    } else if (Array.isArray(value)) {
+        node = buildArrayNode(value, path, compiled);
+    } else if (null === value) {
+        //  null is a documented "unset" sentinel, not a type
+        node = { type: NodeType.Unknown, nullable: true };
+    } else if (_.isPlainObject(value)) {
+        //  {} -- carries no shape at all
+        node = { type: NodeType.Unknown };
+    } else {
+        node = inferScalar(value);
+    }
+
+    return overlay(node, meta);
+}
+
+//
+//  meta declares paths the defaults never mention -- messageNetworks and
+//  friends. Those have to be grafted onto the tree, along with any missing
+//  parents, or the very settings most worth checking would read as unknown
+//  keys.
+//
+//  Intermediates created this way are left open unless meta says otherwise:
+//  knowing a section exists is not the same as knowing every key in it.
+//
+function newDeclaredNode(isLeaf, entry) {
+    if (!isLeaf) {
+        return { type: NodeType.Object, closedKeys: false, children: {} };
+    }
+
+    if (entry && true === entry.openMap) {
+        return {
+            type: NodeType.Object,
+            openMap: true,
+            closedKeys: false,
+            value: { type: NodeType.Unknown },
+        };
+    }
+
+    return { type: NodeType.Unknown };
+}
+
+function insertDeclaredPaths(root, meta, compiled) {
+    Object.keys(meta || {})
+        .filter(path => !path.includes(WILDCARD))
+        .sort() //  parents before their children
+        .forEach(path => {
+            const segments = path.split('.');
+            let node = root;
+
+            for (let i = 0; i < segments.length; ++i) {
+                if (!node) {
+                    break;
+                }
+
+                if (NodeType.Unknown === node.type && !node.openMap) {
+                    //
+                    //  The default said nothing here -- null, {} or absent --
+                    //  but meta declares something beneath it, which is itself
+                    //  a statement that this is an object. Promote it, leaving
+                    //  it permissive: we know it has this child, not that it
+                    //  has only this child.
+                    //
+                    node.type = NodeType.Object;
+                    node.closedKeys = false;
+                    node.children = node.children || {};
+                }
+
+                if (NodeType.Object !== node.type || node.openMap) {
+                    //  nothing to graft onto; an open map already accepts it
+                    break;
+                }
+
+                const segment = segments[i];
+                node.children = node.children || {};
+
+                if (!node.children[segment]) {
+                    const isLeaf = i === segments.length - 1;
+                    const entry = isLeaf ? metaFor(compiled, path) : undefined;
+
+                    node.children[segment] = overlay(
+                        newDeclaredNode(isLeaf, entry),
+                        entry
+                    );
+                }
+
+                node = node.children[segment];
+            }
+        });
+
+    return root;
+}
+
+//
+//  Resolve a dotted config path against a schema, stepping through open maps
+//  transparently. Returns the SchemaNode, or undefined when the path names
+//  nothing the schema knows about.
+//
+function resolvePath(schema, path) {
+    let node = schema;
+
+    for (const segment of String(path).split('.')) {
+        if (!node) {
+            return undefined;
+        }
+
+        if (node.openMap) {
+            //  any key is legal here; step into the value shape
+            node = node.value;
+            continue;
+        }
+
+        if (!node.children || !node.children[segment]) {
+            return undefined;
+        }
+
+        node = node.children[segment];
+    }
+
+    return node;
+}
+
+//
+//  Like resolvePath(), but distinguishes the two very different reasons a path
+//  may not resolve:
+//
+//    known     the schema describes this path exactly
+//    tolerated the schema does not describe it, but does not object to it
+//              either -- it sits under an open map, under a shape derived
+//              from examples, or under a node whose type is unknown
+//
+//  Only a path that is neither known nor tolerated is a candidate for being
+//  reported as an unknown key.
+//
+function lookupPath(schema, path) {
+    let node = schema;
+    const segments = String(path).split('.');
+
+    for (let i = 0; i < segments.length; ++i) {
+        if (!node) {
+            return { known: false, tolerated: false };
+        }
+
+        if (NodeType.Unknown === node.type) {
+            //  we know nothing below here, which is not the same as objecting
+            return { known: false, tolerated: true };
+        }
+
+        if (node.openMap) {
+            //  this segment is a sysop supplied key; step into the value shape
+            node = node.value;
+            continue;
+        }
+
+        const child = node.children && node.children[segments[i]];
+        if (!child) {
+            return { known: false, tolerated: false === node.closedKeys };
+        }
+
+        node = child;
+    }
+
+    return node
+        ? { node, known: true, tolerated: true }
+        : { known: false, tolerated: false };
+}
+
+function buildSchema(defaultConfig, meta) {
+    const config = defaultConfig || DefaultConfig();
+    const metaMap = meta || DefaultMeta;
+    const compiled = compileMeta(metaMap);
+
+    let root = buildNode(config, '', compiled);
+
+    if (NodeType.Object !== root.type) {
+        //  an empty or non-object default still has to be somewhere to graft
+        //  meta declared paths onto
+        root = { type: NodeType.Object, closedKeys: true, children: {} };
+    }
+
+    return insertDeclaredPaths(root, metaMap, compiled);
+}
+
+module.exports = {
+    buildSchema,
+    resolvePath,
+    lookupPath,
+    NodeType,
+};

--- a/test/config_schema.test.js
+++ b/test/config_schema.test.js
@@ -1,0 +1,327 @@
+'use strict';
+
+const { strict: assert } = require('assert');
+const paths = require('path');
+const fs = require('fs');
+const hjson = require('hjson');
+
+//  No load-time Config() dependency here -- require directly.
+const {
+    buildSchema,
+    resolvePath,
+    lookupPath,
+    NodeType,
+} = require('../core/config/schema');
+const Meta = require('../core/config/meta');
+
+// ─── Derivation from a default value ─────────────────────────────────────────
+
+describe('config schema derivation', () => {
+    const build = (defaults, meta = {}) => buildSchema(defaults, meta);
+
+    it('types scalars from their default and records the default', () => {
+        const s = build({ a: 'str', b: 7, c: true });
+        assert.equal(resolvePath(s, 'a').type, NodeType.String);
+        assert.equal(resolvePath(s, 'a').default, 'str');
+        assert.equal(resolvePath(s, 'b').type, NodeType.Number);
+        assert.equal(resolvePath(s, 'c').type, NodeType.Boolean);
+    });
+
+    it('recurses into non-empty objects and marks them closed', () => {
+        const s = build({ outer: { inner: { leaf: 1 } } });
+        assert.equal(resolvePath(s, 'outer').closedKeys, true);
+        assert.equal(resolvePath(s, 'outer.inner.leaf').type, NodeType.Number);
+    });
+
+    it('gives up on an empty object rather than calling it a closed object', () => {
+        const s = build({ nothing: {} });
+        assert.equal(resolvePath(s, 'nothing').type, NodeType.Unknown);
+    });
+
+    it('gives up on null but records that null is legal', () => {
+        const s = build({ unset: null });
+        const node = resolvePath(s, 'unset');
+        assert.equal(node.type, NodeType.Unknown);
+        assert.equal(node.nullable, true);
+    });
+
+    it('types an array of homogeneous scalars', () => {
+        const s = build({ list: ['a', 'b'] });
+        const node = resolvePath(s, 'list');
+        assert.equal(node.type, NodeType.Array);
+        assert.equal(node.items.type, NodeType.String);
+    });
+
+    it('says nothing about the elements of an empty or mixed array', () => {
+        const s = build({ empty: [], mixed: [1, 'two'] });
+        assert.equal(resolvePath(s, 'empty').items, undefined);
+        assert.equal(resolvePath(s, 'mixed').items, undefined);
+    });
+
+    it('derives an element shape for an array of homogeneous objects', () => {
+        const s = build({ sigs: [{ ext: '.dms' }, { ext: '.lha' }] });
+        const node = resolvePath(s, 'sigs');
+        assert.equal(node.type, NodeType.Array);
+        assert.equal(node.items.type, NodeType.Object);
+        assert.equal(node.items.children.ext.type, NodeType.String);
+    });
+});
+
+// ─── meta overlay ────────────────────────────────────────────────────────────
+
+describe('config schema meta overlay', () => {
+    it('lets meta declare a type inference could not supply', () => {
+        const s = buildSchema({ enc: null }, { enc: { type: 'string', nullable: true } });
+        const node = resolvePath(s, 'enc');
+        assert.equal(node.type, NodeType.String);
+        assert.equal(node.nullable, true);
+    });
+
+    it('lets meta override an inferred type', () => {
+        const s = buildSchema({ n: 1 }, { n: { type: 'string' } });
+        assert.equal(resolvePath(s, 'n').type, NodeType.String);
+    });
+
+    it('carries description, enum and range through to the node', () => {
+        const s = buildSchema(
+            { mode: 'warn' },
+            { mode: { enum: ['warn', 'off'], description: 'why', min: 1, max: 9 } }
+        );
+        const node = resolvePath(s, 'mode');
+        assert.deepEqual(node.enum, ['warn', 'off']);
+        assert.equal(node.description, 'why');
+        assert.equal(node.min, 1);
+        assert.equal(node.max, 9);
+    });
+
+    it('grafts on a path the defaults never declare, creating parents', () => {
+        const s = buildSchema({}, { 'a.b.c': { type: 'boolean' } });
+        assert.equal(resolvePath(s, 'a.b.c').type, NodeType.Boolean);
+        //  invented parents stay permissive: knowing a section exists is not
+        //  the same as knowing every key in it
+        assert.equal(resolvePath(s, 'a').closedKeys, false);
+    });
+
+    it('matches a "*" segment against exactly one open map key', () => {
+        const s = buildSchema(
+            { confs: { one: { areas: { a: { name: 'A' } } } } },
+            { confs: { openMap: true }, 'confs.*.areas': { openMap: true } }
+        );
+        assert.equal(resolvePath(s, 'confs').openMap, true);
+        assert.equal(resolvePath(s, 'confs.anything.areas').openMap, true);
+    });
+});
+
+// ─── Open maps ───────────────────────────────────────────────────────────────
+
+describe('config schema open maps', () => {
+    it('does not treat example keys as a key list', () => {
+        const s = buildSchema(
+            { areas: { sample: { name: 'S' } } },
+            { areas: { openMap: true } }
+        );
+        const node = resolvePath(s, 'areas');
+        assert.equal(node.openMap, true);
+        assert.equal(node.closedKeys, false);
+        assert.equal(node.children, undefined);
+    });
+
+    it('derives the value shape from the examples', () => {
+        const s = buildSchema(
+            { areas: { one: { name: 'A', n: 1 }, two: { name: 'B', n: 2 } } },
+            { areas: { openMap: true } }
+        );
+        assert.equal(resolvePath(s, 'areas.whatever.name').type, NodeType.String);
+        assert.equal(resolvePath(s, 'areas.whatever.n').type, NodeType.Number);
+    });
+
+    it('leaves the derived value shape open, so an unlisted key is tolerated', () => {
+        //  §0.1: two shipped file areas do not enumerate every legal key
+        const s = buildSchema(
+            { areas: { one: { name: 'A' } } },
+            { areas: { openMap: true } }
+        );
+        assert.equal(resolvePath(s, 'areas.whatever').closedKeys, false);
+        const r = lookupPath(s, 'areas.whatever.acs');
+        assert.equal(r.known, false);
+        assert.equal(r.tolerated, true);
+    });
+
+    it('prefers an explicit meta value shape over the examples', () => {
+        const s = buildSchema(
+            { tags: { sample: { unexpected: true } } },
+            { tags: { openMap: true, value: { type: 'string' } } }
+        );
+        assert.equal(resolvePath(s, 'tags.anything').type, NodeType.String);
+    });
+
+    it('says nothing when the examples disagree', () => {
+        const s = buildSchema(
+            { m: { a: { k: 1 }, b: ['nope'] } },
+            { m: { openMap: true } }
+        );
+        assert.equal(resolvePath(s, 'm.anything').type, NodeType.Unknown);
+    });
+
+    it('supports an open map with no default at all', () => {
+        const s = buildSchema({}, { 'net.networks': { openMap: true } });
+        const node = resolvePath(s, 'net.networks');
+        assert.equal(node.openMap, true);
+        assert.equal(node.closedKeys, false);
+    });
+});
+
+// ─── lookupPath: known vs tolerated vs neither ───────────────────────────────
+
+describe('config schema lookupPath', () => {
+    const s = buildSchema(
+        { general: { boardName: 'x' }, areas: { one: { name: 'A' } } },
+        { areas: { openMap: true } }
+    );
+
+    it('reports a described path as known', () => {
+        assert.equal(lookupPath(s, 'general.boardName').known, true);
+    });
+
+    it('reports an undescribed key under a closed object as neither', () => {
+        const r = lookupPath(s, 'general.boardnam');
+        assert.equal(r.known, false);
+        assert.equal(r.tolerated, false);
+    });
+
+    it('reports an open map key as tolerated', () => {
+        assert.equal(lookupPath(s, 'areas.anything.acs').tolerated, true);
+    });
+
+    it('tolerates everything beneath an unknown node', () => {
+        const u = buildSchema({ blob: null }, {});
+        assert.equal(lookupPath(u, 'blob.deep.deeper').tolerated, true);
+    });
+});
+
+// ─── Against the real configuration ──────────────────────────────────────────
+
+describe('config schema against config_default.js', () => {
+    const schema = buildSchema();
+
+    it('builds without throwing and produces a closed object at the root', () => {
+        assert.equal(schema.type, NodeType.Object);
+        assert.equal(schema.closedKeys, true);
+        assert.ok(Object.keys(schema.children).length > 20);
+    });
+
+    it('every meta path resolves to a node', () => {
+        const unresolved = Object.keys(Meta)
+            .filter(p => !p.includes('*'))
+            .filter(p => !resolvePath(schema, p));
+
+        assert.deepEqual(
+            unresolved,
+            [],
+            `meta paths that resolve to nothing: ${unresolved}`
+        );
+    });
+
+    it('every meta open map really is an open map in the built schema', () => {
+        const broken = Object.entries(Meta)
+            .filter(([, entry]) => entry.openMap)
+            .filter(([p]) => !p.includes('*'))
+            .filter(([p]) => {
+                const node = resolvePath(schema, p);
+                return !node || true !== node.openMap;
+            })
+            .map(([p]) => p);
+
+        assert.deepEqual(broken, [], `declared open maps that are not open: ${broken}`);
+    });
+
+    it('types the three nodes whose default carries no type', () => {
+        //  Guard 4: this set must not grow silently.
+        assert.equal(
+            resolvePath(schema, 'term.forceOutputEncoding').type,
+            NodeType.String
+        );
+        assert.equal(
+            resolvePath(schema, 'email.outbound.fromDomain').type,
+            NodeType.String
+        );
+        assert.equal(
+            resolvePath(schema, 'contentServers.nntp.publicMessageConferences').openMap,
+            true
+        );
+    });
+
+    it('finds no untyped node that meta has not accounted for', () => {
+        //  Guard 4, stated as a walk: any node left Unknown must be one meta
+        //  deliberately left alone, not a new null/{} default nobody noticed.
+        const declared = new Set(Object.keys(Meta));
+        const orphans = [];
+
+        (function walk(node, path, isMapValue) {
+            if (!node) {
+                return;
+            }
+
+            //
+            //  An open map's value shape is allowed to be Unknown: with no
+            //  example entries -- messageNetworks.ftn.networks has none, since
+            //  the whole section is absent from the defaults -- there is
+            //  genuinely nothing to infer. That is the documented fail-open
+            //  outcome, not an unannotated null.
+            //
+            if (
+                !isMapValue &&
+                NodeType.Unknown === node.type &&
+                path &&
+                !declared.has(path)
+            ) {
+                orphans.push(path);
+            }
+
+            Object.entries(node.children || {}).forEach(([k, child]) =>
+                walk(child, path ? `${path}.${k}` : k, false)
+            );
+
+            if (node.value) {
+                walk(node.value, path ? `${path}.*` : '*', true);
+            }
+        })(schema, '', false);
+
+        assert.deepEqual(orphans, [], `untyped nodes missing from meta: ${orphans}`);
+    });
+
+    it('knows or tolerates every path in the shipped config template', () => {
+        //
+        //  §0.2 regression: the template is what "oputil.js config new"
+        //  produces, so anything it contains is by definition legitimate. A
+        //  path here that is neither known nor tolerated would surface as a
+        //  false unknownKey on a brand new installation.
+        //
+        const templatePath = paths.join(__dirname, '../misc/config_template.in.hjson');
+        const template = hjson.parse(
+            fs.readFileSync(templatePath, 'utf8').replace(/\{\{[^}]*\}\}/g, 'x')
+        );
+
+        const rejected = [];
+        (function walk(value, path) {
+            if (!value || typeof value !== 'object' || Array.isArray(value)) {
+                return;
+            }
+            Object.keys(value).forEach(key => {
+                const childPath = path ? `${path}.${key}` : key;
+                const r = lookupPath(schema, childPath);
+                if (!r.known && !r.tolerated) {
+                    rejected.push(childPath);
+                    return; //  no point walking beneath a rejected path
+                }
+                walk(value[key], childPath);
+            });
+        })(template, '');
+
+        assert.deepEqual(
+            rejected,
+            [],
+            `template paths the schema would reject: ${rejected.join(', ')}`
+        );
+    });
+});


### PR DESCRIPTION
**Part 1/8 of #281** — bottom of a stacked chain. Schema layer only: nothing calls it, and there is **no runtime behaviour change**.

## Why this shape

The ticket has stalled twice (2023, 2024), both times on the assumption that a schema had to be hand-authored from nothing — all 569 nodes up front. That assumption was wrong. `config_default.js` already describes nearly the whole configuration; walking it yields shape, type and default mechanically, so those cannot drift from what the system actually ships.

Of its 569 nodes, exactly **one empty object and two nulls** carry no type at all. Everything else is derivable.

`core/config/meta.js` adds only what a default *value* cannot express:

- **Open maps** — objects keyed by sysop data (area tags, network names, node addresses) rather than by setting name. An unrecognised key in one of those is content, never a typo.
- **Paths with no default.** `messageNetworks` is absent from `config_default.js` entirely, and the config template carries about a dozen more. Without these, a legitimate setting would read as an unknown key.
- **A type for the three untyped nodes.**

It is deliberately sparse — a node with no entry still gets shape, type and default from the defaults. Nothing in `meta.js` is required for the schema to build.

## Failing open

Where a default says nothing, inference says `unknown` and declines to type check rather than guessing. Shapes derived from example entries type the keys they recognise without claiming to know them all — the two file areas in the defaults mention neither `acs` nor `hashTags`, and both are perfectly legal. Getting this wrong would flood a correct configuration with warnings on first run, which is how a feature like this ends up switched off and ignored.

`lookupPath()` separates *"the schema describes this"* from *"the schema does not describe this but does not object to it"* — the distinction the validator needs so a mod's own config block is not reported.

## Looking ahead to menus

`SchemaNode` reserves unused `discriminant`/`variants` fields. `menu.hjson`'s `menus.<name>` is a discriminated union — a `config` block's legal keys depend on which `module` backs that menu — which the open-map model cannot express. Reserving them costs nothing now and keeps the node contract stable if menu validation is attempted later.

## Tests

28 new tests: every derivation rule, meta overlay and wildcard matching, plus assertions against the real `config_default.js` that every declared path resolves, every declared open map really is one, and no untyped node is unaccounted for.

The load-bearing one: **every path in the shipped config template is known or tolerated** — i.e. a brand new installation produces no false warnings. That is the criterion this whole effort lives or dies on, and it is now checked in CI rather than deferred.

Full suite: 2154 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)