### PR TITLE
feat(config): add the configuration validator and its issue model

### DIFF
--- a/core/config/issue.js
+++ b/core/config/issue.js
@@ -1,0 +1,155 @@
+/* jslint node: true */
+'use strict';
+
+//
+//  Configuration validation issues.
+//
+//  An issue is a plain { code, ... } bag, following the precedent set by
+//  validateOutboundConfig() in core/bso_util.js: the code that finds a problem
+//  knows nothing about how it will be reported. Unlike that one, these carry a
+//  severity and a path, because there are enough codes and enough reporting
+//  surfaces -- stderr at boot, the log on reload, oputil -- that repeating a
+//  switch statement at each of them would be silly.
+//
+//  describeIssue() turns an issue into something a human can read. It is the
+//  only place wording lives, so all three surfaces say the same thing.
+//
+
+const IssueCodes = {
+    //  A key the schema does not know, somewhere it does expect to know them
+    //  all. Only ever a warning: it may be a mod's own configuration.
+    UnknownKey: 'unknownKey',
+
+    //  A value whose type disagrees with the default it overrides
+    TypeMismatch: 'typeMismatch',
+
+    //  A value outside a set or range meta declares
+    InvalidEnum: 'invalidEnum',
+    ValueOutOfRange: 'valueOutOfRange',
+
+    //  A name that must exist elsewhere in the configuration and does not
+    //  (storage tags, network names, area tags). Raised by config/refs.js.
+    UnresolvedRef: 'unresolvedRef',
+
+    //  Declared as required and absent. Only meaningful where there is no
+    //  default, since validation runs against the merged configuration.
+    MissingRequired: 'missingRequired',
+
+    //  An "@environment:", "@file:" or "@reference:" spec that did not
+    //  resolve, so the literal spec string is still sitting in the config.
+    //  Only ever raised when explicitly asked for -- resolution depends on
+    //  the invoking process, so checking it by default would report perfectly
+    //  good configurations as broken.
+    UnresolvedSpec: 'unresolvedSpec',
+
+    //  Reserved for later use
+    DeprecatedKey: 'deprecatedKey',
+};
+
+const Severity = {
+    Error: 'error',
+    Warning: 'warning',
+};
+
+const SeverityByCode = {
+    [IssueCodes.UnknownKey]: Severity.Warning,
+    [IssueCodes.DeprecatedKey]: Severity.Warning,
+    [IssueCodes.TypeMismatch]: Severity.Error,
+    [IssueCodes.InvalidEnum]: Severity.Error,
+    [IssueCodes.ValueOutOfRange]: Severity.Error,
+    [IssueCodes.UnresolvedRef]: Severity.Error,
+    [IssueCodes.MissingRequired]: Severity.Error,
+    [IssueCodes.UnresolvedSpec]: Severity.Error,
+};
+
+function severityOf(code) {
+    //  an unrecognised code is a bug in us, not in the operator's config
+    return SeverityByCode[code] || Severity.Warning;
+}
+
+function makeIssue(code, path, extra = {}) {
+    return Object.assign({ code, severity: severityOf(code), path }, extra);
+}
+
+function listOf(values) {
+    return (values || []).join(', ');
+}
+
+function describeIssue(issue) {
+    let message;
+
+    switch (issue.code) {
+        case IssueCodes.UnknownKey:
+            message = `unknown key "${issue.key}"`;
+            if (issue.suggestion) {
+                message += ` -- did you mean "${issue.suggestion}"?`;
+            }
+            break;
+
+        case IssueCodes.TypeMismatch:
+            message = `expected ${issue.expected}, got ${issue.actual}`;
+            break;
+
+        case IssueCodes.InvalidEnum:
+            message = `"${issue.value}" is not one of: ${listOf(issue.allowed)}`;
+            break;
+
+        case IssueCodes.ValueOutOfRange:
+            message =
+                undefined !== issue.min && issue.value < issue.min
+                    ? `${issue.value} is below the minimum of ${issue.min}`
+                    : `${issue.value} is above the maximum of ${issue.max}`;
+            break;
+
+        case IssueCodes.UnresolvedRef:
+            message = `${issue.refKind} "${issue.value}" is not defined in ${issue.refPath}`;
+            if (issue.candidates && issue.candidates.length) {
+                message += `\nknown: ${listOf(issue.candidates)}`;
+            }
+            break;
+
+        case IssueCodes.MissingRequired:
+            message = 'required, but not set';
+            break;
+
+        case IssueCodes.UnresolvedSpec:
+            message = `"${issue.spec}" did not resolve`;
+            break;
+
+        case IssueCodes.DeprecatedKey:
+            message = `"${issue.key}" is deprecated`;
+            if (issue.replacement) {
+                message += `; use "${issue.replacement}"`;
+            }
+            break;
+
+        default:
+            message = issue.code;
+            break;
+    }
+
+    return { severity: issue.severity, path: issue.path, message };
+}
+
+function countBySeverity(issues) {
+    return (issues || []).reduce(
+        (acc, issue) => {
+            if (Severity.Error === issue.severity) {
+                acc.errors += 1;
+            } else {
+                acc.warnings += 1;
+            }
+            return acc;
+        },
+        { errors: 0, warnings: 0 }
+    );
+}
+
+module.exports = {
+    IssueCodes,
+    Severity,
+    severityOf,
+    makeIssue,
+    describeIssue,
+    countBySeverity,
+};

--- a/core/config/validate.js
+++ b/core/config/validate.js
@@ -1,0 +1,324 @@
+/* jslint node: true */
+'use strict';
+
+//  ENiGMA½
+const { NodeType } = require('./schema.js');
+const { IssueCodes, makeIssue } = require('./issue.js');
+
+//  deps
+const _ = require('lodash');
+
+//
+//  Validates a configuration against a schema.
+//
+//  Pure: no logging, no filesystem, no Config(). It takes values and returns a
+//  list of issues, empty when all is well -- the same shape as
+//  validateOutboundConfig() in core/bso_util.js, for the same reason. Every
+//  reporting surface shares one formatter rather than each mapping codes to
+//  wording of its own.
+//
+//  Two walks over two different objects, deliberately:
+//
+//    * Unknown keys are only visible in the *pre-merge* configuration. After
+//      _.merge() folds the sysop's file into the defaults, a misspelled key
+//      sits quietly beside the correctly spelled default and both are present.
+//      That silent shadowing is the failure mode this whole effort exists to
+//      catch, so this walk has to see what the sysop actually wrote.
+//
+//    * Types are only correct in the *merged* configuration, where every
+//      defaulted value is present and every "@" spec has been resolved.
+//
+//  Throughout, the rule is to stay quiet when unsure. A validator that cries
+//  wolf on a working board gets switched off, and then it protects nobody.
+//
+
+//  A spec _resolveAtSpecs() left alone because it could not resolve it; see
+//  core/config_loader.js:310-325. The literal string is still in the config.
+const UNRESOLVED_SPEC = /^@(reference|environment|file):/;
+
+//  Below this length a single edit is too likely to be a different word
+const SHORT_KEY_LENGTH = 5;
+
+function childPath(path, key) {
+    return path ? `${path}.${key}` : key;
+}
+
+function typeNameOf(value) {
+    if (null === value) {
+        return 'null';
+    }
+    if (Array.isArray(value)) {
+        return NodeType.Array;
+    }
+    return typeof value;
+}
+
+//
+//  Levenshtein distance, bailing out as soon as it exceeds |max|. Keys are
+//  short and the candidate list is one object's worth, so the naive matrix is
+//  entirely adequate.
+//
+function editDistance(a, b, max) {
+    if (Math.abs(a.length - b.length) > max) {
+        return max + 1;
+    }
+
+    let prev = Array.from({ length: b.length + 1 }, (_unused, i) => i);
+
+    for (let i = 1; i <= a.length; ++i) {
+        const row = [i];
+        let best = i;
+
+        for (let j = 1; j <= b.length; ++j) {
+            const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+            row[j] = Math.min(row[j - 1] + 1, prev[j] + 1, prev[j - 1] + cost);
+            best = Math.min(best, row[j]);
+        }
+
+        if (best > max) {
+            return max + 1;
+        }
+
+        prev = row;
+    }
+
+    return prev[b.length];
+}
+
+//
+//  The nearest sibling key, when there is one close enough to be worth
+//  mentioning. Siblings only: searching the whole tree turns up confident
+//  nonsense for common names like "enabled", "port" and "path".
+//
+function suggestKey(key, candidates) {
+    const max = key.length < SHORT_KEY_LENGTH ? 1 : 2;
+    let best;
+    let bestDistance = max + 1;
+
+    (candidates || []).forEach(candidate => {
+        const distance = editDistance(
+            key.toLowerCase(),
+            candidate.toLowerCase(),
+            max
+        );
+        if (distance <= max && distance < bestDistance) {
+            best = candidate;
+            bestDistance = distance;
+        }
+    });
+
+    return best;
+}
+
+//
+//  Walk 1: keys the sysop wrote that the schema does not recognise.
+//
+function collectUnknownKeys(userConfig, schema, issues) {
+    (function walk(value, node, path) {
+        if (!node || !_.isPlainObject(value)) {
+            return;
+        }
+
+        //  nothing is known below here, so nothing can be wrong either
+        if (NodeType.Unknown === node.type) {
+            return;
+        }
+
+        if (true === node.openMap) {
+            //  these keys are sysop data; only their contents are checkable
+            Object.entries(value).forEach(([key, child]) =>
+                walk(child, node.value, childPath(path, key))
+            );
+            return;
+        }
+
+        if (NodeType.Object !== node.type) {
+            //  the value disagrees with the schema's shape; walk 2 reports it
+            return;
+        }
+
+        const children = node.children || {};
+
+        Object.entries(value).forEach(([key, child]) => {
+            const childNode = children[key];
+
+            if (childNode) {
+                return walk(child, childNode, childPath(path, key));
+            }
+
+            //
+            //  Only complain where the schema claims to know every key. A
+            //  shape derived from a couple of example entries does not, and
+            //  neither does a section we only know about because meta
+            //  mentioned it.
+            //
+            if (true === node.closedKeys) {
+                issues.push(
+                    makeIssue(IssueCodes.UnknownKey, childPath(path, key), {
+                        key,
+                        suggestion: suggestKey(key, Object.keys(children)),
+                    })
+                );
+            }
+
+            //  do not descend: everything under an unknown key is unknown too
+        });
+    })(userConfig, schema, '');
+}
+
+function checkEnum(value, node, path, issues) {
+    if (!node.enum || node.enum.includes(value)) {
+        return;
+    }
+
+    issues.push(
+        makeIssue(IssueCodes.InvalidEnum, path, { value, allowed: node.enum })
+    );
+}
+
+function checkRange(value, node, path, issues) {
+    if ('number' !== typeof value) {
+        return;
+    }
+
+    const belowMin = undefined !== node.min && value < node.min;
+    const aboveMax = undefined !== node.max && value > node.max;
+
+    if (belowMin || aboveMax) {
+        issues.push(
+            makeIssue(IssueCodes.ValueOutOfRange, path, {
+                value,
+                min: node.min,
+                max: node.max,
+            })
+        );
+    }
+}
+
+function checkLeaf(value, node, path, issues, options) {
+    if (undefined === value) {
+        return;
+    }
+
+    if (null === value) {
+        if (true !== node.nullable) {
+            issues.push(
+                makeIssue(IssueCodes.TypeMismatch, path, {
+                    expected: node.type,
+                    actual: 'null',
+                })
+            );
+        }
+        return;
+    }
+
+    //
+    //  An unresolved "@" spec is a resolution problem, not a type error: the
+    //  variable may simply not exist in whatever shell is doing the checking.
+    //  Reporting it by default would flag correct production configurations,
+    //  so it is opt-in.
+    //
+    if ('string' === typeof value && UNRESOLVED_SPEC.test(value)) {
+        if (options.checkEnv) {
+            issues.push(makeIssue(IssueCodes.UnresolvedSpec, path, { spec: value }));
+        }
+        return;
+    }
+
+    const actual = typeNameOf(value);
+    if (actual !== node.type) {
+        issues.push(
+            makeIssue(IssueCodes.TypeMismatch, path, {
+                expected: node.type,
+                actual,
+            })
+        );
+        return;
+    }
+
+    if (NodeType.Array === node.type) {
+        if (node.items && node.items.type !== NodeType.Unknown) {
+            value.forEach((entry, i) => {
+                checkLeaf(entry, node.items, `${path}[${i}]`, issues, options);
+            });
+        }
+        return;
+    }
+
+    checkEnum(value, node, path, issues);
+    checkRange(value, node, path, issues);
+}
+
+//
+//  Walk 2: values whose type, set or range disagrees with the schema.
+//
+function collectValueIssues(mergedConfig, schema, issues, options) {
+    (function walk(value, node, path) {
+        if (!node || NodeType.Unknown === node.type || undefined === value) {
+            return;
+        }
+
+        if (true === node.openMap) {
+            if (_.isPlainObject(value)) {
+                Object.entries(value).forEach(([key, child]) =>
+                    walk(child, node.value, childPath(path, key))
+                );
+            }
+            return;
+        }
+
+        if (NodeType.Object === node.type) {
+            if (!_.isPlainObject(value)) {
+                issues.push(
+                    makeIssue(IssueCodes.TypeMismatch, path, {
+                        expected: NodeType.Object,
+                        actual: typeNameOf(value),
+                    })
+                );
+                return;
+            }
+
+            const children = node.children || {};
+            Object.entries(value).forEach(([key, child]) => {
+                if (children[key]) {
+                    walk(child, children[key], childPath(path, key));
+                }
+            });
+            return;
+        }
+
+        checkLeaf(value, node, path, issues, options);
+    })(mergedConfig, schema, '');
+}
+
+//
+//  |userConfig|   what the sysop wrote, before the defaults were merged in.
+//                 Pass undefined to skip unknown key detection.
+//  |mergedConfig| the effective configuration, after merging and after "@"
+//                 specs were resolved.
+//  |options|      { checkEnv } -- report "@" specs that did not resolve.
+//
+//  Returns an array of issues, empty when the configuration is clean.
+//
+function validateConfig(userConfig, mergedConfig, schema, options = {}) {
+    const issues = [];
+
+    if (!schema) {
+        return issues;
+    }
+
+    if (_.isPlainObject(userConfig)) {
+        collectUnknownKeys(userConfig, schema, issues);
+    }
+
+    if (_.isPlainObject(mergedConfig)) {
+        collectValueIssues(mergedConfig, schema, issues, options);
+    }
+
+    return issues;
+}
+
+module.exports = {
+    validateConfig,
+    suggestKey,
+};

--- a/test/config_validate.test.js
+++ b/test/config_validate.test.js
@@ -1,0 +1,311 @@
+'use strict';
+
+const { strict: assert } = require('assert');
+const _ = require('lodash');
+const paths = require('path');
+const fs = require('fs');
+const hjson = require('hjson');
+
+const { buildSchema } = require('../core/config/schema');
+const { validateConfig, suggestKey } = require('../core/config/validate');
+const {
+    IssueCodes,
+    Severity,
+    describeIssue,
+    countBySeverity,
+} = require('../core/config/issue');
+const DefaultConfig = require('../core/config_default');
+
+//  Merge the way ConfigLoader does, so tests exercise the real shadowing.
+const merge = user => _.merge(DefaultConfig(), _.cloneDeep(user));
+
+const validate = (user, options) =>
+    validateConfig(user, merge(user), buildSchema(), options);
+
+const codes = issues => issues.map(i => i.code);
+
+// ─── The failure mode this exists to catch ───────────────────────────────────
+
+describe('config validation: silent shadowing', () => {
+    it('reports a misspelled key that the merge left sitting beside the default', () => {
+        const issues = validate({
+            scannerTossers: { ftn_bso: { paths: { outbund: '/home/bbs/out' } } },
+        });
+
+        assert.equal(issues.length, 1);
+        assert.equal(issues[0].code, IssueCodes.UnknownKey);
+        assert.equal(issues[0].severity, Severity.Warning);
+        assert.equal(issues[0].path, 'scannerTossers.ftn_bso.paths.outbund');
+        assert.equal(issues[0].suggestion, 'outbound');
+    });
+
+    it('says what to do about it', () => {
+        const [issue] = validate({ general: { boardnam: 'x' } });
+        const described = describeIssue(issue);
+        assert.equal(described.severity, Severity.Warning);
+        assert.equal(described.path, 'general.boardnam');
+        assert.equal(
+            described.message,
+            'unknown key "boardnam" -- did you mean "boardName"?'
+        );
+    });
+
+    it('offers no suggestion when nothing is close', () => {
+        const [issue] = validate({ general: { zzzzzzzzzz: 1 } });
+        assert.equal(issue.code, IssueCodes.UnknownKey);
+        assert.equal(issue.suggestion, undefined);
+        assert.equal(describeIssue(issue).message, 'unknown key "zzzzzzzzzz"');
+    });
+});
+
+// ─── Staying quiet when it should ────────────────────────────────────────────
+
+describe('config validation: false positives', () => {
+    it('finds nothing wrong with the shipped defaults', () => {
+        //  The defaults are where the types come from, so anything reported
+        //  here is a bug in the schema rather than in a configuration.
+        const issues = validateConfig({}, DefaultConfig(), buildSchema());
+        assert.deepEqual(issues, []);
+    });
+
+    it('finds nothing wrong with a freshly generated configuration', () => {
+        //
+        //  The check the whole effort lives or dies on: a brand new
+        //  installation must produce no findings at all. Anything here is a
+        //  warning the very first sysop to run this would see on a config
+        //  they did nothing wrong to create.
+        //
+        //  Reproduces what "oputil.js config new" builds -- the shipped
+        //  template with real defaults merged over its XXXXX placeholders.
+        //  ConfigIncludeKeys mirrors core/oputil/oputil_config.js:30-42; PR 3
+        //  replaces this with a call to the command itself.
+        //
+        const ConfigIncludeKeys = [
+            'theme',
+            'users.preAuthIdleLogoutSeconds',
+            'users.idleLogoutSeconds',
+            'users.newUserNames',
+            'users.failedLogin',
+            'users.unlockAtEmailPwReset',
+            'paths.logs',
+            'loginServers',
+            'contentServers',
+            'fileBase.areaStoragePrefix',
+            'logging.rotatingFile',
+        ];
+
+        const templatePath = paths.join(__dirname, '../misc/config_template.in.hjson');
+        const template = hjson.parse(fs.readFileSync(templatePath, 'utf8'));
+
+        const direct = {};
+        const defaults = DefaultConfig();
+        ConfigIncludeKeys.forEach(keyPath =>
+            _.set(direct, keyPath, _.get(defaults, keyPath))
+        );
+
+        const generated = _.mergeWith(template, direct);
+        generated.general.boardName = 'Test BBS';
+
+        const issues = validate(generated);
+        assert.deepEqual(
+            issues.map(i => `${i.severity} ${i.path}: ${describeIssue(i).message}`),
+            []
+        );
+    });
+
+    it('does not object to extra keys in a file area', () => {
+        //  §0.1: the two example areas in the defaults mention neither of
+        //  these, and both are perfectly legal.
+        const issues = validate({
+            fileBase: {
+                areas: {
+                    retro_pc: {
+                        name: 'Retro PC',
+                        storageTags: ['retro_pc'],
+                        acs: { download: 'GM[users]' },
+                        hashTags: ['retro', 'pc'],
+                    },
+                },
+            },
+        });
+
+        assert.deepEqual(issues, []);
+    });
+
+    it('does not object to sysop chosen keys in an open map', () => {
+        const issues = validate({
+            messageConferences: {
+                my_conf: { name: 'Mine', areas: { my_area: { name: 'Area' } } },
+            },
+            fileBase: { storageTags: { my_tag: '/some/where' } },
+        });
+
+        assert.deepEqual(issues, []);
+    });
+
+    it('accepts a section that has no default at all', () => {
+        const issues = validate({
+            messageNetworks: {
+                ftn: {
+                    networks: {
+                        agoranet: { localAddress: '46:1/100' },
+                    },
+                },
+            },
+        });
+
+        assert.deepEqual(issues, []);
+    });
+
+    it('accepts null for a path documented as nullable', () => {
+        const issues = validate({
+            term: { forceOutputEncoding: null },
+            email: { outbound: { fromDomain: null } },
+        });
+
+        assert.deepEqual(issues, []);
+    });
+
+    it('reports a mod section once, not once per key inside it', () => {
+        const issues = validate({
+            my_fancy_mod: { one: 1, two: 2, three: { four: 4, five: 5 } },
+        });
+
+        assert.equal(issues.length, 1);
+        assert.equal(issues[0].path, 'my_fancy_mod');
+        assert.equal(issues[0].severity, Severity.Warning);
+    });
+});
+
+// ─── Values ──────────────────────────────────────────────────────────────────
+
+describe('config validation: values', () => {
+    it('reports a type that disagrees with the default it overrides', () => {
+        const [issue] = validate({ general: { maxConnections: 'lots' } });
+        assert.equal(issue.code, IssueCodes.TypeMismatch);
+        assert.equal(issue.severity, Severity.Error);
+        assert.equal(describeIssue(issue).message, 'expected number, got string');
+    });
+
+    it('reports null where null is not documented', () => {
+        const [issue] = validate({ general: { boardName: null } });
+        assert.equal(issue.code, IssueCodes.TypeMismatch);
+        assert.equal(issue.actual, 'null');
+    });
+
+    it('reports an object where a scalar belongs', () => {
+        const [issue] = validate({ general: { boardName: { nope: true } } });
+        assert.equal(issue.code, IssueCodes.TypeMismatch);
+        assert.equal(issue.expected, 'string');
+    });
+
+    it('checks the elements of a typed array', () => {
+        const schema = buildSchema({ list: ['a'] }, {});
+        const issues = validateConfig({}, { list: ['ok', 7] }, schema);
+        assert.equal(issues.length, 1);
+        assert.equal(issues[0].code, IssueCodes.TypeMismatch);
+        assert.equal(issues[0].path, 'list[1]');
+    });
+
+    it('enforces an enum meta declares', () => {
+        const schema = buildSchema({ mode: 'warn' }, { mode: { enum: ['warn', 'off'] } });
+        const [issue] = validateConfig({}, { mode: 'loud' }, schema);
+        assert.equal(issue.code, IssueCodes.InvalidEnum);
+        assert.equal(describeIssue(issue).message, '"loud" is not one of: warn, off');
+    });
+
+    it('enforces a range meta declares', () => {
+        const schema = buildSchema({ port: 8080 }, { port: { min: 1, max: 65535 } });
+        const [low] = validateConfig({}, { port: 0 }, schema);
+        assert.equal(low.code, IssueCodes.ValueOutOfRange);
+        assert.equal(describeIssue(low).message, '0 is below the minimum of 1');
+
+        const [high] = validateConfig({}, { port: 70000 }, schema);
+        assert.equal(describeIssue(high).message, '70000 is above the maximum of 65535');
+    });
+
+    it('says nothing about a node whose default carried no type', () => {
+        const schema = buildSchema({ blob: {} }, {});
+        assert.deepEqual(validateConfig({}, { blob: 'anything at all' }, schema), []);
+    });
+});
+
+// ─── Unresolved @ specs ──────────────────────────────────────────────────────
+
+describe('config validation: unresolved @ specs', () => {
+    //
+    //  When an environment variable is not set, _resolveAtSpecs() leaves the
+    //  literal spec string in place. Type checking it would report a correct
+    //  production config as broken purely because it was validated from the
+    //  wrong shell.
+    //
+    const schema = buildSchema({ port: 8080 }, {});
+    const merged = { port: '@environment:BBS_PORT:number' };
+
+    it('ignores an unresolved spec by default', () => {
+        assert.deepEqual(validateConfig({}, merged, schema), []);
+    });
+
+    it('reports one when asked to check the environment', () => {
+        const issues = validateConfig({}, merged, schema, { checkEnv: true });
+        assert.equal(issues.length, 1);
+        assert.equal(issues[0].code, IssueCodes.UnresolvedSpec);
+        assert.equal(issues[0].severity, Severity.Error);
+        assert.equal(
+            describeIssue(issues[0]).message,
+            '"@environment:BBS_PORT:number" did not resolve'
+        );
+    });
+
+    it('leaves an ordinary string beginning with @ alone', () => {
+        const strings = buildSchema({ note: 'x' }, {});
+        assert.deepEqual(
+            validateConfig({}, { note: '@home tonight' }, strings, { checkEnv: true }),
+            []
+        );
+    });
+});
+
+// ─── Suggestions ─────────────────────────────────────────────────────────────
+
+describe('config validation: suggestions', () => {
+    const siblings = ['outbound', 'inbound', 'secInbound', 'reject'];
+
+    it('finds a single character slip', () => {
+        assert.equal(suggestKey('outbund', siblings), 'outbound');
+        assert.equal(suggestKey('inbnud', siblings), 'inbound');
+    });
+
+    it('is case insensitive', () => {
+        assert.equal(suggestKey('OutBound', siblings), 'outbound');
+    });
+
+    it('gives up rather than guessing wildly', () => {
+        assert.equal(suggestKey('completelyDifferent', siblings), undefined);
+    });
+
+    it('is stricter about short keys, where one edit is a different word', () => {
+        //  "port" -> "sort" is one edit but plainly not a typo of the other
+        assert.equal(suggestKey('acs', ['acl']), 'acl');
+        assert.equal(suggestKey('acs', ['name', 'desc']), undefined);
+    });
+});
+
+// ─── Reporting helpers ───────────────────────────────────────────────────────
+
+describe('config validation: issue helpers', () => {
+    it('counts by severity', () => {
+        const issues = validate({
+            general: { boardnam: 'x', maxConnections: 'lots' },
+        });
+        assert.deepEqual(countBySeverity(issues), { errors: 1, warnings: 1 });
+        assert.deepEqual(codes(issues).sort(), [
+            IssueCodes.TypeMismatch,
+            IssueCodes.UnknownKey,
+        ]);
+    });
+
+    it('returns nothing when there is no schema', () => {
+        assert.deepEqual(validateConfig({ a: 1 }, { a: 1 }, undefined), []);
+    });
+});


### PR DESCRIPTION
**Part 2/8 of #281.** Stacked on #764 — **review that first**; this PR's diff is only its own two modules plus tests. Still nothing calls this, and there is no runtime behaviour change.

## Two walks, over two different objects

This is the crux of the design, and the reason a naive "validate the config" would catch nothing:

- **Unknown keys are only visible pre-merge.** Once `_.merge()` folds the sysop's file into the defaults, `outbund` sits quietly *beside* `outbound` and both are present. The board keeps spooling to the default path and nothing is ever reported. So this walk has to see what the sysop actually wrote.
- **Types are only correct post-merge**, where defaulted values are present and `@` specs have resolved.

## Staying quiet when unsure

A validator that cries wolf on a working board gets switched off, and then it protects nobody. Three deliberate silences:

- **Unresolved `@` specs are skipped, not type-checked.** When a variable is unset, `_resolveAtSpecs()` leaves the literal spec string in the config ([config_loader.js:310-325](core/config_loader.js#L310-L325)), so `@environment:PORT:number` would read as a string and be reported as a type error — on a correct production config, purely because it was validated from a shell without that variable. Opt in with `{ checkEnv: true }` when that is genuinely the question.
- **Shapes derived from examples don't constrain key sets.** The two file areas in the defaults mention neither `acs` nor `hashTags`; both are legal.
- **An unknown subtree is reported once, not once per key.** A mod's section yields one warning, not twenty.

## Suggestions

Levenshtein over **sibling keys only**, with a tighter bound on short keys where a single edit is more likely a different word than a typo. Whole-tree search was considered and rejected: it produces confident nonsense for names like `enabled`, `port` and `path`.

## Issue model

Plain `{ code, ... }` bags following `validateOutboundConfig()` in [core/bso_util.js](core/bso_util.js#L210), with `severity` and `path` added — there are enough codes and enough reporting surfaces (stderr at boot, the log on reload, oputil) that repeating a switch at each would be silly. `describeIssue()` is the only place wording lives, so all three surfaces say the same thing.

## The test that matters

**A freshly generated configuration produces no findings at all** — the shipped template with real defaults merged over its `XXXXX` placeholders, exactly as `oputil config new` builds it. One false warning there is one every new sysop sees on a config they did nothing wrong to create. Verified: zero.

Also covered: the shipped defaults alone validate clean (anything there would be a schema bug, not a config bug), the `outbund` case end to end, extra file-area keys, open-map keys, `null` on documented-nullable paths, and a section with no default at all.

26 new tests. Full suite: 2180 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)