### PR TITLE
feat(config): add "oputil.js config validate"

### DIFF
--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -3,6 +3,24 @@ This document attempts to track **major** changes and additions in ENiGMA½. For
 
 ## 0.5.1-beta
 
+* **`oputil.js config validate` checks your configuration before you restart** ([#281](https://github.com/NuSkooler/enigma-bbs/issues/281)) — a mistyped key in `config.hjson` has never been reported. Because your file is merged *into* the defaults, a typo does not replace anything: `outbund` lands quietly beside `outbound`, the setting you wrote is never read, and the board goes on using the default. Nothing is logged, and the file looks correct.
+
+  The new command reports those, along with values whose type disagrees with the default they override:
+
+  ```
+  config.hjson: 2 issues (1 error, 1 warning)
+
+    error    general.maxConnections
+             expected number, got string
+
+    warning  scannerTossers.ftn_bso.paths.outbund
+             unknown key "outbund" -- did you mean "outbound"?
+  ```
+
+  It exits non-zero when there are errors, so it can be used from a script or a systemd `ExecStartPre`. Warnings alone are not a failure: an unrecognised key may perfectly well belong to a mod. Sections you add yourself, and the tags and names you choose for areas, networks and nodes, are never reported.
+
+  `--check-env` additionally reports `@environment:`, `@file:` and `@reference:` specs that do not resolve. That one is opt-in because resolution depends on the shell it runs in: checked by default, a perfectly good configuration would look broken purely because it was validated from the wrong place.
+
 * **TIC-announced files were lost whenever the file arrived after its announcement** ([#735](https://github.com/NuSkooler/enigma-bbs/issues/735)) — a `.tic` control file and the file it announces routinely arrive in *separate* mailer sessions; a peer running HTick was observed announcing a full Zone 1 nodelist 15–20 minutes ahead of the payload. ENiGMA½ processed the `.tic` the moment it landed, could not find the file, archived the announcement to `reject/` and unlinked it. The file then arrived with nothing left to pair it with and sat in the secure inbound indefinitely. For that peer and that file it failed every single time, and recovery meant finding the orphan by hand and forcing a rescan.
 
   A TIC whose file is not here yet is now **held** and retried on later import passes — the same disposition HTick uses (`TIC_NotRecvd`, "has not been received, waiting") — rather than rejected. Because an import pass already runs the instant a BinkP session delivers files, the pairing normally completes within seconds of the file landing. A TIC that is never satisfied is given up on after `tic.holdMaxAgeMs` (48 hours by default) and rejected as before, so nothing accumulates forever.

--- a/core/config.js
+++ b/core/config.js
@@ -58,6 +58,8 @@ exports.Config = class Config extends ConfigLoader {
             //  instance we just created
             exports.get = systemConfigInstance.get.bind(systemConfigInstance);
             exports.reload = systemConfigInstance.reload.bind(systemConfigInstance);
+            exports.getUserConfig =
+                systemConfigInstance.getUserConfig.bind(systemConfigInstance);
 
             return cb(null);
         });

--- a/core/config_loader.js
+++ b/core/config_loader.js
@@ -15,16 +15,27 @@ module.exports = class ConfigLoader {
             defaultsCustomizer = null,
             onReload = null,
             keepWsc = false,
+            validator = null,
+            onValidation = null,
         } = {
             hotReload: true,
             defaultConfig: {},
             defaultsCustomizer: null,
             onReload: null,
             keepWsc: false,
+            validator: null,
+            onValidation: null,
         }
     ) {
         this.current = {};
         this.rawConfig = undefined;
+        //  what the operator wrote, before defaults; see _reload()
+        this.userConfig = {};
+        this.lastIssues = [];
+        this._hasLoaded = false;
+
+        this.validator = validator;
+        this.onValidation = onValidation;
 
         this.hotReload = hotReload;
         this.defaultConfig = defaultConfig;
@@ -89,6 +100,19 @@ module.exports = class ConfigLoader {
         return this.rawConfig !== undefined ? this.rawConfig : this.current;
     }
 
+    //  What the operator wrote -- the base file unioned with anything its
+    //  "includes" pulled in -- with no defaults merged over it. Note that
+    //  this copy is taken before @reference/@environment/@file are resolved,
+    //  since it exists to answer questions about keys rather than values.
+    getUserConfig() {
+        return this.userConfig;
+    }
+
+    //  Issues from the most recent load; empty unless a validator was supplied.
+    getIssues() {
+        return this.lastIssues;
+    }
+
     _reload(baseConfigPath, cb) {
         let defaultConfig;
         if (_.isFunction(this.defaultConfig)) {
@@ -109,7 +133,24 @@ module.exports = class ConfigLoader {
         async.waterfall(
             [
                 callback => {
-                    return this._loadConfigFile(baseConfigPath, callback);
+                    return this._loadConfigFile(baseConfigPath, (err, config) => {
+                        if (err) {
+                            return callback(err);
+                        }
+
+                        //
+                        //  Keep what the operator actually wrote, before the
+                        //  defaults are merged over the top of it. Afterwards
+                        //  there is no way to tell a deliberate setting from a
+                        //  default, so a misspelled key -- which lands beside
+                        //  the correctly spelled default rather than replacing
+                        //  it -- becomes invisible. Validation needs this copy
+                        //  to see it.
+                        //
+                        this.userConfig = _.cloneDeep(config);
+
+                        return callback(null, config);
+                    });
                 },
                 (config, callback) => {
                     if (_.isFunction(this.defaultsCustomizer)) {
@@ -159,6 +200,10 @@ module.exports = class ConfigLoader {
                     config = this._resolveAtSpecs(config);
                     return callback(null, config);
                 },
+                (config, callback) => {
+                    this._validate(config);
+                    return callback(null, config);
+                },
             ],
             (err, config) => {
                 if (!err) {
@@ -168,6 +213,44 @@ module.exports = class ConfigLoader {
                 return cb(err);
             }
         );
+    }
+
+    //
+    //  Step 5 of the waterfall. Validation is advisory: it reports, and the
+    //  configuration is applied either way.
+    //
+    //  Both calls are guarded because a *synchronous* throw inside an
+    //  async.waterfall task does not reach the waterfall's callback -- it
+    //  propagates straight out. _reload() runs from the file watcher, so an
+    //  unguarded throw here would be an uncaught exception that takes the
+    //  board down mid-session, on nothing worse than a bad config edit. A
+    //  validator bug must never be able to do that.
+    //
+    _validate(config) {
+        let issues = [];
+
+        try {
+            if (_.isFunction(this.validator)) {
+                issues = this.validator(this.userConfig, config) || [];
+            }
+        } catch (e) {
+            //  console: this can run before logger.init()
+            console.info(`WARNING: configuration validation failed: ${e.message}`); //  eslint-disable-line no-console
+        }
+
+        this.lastIssues = issues;
+
+        try {
+            if (_.isFunction(this.onValidation)) {
+                this.onValidation(issues, { initialLoad: !this._hasLoaded });
+            }
+        } catch (e) {
+            console.info(
+                `WARNING: configuration validation reporting failed: ${e.message}`
+            ); //  eslint-disable-line no-console
+        }
+
+        this._hasLoaded = true;
     }
 
     _convertTo(value, type) {
@@ -297,6 +380,13 @@ module.exports = class ConfigLoader {
                     }
 
                     _.defaultsDeep(config, includedConfig);
+
+                    //  an include is operator content too, so it belongs in
+                    //  the pre-merge copy validation reads
+                    if (_.isObject(this.userConfig)) {
+                        _.defaultsDeep(this.userConfig, _.cloneDeep(includedConfig));
+                    }
+
                     return nextIncludePath(null);
                 });
             },

--- a/core/oputil/oputil_common.js
+++ b/core/oputil/oputil_common.js
@@ -16,6 +16,7 @@ const packageJson = require('../../package.json');
 exports.printUsageAndSetExitCode = printUsageAndSetExitCode;
 exports.getDefaultConfigPath = getDefaultConfigPath;
 exports.getConfigPath = getConfigPath;
+exports.initConfig = initConfig;
 exports.initConfigAndDatabases = initConfigAndDatabases;
 exports.getAreaAndStorage = getAreaAndStorage;
 exports.looksLikePattern = looksLikePattern;
@@ -45,7 +46,7 @@ const argv = (exports.argv = require('minimist')(process.argv.slice(2), {
         c: 'config',
         n: 'no-prompt',
     },
-    boolean: ['quick', 'full', 'verbose', 'update', 'yes'],
+    boolean: ['quick', 'full', 'verbose', 'update', 'yes', 'check-env'],
 }));
 
 function printUsageAndSetExitCode(errMsg, exitCode) {

--- a/core/oputil/oputil_config.js
+++ b/core/oputil/oputil_config.js
@@ -318,6 +318,90 @@ function catCurrentConfig() {
     }
 }
 
+//
+//  Check the configuration and say what is wrong with it, without starting
+//  anything. A sysop wants to know *before* a restart, not from a log line
+//  afterwards -- and unlike the boot time report, this one sets an exit code
+//  so it is usable from a script or a systemd ExecStartPre.
+//
+//  Deliberately uses initConfig() rather than initConfigAndDatabases(): a
+//  broken configuration is exactly when the databases are least likely to be
+//  reachable, and validation needs none of them.
+//
+function validateCurrentConfig() {
+    const { initConfig } = require('./oputil_common.js');
+    const conf = require('../../core/config.js');
+
+    initConfig(err => {
+        if (err) {
+            console.error(`Failed to load configuration: ${err.message}`);
+            if (err.configPath) {
+                console.error(`Note: ${err.configPath}`);
+            }
+            process.exitCode = ExitCodes.ERROR;
+            return;
+        }
+
+        const { buildSchema } = require('../../core/config/schema.js');
+        const { validateConfig } = require('../../core/config/validate.js');
+        const {
+            describeIssue,
+            countBySeverity,
+            Severity,
+        } = require('../../core/config/issue.js');
+
+        const issues = validateConfig(conf.getUserConfig(), conf.get(), buildSchema(), {
+            checkEnv: true === argv['check-env'],
+        });
+
+        const configPath = getConfigPath();
+
+        if (0 === issues.length) {
+            console.info(`${configPath}: no problems found`);
+            process.exitCode = ExitCodes.SUCCESS;
+            return;
+        }
+
+        const { errors, warnings } = countBySeverity(issues);
+        const parts = [];
+        if (errors) {
+            parts.push(`${errors} error${1 === errors ? '' : 's'}`);
+        }
+        if (warnings) {
+            parts.push(`${warnings} warning${1 === warnings ? '' : 's'}`);
+        }
+
+        console.info(
+            `${configPath}: ${issues.length} issue${
+                1 === issues.length ? '' : 's'
+            } (${parts.join(', ')})\n`
+        );
+
+        //  errors first; they are the ones that will actually misbehave
+        const ordered = issues.slice().sort((a, b) => {
+            if (a.severity === b.severity) {
+                return a.path.localeCompare(b.path);
+            }
+            return Severity.Error === a.severity ? -1 : 1;
+        });
+
+        ordered.forEach(issue => {
+            const described = describeIssue(issue);
+            console.info(`  ${described.severity.padEnd(8)} ${described.path}`);
+            described.message.split('\n').forEach(line => {
+                console.info(`           ${line}`);
+            });
+            console.info('');
+        });
+
+        //
+        //  Warnings alone are not a failure: an unknown key may well be a
+        //  mod's own configuration block.
+        //
+        process.exitCode = errors > 0 ? ExitCodes.ERROR : ExitCodes.SUCCESS;
+    });
+}
+
 function handleConfigCommand() {
     if (true === argv.help) {
         return printUsageAndSetExitCode(getHelpFor('Config'), ExitCodes.ERROR);
@@ -330,6 +414,8 @@ function handleConfigCommand() {
             return buildNewConfig();
         case 'cat':
             return catCurrentConfig();
+        case 'validate':
+            return validateCurrentConfig();
 
         default:
             return printUsageAndSetExitCode(getHelpFor('Config'), ExitCodes.ERROR);

--- a/core/oputil/oputil_help.js
+++ b/core/oputil/oputil_help.js
@@ -111,9 +111,15 @@ Actions:
 
   cat                      Write current configuration to stdout
 
+  validate                 Check the configuration for problems
+
 cat arguments:
   --no-colors              Disable color
   --no-comments            Strip any comments
+
+validate arguments:
+  --check-env              Also report @environment:, @file: and @reference:
+                           specs that do not resolve in this environment
 `,
     FileBase: `usage: oputil.js fb <action> [<arguments>]
 

--- a/test/config_loader.test.js
+++ b/test/config_loader.test.js
@@ -313,3 +313,163 @@ describe('ConfigLoader debounce (_scheduleReload)', () => {
         });
     });
 });
+
+// ─── Pre-merge capture and validation hook ───────────────────────────────────
+
+describe('ConfigLoader.getUserConfig()', () => {
+    //
+    //  Once the defaults are merged in there is no way to tell a deliberate
+    //  setting from a default, so a misspelled key -- which lands beside the
+    //  correct default rather than replacing it -- becomes invisible. This is
+    //  the copy that still knows the difference.
+    //
+    const stubbedLoader = (baseConfig, includes = {}) => {
+        const loader = new ConfigLoader({
+            hotReload: false,
+            defaultConfig: { general: { boardName: 'Default BBS', port: 23 } },
+        });
+        loader.baseConfigPath = '/fake/config.hjson';
+
+        loader._loadConfigFile = (filePath, cb) => {
+            if (filePath === loader.baseConfigPath) {
+                return cb(null, JSON.parse(JSON.stringify(baseConfig)));
+            }
+            return cb(null, JSON.parse(JSON.stringify(includes[filePath] || {})));
+        };
+
+        return loader;
+    };
+
+    it('keeps what the operator wrote, without the defaults merged over it', done => {
+        const loader = stubbedLoader({ general: { boardName: 'Mine' } });
+
+        loader._reload(loader.baseConfigPath, err => {
+            assert.ifError(err);
+            //  the merged view has the default port; the operator's copy does not
+            assert.equal(loader.get().general.port, 23);
+            assert.deepEqual(loader.getUserConfig(), { general: { boardName: 'Mine' } });
+            done();
+        });
+    });
+
+    it('keeps a misspelled key distinguishable from the default it shadows', done => {
+        const loader = stubbedLoader({ general: { prot: 8888 } });
+
+        loader._reload(loader.baseConfigPath, err => {
+            assert.ifError(err);
+            //  both present after the merge -- which is the whole problem
+            assert.equal(loader.get().general.port, 23);
+            assert.equal(loader.get().general.prot, 8888);
+            //  but only the typo is in what the operator wrote
+            assert.deepEqual(Object.keys(loader.getUserConfig().general), ['prot']);
+            done();
+        });
+    });
+
+    it('includes are operator content too', done => {
+        const loader = stubbedLoader(
+            { general: { boardName: 'Mine' }, includes: ['areas.hjson'] },
+            { '/fake/areas.hjson': { messageConferences: { local: { name: 'Local' } } } }
+        );
+
+        loader._reload(loader.baseConfigPath, err => {
+            assert.ifError(err);
+            assert.equal(loader.getUserConfig().messageConferences.local.name, 'Local');
+            assert.equal(loader.getUserConfig().general.boardName, 'Mine');
+            done();
+        });
+    });
+});
+
+describe('ConfigLoader validation hook', () => {
+    const loaderWith = options => {
+        const loader = new ConfigLoader(Object.assign({ hotReload: false }, options));
+        loader.baseConfigPath = '/fake/config.hjson';
+        loader._loadConfigFile = (filePath, cb) => cb(null, { a: 1 });
+        return loader;
+    };
+
+    it('passes the operator config and the merged config to the validator', done => {
+        let seen;
+        const loader = loaderWith({
+            defaultConfig: { b: 2 },
+            validator: (userConfig, merged) => {
+                seen = { userConfig, merged };
+                return [{ code: 'test', severity: 'warning', path: 'a' }];
+            },
+        });
+
+        loader._reload(loader.baseConfigPath, err => {
+            assert.ifError(err);
+            assert.deepEqual(seen.userConfig, { a: 1 });
+            assert.deepEqual(seen.merged, { a: 1, b: 2 });
+            assert.equal(loader.getIssues().length, 1);
+            done();
+        });
+    });
+
+    it('tells onValidation whether this is the first load', done => {
+        const seen = [];
+        const loader = loaderWith({
+            validator: () => [],
+            onValidation: (issues, { initialLoad }) => seen.push(initialLoad),
+        });
+
+        loader._reload(loader.baseConfigPath, err => {
+            assert.ifError(err);
+            loader._reload(loader.baseConfigPath, err2 => {
+                assert.ifError(err2);
+                assert.deepEqual(seen, [true, false]);
+                done();
+            });
+        });
+    });
+
+    it('survives a validator that throws, rather than taking the board down', done => {
+        //
+        //  A *synchronous* throw inside an async.waterfall task propagates
+        //  straight out and the waterfall's callback never fires. _reload()
+        //  runs from the file watcher, so unguarded that is an uncaught
+        //  exception on nothing worse than a bad config edit. Asserted
+        //  against the real async, not a stub, because the stub is exactly
+        //  what would hide it.
+        //
+        const loader = loaderWith({
+            validator: () => {
+                throw new Error('validator is broken');
+            },
+        });
+
+        loader._reload(loader.baseConfigPath, err => {
+            assert.ifError(err);
+            assert.deepEqual(loader.get(), { a: 1 });
+            assert.deepEqual(loader.getIssues(), []);
+            done();
+        });
+    });
+
+    it('survives a reporter that throws', done => {
+        const loader = loaderWith({
+            validator: () => [{ code: 'test', severity: 'warning', path: 'a' }],
+            onValidation: () => {
+                throw new Error('reporter is broken');
+            },
+        });
+
+        loader._reload(loader.baseConfigPath, err => {
+            assert.ifError(err);
+            assert.deepEqual(loader.get(), { a: 1 });
+            done();
+        });
+    });
+
+    it('does nothing at all when no validator is supplied', done => {
+        const loader = loaderWith({});
+
+        loader._reload(loader.baseConfigPath, err => {
+            assert.ifError(err);
+            assert.deepEqual(loader.getIssues(), []);
+            done();
+        });
+    });
+});


### PR DESCRIPTION
**Part 3/8 of #281** — the first part a sysop can actually use. Stacked on #765 (→ #764). Nothing validates at boot yet; that is PR 4.

```
$ ./oputil.js config validate
config.hjson: 4 issues (1 error, 3 warnings)

  error    general.maxConnections
           expected number, got string

  warning  general.boardnam
           unknown key "boardnam" -- did you mean "boardName"?

  warning  my_fancy_mod
           unknown key "my_fancy_mod"

  warning  scannerTossers.ftn_bso.paths.outbund
           unknown key "outbund" -- did you mean "outbound"?
```

## Keeping what the operator wrote

`ConfigLoader` now captures the config **before** the defaults are merged over it. Afterwards there is no way to tell a deliberate setting from a default — a misspelled key lands *beside* the correctly spelled default rather than replacing it, so both are present and the typo is invisible. `getUserConfig()` is that copy: the base file unioned with anything its `includes` pulled in, since an include is operator content too.

It is taken before `@reference`/`@environment`/`@file` resolve, because it exists to answer questions about **keys**, not values. Commented as such so nobody later "fixes" it.

## The waterfall's step 5, and why it is wrapped

The long-reserved `// 5 - Perform any validation` is now real. Both the validator and the reporter are called inside `try/catch`, which matters more than it looks:

> A **synchronous** throw inside an `async.waterfall` task does not reach the waterfall's callback — it propagates straight out.

`_reload()` runs from the file watcher, so unguarded that is an uncaught exception that takes the board down mid-session on nothing worse than a bad config edit. There is a test for it, asserted against the real `async` rather than a stub, because a stub is exactly what would hide it.

## Command details

- Uses `initConfig()`, **not** `initConfigAndDatabases()` — a broken configuration is precisely when the databases are least likely to be reachable, and validation needs none of them. `initConfig` was private, so it is now exported.
- Errors sort before warnings; exits non-zero **only** on errors, so it works from a script or a systemd `ExecStartPre`. Warnings alone are not a failure — an unrecognised key may perfectly well be a mod's own block.
- `--check-env` additionally reports `@` specs that did not resolve. Opt-in because resolution depends on the invoking process: checked by default, a correct production config would look broken purely because it was validated from the wrong shell.

## Verification

Beyond the tests — run against a real generated config (no findings); against one with a deliberate typo, type error, mod section, extra file-area keys and an unresolved spec (correct findings, exit 255); `--check-env` both with and without the variable set; and `main.js` booted far enough to prove the loader changes do not break startup, which the unit tests would not catch.

8 new loader tests. Full suite: 2188 passing. `WHATSNEW.md` updated per CONTRIBUTING.

🤖 Generated with [Claude Code](https://claude.com/claude-code)