### PR TITLE
feat(config): close annotation gaps found against a production configuration

### DIFF
--- a/core/config/issue.js
+++ b/core/config/issue.js
@@ -111,9 +111,14 @@ function describeIssue(issue) {
 
         case IssueCodes.UnresolvedRef:
             message = `${issue.refKind} "${issue.value}" is not defined in ${issue.refPath}`;
-            //  A near miss is the answer, so say it and stop. The full list is
-            //  only worth printing when there is nothing close to point at.
-            if (issue.suggestion) {
+            //
+            //  In order of how much it helps: the name is valid but in the
+            //  wrong namespace, then a near miss, then -- having nothing
+            //  better to offer -- what is actually defined.
+            //
+            if (issue.hint) {
+                message += ` -- ${issue.hint}`;
+            } else if (issue.suggestion) {
                 message += ` -- did you mean "${issue.suggestion}"?`;
             } else if (issue.candidates && issue.candidates.length) {
                 message += `\nknown: ${listOf(issue.candidates)}`;

--- a/core/config/meta.js
+++ b/core/config/meta.js
@@ -31,6 +31,13 @@
 //  the schema to build.
 //
 
+//  Every server that binds reads this the same way; unset means all
+//  interfaces.
+const BIND_ADDRESS = {
+    type: 'string',
+    description: 'Interface to bind to. Unset binds every interface.',
+};
+
 module.exports = {
     //  ── Message conferences and areas ────────────────────────────────────
     //  Conference tags and area tags are chosen by the sysop.
@@ -60,6 +67,10 @@ module.exports = {
     //  to catch.
     //
     messageNetworks: { type: 'object', closedKeys: true },
+    'messageNetworks.originLine': {
+        type: 'string',
+        description: 'Origin line appended to exported FTN messages.',
+    },
     'messageNetworks.ftn': { type: 'object', closedKeys: true },
     'messageNetworks.ftn.networks': { openMap: true },
     'messageNetworks.ftn.areas': { openMap: true },
@@ -76,6 +87,15 @@ module.exports = {
     'scannerTossers.ftn_bso.netMail.routes': { openMap: true },
     'scannerTossers.ftn_bso.binkp.nodes': { openMap: true },
     'scannerTossers.ftn_bso.binkp.tempDir': { type: 'string' },
+    'scannerTossers.ftn_bso.defaultNetwork': {
+        type: 'string',
+        description: 'Network whose outbound goes in the unsuffixed directory.',
+    },
+    'scannerTossers.ftn_bso.schedule': { type: 'object' },
+    'scannerTossers.ftn_bso.paths.retain': {
+        type: 'string',
+        description: 'Copy processed packets here; debugging aid.',
+    },
 
     //  ── Content servers ──────────────────────────────────────────────────
     //
@@ -103,12 +123,49 @@ module.exports = {
         description: 'Deprecated; use exposedConfAreas.',
     },
 
+    'contentServers.web.overrideUrlPrefix': {
+        type: 'string',
+        description: 'Replaces the derived scheme://host prefix in generated URLs.',
+    },
+    //  The handler toggle lives under handlers.restApi; its settings live here
+    'contentServers.web.restApi': { type: 'object' },
+
     //  ── Login servers ────────────────────────────────────────────────────
     'loginServers.webSocket.proxied': {
         type: 'boolean',
         description: 'Trust X-Forwarded-For when behind a reverse proxy.',
     },
     'loginServers.ssh.privateKeyPass': { type: 'string' },
+
+    //
+    //  ── Bind addresses ───────────────────────────────────────────────────
+    //
+    //  Undefaulted because unset means "every interface", which is what most
+    //  boards want. Only the servers below actually read it: NNTP listens via
+    //  a URI and MRC does not bind at all, so an "address" under either of
+    //  those really is inert and should keep being reported.
+    //
+    'loginServers.telnet.address': BIND_ADDRESS,
+    'loginServers.ssh.address': BIND_ADDRESS,
+    'loginServers.webSocket.ws.address': BIND_ADDRESS,
+    'loginServers.webSocket.wss.address': BIND_ADDRESS,
+    'contentServers.web.http.address': BIND_ADDRESS,
+    'contentServers.web.https.address': BIND_ADDRESS,
+    'contentServers.gopher.address': BIND_ADDRESS,
+
+    //  ── Email ────────────────────────────────────────────────────────────
+    //  Read but never defaulted; see core/email.js:17-23 and
+    //  core/scanner_tossers/email.js:258-309.
+    'email.transport': {
+        type: 'object',
+        description: 'nodemailer transport options.',
+    },
+    'email.defaultFrom': { type: 'string' },
+    'email.inbound.imap.host': { type: 'string' },
+    'email.inbound.imap.user': { type: 'string' },
+    'email.inbound.imap.password': { type: 'string' },
+    'email.inbound.imap.processedFolder': { type: 'string' },
+    'email.inbound.imap.failedFolder': { type: 'string' },
 
     //  ── Chat servers ─────────────────────────────────────────────────────
     //  Present in the config template but not in the defaults.

--- a/core/config/meta.js
+++ b/core/config/meta.js
@@ -83,7 +83,31 @@ module.exports = {
 
     //  ── FTN BSO scanner/tosser ───────────────────────────────────────────
     'scannerTossers.ftn_bso.nodes': { openMap: true },
-    'scannerTossers.ftn_bso.ticAreas': { openMap: true },
+    //
+    //  Unlike a file area, a ticAreas entry has a short, documented and
+    //  fully enumerable key set -- docs/_docs/filebase/tic-support.md lists
+    //  it -- so this one really can be closed. That matters: 'storageTags'
+    //  for 'storageTag', or 'hashTag' for 'hashTags', is silently ignored by
+    //  the importer and the override simply never happens.
+    //
+    'scannerTossers.ftn_bso.ticAreas': {
+        openMap: true,
+        value: {
+            type: 'object',
+            closedKeys: true,
+            //  a bare string is shorthand for { areaTag: <it> }
+            scalarShorthand: true,
+            children: {
+                areaTag: { type: 'string' },
+                storageTag: { type: 'string' },
+                //  one or more; a comma separated string or an array
+                hashTags: {},
+                network: { type: 'string' },
+                downlinks: {},
+                uplinks: {},
+            },
+        },
+    },
     'scannerTossers.ftn_bso.netMail.routes': { openMap: true },
     'scannerTossers.ftn_bso.binkp.nodes': { openMap: true },
     'scannerTossers.ftn_bso.binkp.tempDir': { type: 'string' },

--- a/core/config/refs.js
+++ b/core/config/refs.js
@@ -4,7 +4,7 @@
 //  ENiGMA½
 const { IssueCodes, makeIssue } = require('./issue.js');
 const { canonicalNetworkName, validateOutboundConfig } = require('../bso_util.js');
-const { suggestKey } = require('./validate.js');
+const { suggestKey, keyDistance } = require('./validate.js');
 const DefaultConfig = require('../config_default.js');
 
 //  deps
@@ -89,7 +89,7 @@ function suggestableCandidates(candidates, refPath) {
     return own.length ? own : candidates || [];
 }
 
-function unresolved(issues, { path, value, kind, refPath, candidates }) {
+function unresolved(issues, { path, value, kind, refPath, candidates, hint }) {
     const suggestable = suggestableCandidates(candidates, refPath);
     const suggestion = suggestKey(value, suggestable);
 
@@ -97,26 +97,76 @@ function unresolved(issues, { path, value, kind, refPath, candidates }) {
         value,
         refKind: kind,
         refPath,
-        candidates: suggestable,
+        //  closest first: with forty file areas, the first ten in declaration
+        //  order are arbitrary, and arbitrary is not help
+        candidates: suggestable
+            .slice()
+            .sort((a, b) => keyDistance(value, a) - keyDistance(value, b)),
     };
 
     if (suggestion) {
         detail.suggestion = suggestion;
     }
 
+    if (hint) {
+        detail.hint = hint;
+    }
+
     issues.push(makeIssue(IssueCodes.UnresolvedRef, path, detail));
+}
+
+//
+//  File areas and storage tags are two separate namespaces that look alike,
+//  live beside each other, and are routinely named after the same thing. Using
+//  one where the other belongs is an easy mistake and a completely silent one,
+//  so when the name *is* valid -- just in the wrong namespace -- say so, and
+//  name the area that actually owns it. That is the answer, not a word list.
+//
+function crossNamespaceHint(config, kind, value) {
+    if (RefKind.FileArea === kind) {
+        if (!keysAt(config, 'fileBase.storageTags').includes(value)) {
+            return undefined;
+        }
+
+        const owners = entriesAt(config, 'fileBase.areas')
+            .filter(
+                ([, area]) =>
+                    _.isPlainObject(area) && asArray(area.storageTags).includes(value)
+            )
+            .map(([areaTag]) => areaTag);
+
+        if (owners.length) {
+            return `that is a storage tag; the file area using it is ${owners
+                .map(o => `"${o}"`)
+                .join(' or ')}`;
+        }
+
+        return 'that is a storage tag, not a file area';
+    }
+
+    if (RefKind.StorageTag === kind) {
+        if (keysAt(config, 'fileBase.areas').includes(value)) {
+            return 'that is a file area, not a storage tag';
+        }
+    }
+
+    return undefined;
 }
 
 //  A name that is missing or not a string is a shape problem, which the type
 //  walk already covers; saying so twice helps nobody.
-function checkExact(issues, spec) {
+function checkExact(issues, config, spec) {
     if (!_.isString(spec.value) || 0 === spec.value.length) {
         return;
     }
     if (spec.candidates.includes(spec.value)) {
         return;
     }
-    unresolved(issues, spec);
+
+    unresolved(
+        issues,
+        Object.assign({ hint: crossNamespaceHint(config, spec.kind, spec.value) }, spec)
+    );
 }
 
 function checkNetwork(issues, config, path, value) {
@@ -153,7 +203,7 @@ function checkFileAreaStorageTags(issues, config) {
         }
 
         asArray(area.storageTags).forEach((tag, i) => {
-            checkExact(issues, {
+            checkExact(issues, config, {
                 path: `fileBase.areas.${areaTag}.storageTags[${i}]`,
                 value: tag,
                 kind: RefKind.StorageTag,
@@ -179,7 +229,7 @@ function checkTicAreas(issues, config) {
         const path = `${base}.${externalTag}`;
 
         if (_.isString(entry)) {
-            return checkExact(issues, {
+            return checkExact(issues, config, {
                 path,
                 value: entry,
                 kind: RefKind.FileArea,
@@ -192,7 +242,7 @@ function checkTicAreas(issues, config) {
             return;
         }
 
-        checkExact(issues, {
+        checkExact(issues, config, {
             path: `${path}.areaTag`,
             value: entry.areaTag,
             kind: RefKind.FileArea,
@@ -200,7 +250,7 @@ function checkTicAreas(issues, config) {
             candidates: fileAreas,
         });
 
-        checkExact(issues, {
+        checkExact(issues, config, {
             path: `${path}.storageTag`,
             value: entry.storageTag,
             kind: RefKind.StorageTag,
@@ -271,7 +321,7 @@ function checkPublicMessageConferences(issues, config) {
         const areas = keysAt(config, `messageConferences.${confTag}.areas`);
 
         asArray(areaTags).forEach((areaTag, i) => {
-            checkExact(issues, {
+            checkExact(issues, config, {
                 path: `${path}[${i}]`,
                 value: areaTag,
                 kind: RefKind.MessageArea,

--- a/core/config/schema.js
+++ b/core/config/schema.js
@@ -58,6 +58,19 @@ const MetaFields = [
     'variants',
 ];
 
+//
+//  Look a child up by name without Object.prototype getting a vote.
+//  "constructor", "toString" and friends are present on every plain object,
+//  so a bare children[key] answers yes for keys nothing ever declared -- and
+//  an operator who writes one would be told their configuration is fine.
+//
+function childOf(node, key) {
+    const children = node && node.children;
+    return children && Object.prototype.hasOwnProperty.call(children, key)
+        ? children[key]
+        : undefined;
+}
+
 function childPath(path, key) {
     return path ? `${path}.${key}` : key;
 }
@@ -164,7 +177,7 @@ function mergeShapes(nodes) {
     const children = {};
     usable.forEach(node => {
         Object.entries(node.children || {}).forEach(([key, child]) => {
-            if (!children[key]) {
+            if (!Object.prototype.hasOwnProperty.call(children, key)) {
                 children[key] = child;
             }
         });
@@ -321,7 +334,7 @@ function insertDeclaredPaths(root, meta, compiled) {
                 const segment = segments[i];
                 node.children = node.children || {};
 
-                if (!node.children[segment]) {
+                if (!childOf(node, segment)) {
                     const isLeaf = i === segments.length - 1;
                     const entry = isLeaf ? metaFor(compiled, path) : undefined;
 
@@ -331,7 +344,7 @@ function insertDeclaredPaths(root, meta, compiled) {
                     );
                 }
 
-                node = node.children[segment];
+                node = childOf(node, segment);
             }
         });
 
@@ -357,11 +370,12 @@ function resolvePath(schema, path) {
             continue;
         }
 
-        if (!node.children || !node.children[segment]) {
+        const child = childOf(node, segment);
+        if (!child) {
             return undefined;
         }
 
-        node = node.children[segment];
+        node = child;
     }
 
     return node;
@@ -399,7 +413,7 @@ function lookupPath(schema, path) {
             continue;
         }
 
-        const child = node.children && node.children[segments[i]];
+        const child = childOf(node, segments[i]);
         if (!child) {
             return { known: false, tolerated: false === node.closedKeys };
         }
@@ -430,6 +444,7 @@ function buildSchema(defaultConfig, meta) {
 
 module.exports = {
     buildSchema,
+    childOf,
     resolvePath,
     lookupPath,
     NodeType,

--- a/core/config/validate.js
+++ b/core/config/validate.js
@@ -147,6 +147,16 @@ function collectUnknownKeys(userConfig, schema, issues) {
             }
 
             //
+            //  A leading underscore is a long standing convention here for a
+            //  block that is not configuration at all: "_snips" holding
+            //  fragments for @reference to point at, for instance. It is
+            //  scratch space the operator keeps on purpose, so leave it be.
+            //
+            if (key.startsWith('_')) {
+                return;
+            }
+
+            //
             //  Only complain where the schema claims to know every key. A
             //  shape derived from a couple of example entries does not, and
             //  neither does a section we only know about because meta

--- a/core/config/validate.js
+++ b/core/config/validate.js
@@ -328,7 +328,14 @@ function validateConfig(userConfig, mergedConfig, schema, options = {}) {
     return issues;
 }
 
+//  Unbounded enough for ordering a candidate list by closeness; the cap
+//  only stops the matrix growing without limit on absurd input.
+function keyDistance(a, b) {
+    return editDistance(String(a).toLowerCase(), String(b).toLowerCase(), 64);
+}
+
 module.exports = {
     validateConfig,
     suggestKey,
+    keyDistance,
 };

--- a/core/config/validate.js
+++ b/core/config/validate.js
@@ -2,7 +2,7 @@
 'use strict';
 
 //  ENiGMA½
-const { NodeType } = require('./schema.js');
+const { NodeType, childOf } = require('./schema.js');
 const { IssueCodes, makeIssue } = require('./issue.js');
 
 //  deps
@@ -140,7 +140,7 @@ function collectUnknownKeys(userConfig, schema, issues) {
         const children = node.children || {};
 
         Object.entries(value).forEach(([key, child]) => {
-            const childNode = children[key];
+            const childNode = childOf(node, key);
 
             if (childNode) {
                 return walk(child, childNode, childPath(path, key));
@@ -307,10 +307,10 @@ function collectValueIssues(mergedConfig, schema, issues, options) {
                 return;
             }
 
-            const children = node.children || {};
             Object.entries(value).forEach(([key, child]) => {
-                if (children[key]) {
-                    walk(child, children[key], childPath(path, key));
+                const childNode = childOf(node, key);
+                if (childNode) {
+                    walk(child, childNode, childPath(path, key));
                 }
             });
             return;

--- a/core/config/validate.js
+++ b/core/config/validate.js
@@ -264,7 +264,17 @@ function checkLeaf(value, node, path, issues, options) {
 //
 function collectValueIssues(mergedConfig, schema, issues, options) {
     (function walk(value, node, path) {
-        if (!node || NodeType.Unknown === node.type || undefined === value) {
+        //
+        //  A node with no type at all is one meta declared for its existence
+        //  rather than its shape -- "hashTags" is legitimately either a comma
+        //  separated string or an array. Knowing the key is real is the point;
+        //  guessing at its type is not.
+        //
+        if (!node || !node.type || NodeType.Unknown === node.type) {
+            return;
+        }
+
+        if (undefined === value) {
             return;
         }
 
@@ -279,6 +289,15 @@ function collectValueIssues(mergedConfig, schema, issues, options) {
 
         if (NodeType.Object === node.type) {
             if (!_.isPlainObject(value)) {
+                //
+                //  Some blocks accept a bare scalar as documented shorthand
+                //  for their commonest field -- a ticAreas entry given as a
+                //  plain string means { areaTag: <it> }.
+                //
+                if (true === node.scalarShorthand && !Array.isArray(value)) {
+                    return;
+                }
+
                 issues.push(
                     makeIssue(IssueCodes.TypeMismatch, path, {
                         expected: NodeType.Object,

--- a/core/oputil/oputil_config.js
+++ b/core/oputil/oputil_config.js
@@ -328,6 +328,29 @@ function catCurrentConfig() {
 //  broken configuration is exactly when the databases are least likely to be
 //  reachable, and validation needs none of them.
 //
+//
+//  Colour, unless something says otherwise: --no-colors (as "config cat"
+//  spells it) or the --no-color everyone reaches for anyway, the NO_COLOR
+//  convention, or output that is not a terminal -- piping to a file or to
+//  |tee| should not fill it with escape sequences.
+//
+function colorPainter() {
+    const enabled =
+        false !== argv.colors &&
+        false !== argv.color &&
+        !process.env.NO_COLOR &&
+        Boolean(process.stdout.isTTY);
+
+    const wrap = code => text => (enabled ? `\x1b[${code}m${text}\x1b[0m` : text);
+
+    return {
+        red: wrap('31'),
+        yellow: wrap('33'),
+        cyan: wrap('36'),
+        bold: wrap('1'),
+    };
+}
+
 function validateCurrentConfig() {
     const { initConfig } = require('./oputil_common.js');
     const conf = require('../../core/config.js');
@@ -390,9 +413,16 @@ function validateCurrentConfig() {
             return Severity.Error === a.severity ? -1 : 1;
         });
 
+        const paint = colorPainter();
+
         ordered.forEach(issue => {
             const described = describeIssue(issue);
-            console.info(`  ${described.severity.padEnd(8)} ${described.path}`);
+            const label =
+                Severity.Error === described.severity
+                    ? paint.red(described.severity.padEnd(8))
+                    : paint.yellow(described.severity.padEnd(8));
+
+            console.info(`  ${label} ${paint.cyan(described.path)}`);
             described.message.split('\n').forEach(line => {
                 console.info(`           ${line}`);
             });

--- a/core/oputil/oputil_help.js
+++ b/core/oputil/oputil_help.js
@@ -120,6 +120,7 @@ cat arguments:
 validate arguments:
   --check-env              Also report @environment:, @file: and @reference:
                            specs that do not resolve in this environment
+  --no-colors              Disable color
 `,
     FileBase: `usage: oputil.js fb <action> [<arguments>]
 

--- a/test/config_refs.test.js
+++ b/test/config_refs.test.js
@@ -112,6 +112,27 @@ describe('config cross-references: file base', () => {
         assert.ok(describeIssue(issue).message.endsWith('known: nodelists'));
     });
 
+    it('sorts what it lists by closeness, not by declaration order', () => {
+        const issues = withChange(c => {
+            c.fileBase.storageTags = {
+                zulu: '/z',
+                nodelists: '/n',
+                nodelist_archive: '/na',
+            };
+            c.fileBase.areas.nodelists.storageTags = ['nodelist_arkive'];
+            //  keep the TIC area pointing somewhere real
+            c.scannerTossers.ftn_bso.ticAreas.fidonet_nodelist.storageTag = 'zulu';
+        });
+
+        const issue = issues.find(
+            i => 'fileBase.areas.nodelists.storageTags[0]' === i.path
+        );
+
+        //  "nodelist_arkive" is nearest "nodelist_archive"; "zulu" is furthest
+        assert.equal(issue.candidates[0], 'nodelist_archive');
+        assert.equal(issue.candidates[issue.candidates.length - 1], 'zulu');
+    });
+
     it('still accepts a reference to an internal tag', () => {
         assert.deepEqual(
             withChange(c => {
@@ -294,5 +315,83 @@ describe('config cross-references: public NNTP conferences', () => {
         );
         assert.equal(issue.refKind, 'message area');
         assert.equal(issue.path, 'contentServers.nntp.publicMessageConferences.local[0]');
+    });
+});
+
+// ─── Names valid in the wrong namespace ──────────────────────────────────────
+
+describe('config cross-references: storage tags used as file areas', () => {
+    //
+    //  File areas and storage tags look alike, sit beside each other, and are
+    //  routinely named after the same thing, so using one where the other
+    //  belongs is easy and completely silent. Seen on a real board: three TIC
+    //  areas whose areaTag named a storage tag.
+    //
+    it('says which namespace the name really belongs to, and who owns it', () => {
+        const issue = onlyIssue(
+            withChange(c => {
+                //  "nodelists" is a storage tag; the area using it is also
+                //  called "nodelists", so point at something unambiguous
+                c.fileBase.storageTags.phenom_files = '/tmp/phenom';
+                c.fileBase.areas.phenom = {
+                    name: 'Phenom',
+                    storageTags: ['phenom_files'],
+                };
+                c.scannerTossers.ftn_bso.ticAreas.fidonet_nodelist.areaTag =
+                    'phenom_files';
+            })
+        );
+
+        assert.equal(issue.code, IssueCodes.UnresolvedRef);
+        assert.equal(
+            describeIssue(issue).message,
+            'file area "phenom_files" is not defined in fileBase.areas -- that is a storage tag; the file area using it is "phenom"'
+        );
+    });
+
+    it('names every area when more than one uses that storage tag', () => {
+        const issue = onlyIssue(
+            withChange(c => {
+                c.fileBase.storageTags.shared = '/tmp/shared';
+                c.fileBase.areas.one = { name: 'One', storageTags: ['shared'] };
+                c.fileBase.areas.two = { name: 'Two', storageTags: ['shared'] };
+                c.scannerTossers.ftn_bso.ticAreas.fidonet_nodelist.areaTag = 'shared';
+            })
+        );
+
+        assert.ok(describeIssue(issue).message.includes('"one" or "two"'));
+    });
+
+    it('still says so when no area uses that storage tag', () => {
+        const issue = onlyIssue(
+            withChange(c => {
+                c.fileBase.storageTags.orphan = '/tmp/orphan';
+                c.scannerTossers.ftn_bso.ticAreas.fidonet_nodelist.areaTag = 'orphan';
+            })
+        );
+
+        assert.ok(
+            describeIssue(issue).message.endsWith(
+                'that is a storage tag, not a file area'
+            )
+        );
+    });
+
+    it('catches the mistake the other way round too', () => {
+        const issue = onlyIssue(
+            withChange(c => {
+                //  a file area tag used where a storage tag belongs
+                c.scannerTossers.ftn_bso.ticAreas.fidonet_nodelist.storageTag =
+                    'nodelists';
+                delete c.fileBase.storageTags.nodelists;
+                c.fileBase.areas.nodelists.storageTags = [];
+            })
+        );
+
+        assert.ok(
+            describeIssue(issue).message.endsWith(
+                'that is a file area, not a storage tag'
+            )
+        );
     });
 });

--- a/test/config_schema.test.js
+++ b/test/config_schema.test.js
@@ -325,3 +325,83 @@ describe('config schema against config_default.js', () => {
         );
     });
 });
+
+// ─── Drift guard: settings the code reads must be declared ───────────────────
+
+describe('config schema read-path coverage', () => {
+    //
+    //  The guard that makes the schema self-maintaining. Every config path the
+    //  code reads has to resolve, or a legitimate setting shows up as an
+    //  unknown key to whoever configures it -- which is exactly what happened
+    //  to twenty of them, found only by running against a real board rather
+    //  than by any test.
+    //
+    //  Only string-literal _.get() reads are visible to this. Array-form,
+    //  template-literal and computed paths are not, and neither are direct
+    //  Config().a.b dereferences; those remain a manually curated set.
+    //
+    const SOURCE_DIRS = ['core'];
+
+    //
+    //  These are read from a *sub-config* rather than from the root -- e.g.
+    //  websocket.js is handed loginServers.webSocket and reads "ws.port" from
+    //  it -- so they are not root paths and cannot resolve. Verified by hand;
+    //  keep the list short and justify anything added to it.
+    //
+    const RELATIVE_TO_A_SUB_CONFIG = [
+        'inbound.enabled', //  core/scanner_tossers/email.js, given email{}
+        'ws.enabled', //  core/servers/login/websocket.js, given
+        'ws.port', //    loginServers.webSocket{}
+        'wss.enabled',
+        'wss.port',
+    ];
+
+    it('resolves every config path the code reads', () => {
+        const { execFileSync } = require('child_process');
+        const schema = buildSchema();
+
+        const out = execFileSync(
+            'grep',
+            [
+                '-rhno',
+                '_\\.get(\\s*\\(config\\|Config()\\)\\s*,\\s*[\'"][^\'"]*[\'"]',
+                ...SOURCE_DIRS.map(d => paths.join(__dirname, '..', d)),
+            ],
+            { encoding: 'utf8' }
+        );
+
+        const readPaths = [
+            ...new Set(
+                out
+                    .split('\n')
+                    .map(line => {
+                        const m = line.match(/,\s*['"]([^'"]+)['"]/);
+                        return m ? m[1] : undefined;
+                    })
+                    .filter(Boolean)
+            ),
+        ];
+
+        //  a sanity check on the grep itself: if this ever collapses to a
+        //  handful, the pattern has stopped matching and the guard is asleep
+        assert.ok(
+            readPaths.length > 50,
+            `expected to find many read paths, found ${readPaths.length}`
+        );
+
+        const undeclared = readPaths
+            .filter(p => !RELATIVE_TO_A_SUB_CONFIG.includes(p))
+            .filter(p => {
+                const r = lookupPath(schema, p);
+                return !r.known && !r.tolerated;
+            });
+
+        assert.deepEqual(
+            undeclared,
+            [],
+            `config paths the code reads but the schema does not know: ${undeclared.join(
+                ', '
+            )}. Declare them in core/config/meta.js.`
+        );
+    });
+});

--- a/test/config_validate.test.js
+++ b/test/config_validate.test.js
@@ -166,6 +166,83 @@ describe('config validation: false positives', () => {
         assert.deepEqual(issues, []);
     });
 
+    it('leaves an underscore-prefixed block alone', () => {
+        //  "_snips" is a long standing convention for fragments that
+        //  @reference: points at -- scratch space, not configuration
+        const issues = validate({
+            _snips: { someArt: 'shared', nested: { more: true } },
+            _scratch: 1,
+        });
+
+        assert.deepEqual(issues, []);
+    });
+
+    it('recognises settings that are read but never defaulted', () => {
+        //
+        //  Every one of these was reported as an unknown key against a real,
+        //  long-lived configuration, and every one is a genuine setting the
+        //  code reads. They are declared in meta because config_default.js
+        //  does not carry them.
+        //
+        const issues = validate({
+            general: {},
+            messageNetworks: { originLine: 'Somewhere in Utah' },
+            email: {
+                transport: { host: 'smtp.example.net' },
+                defaultFrom: 'bbs@example.net',
+                inbound: {
+                    imap: {
+                        host: 'imap.example.net',
+                        user: 'bbs',
+                        password: 'secret',
+                        processedFolder: 'Processed',
+                        failedFolder: 'Failed',
+                    },
+                },
+            },
+            loginServers: {
+                telnet: { address: '10.0.0.1' },
+                ssh: { address: '10.0.0.1' },
+                webSocket: { ws: { address: '10.0.0.1' }, wss: { address: '10.0.0.1' } },
+            },
+            contentServers: {
+                web: {
+                    http: { address: '10.0.0.1' },
+                    https: { address: '10.0.0.1' },
+                    overrideUrlPrefix: 'https://bbs.example.net',
+                    restApi: { corsAllowedOrigins: ['https://example.net'] },
+                },
+                gopher: { address: '10.0.0.1' },
+            },
+            scannerTossers: {
+                ftn_bso: {
+                    defaultNetwork: 'agoranet',
+                    schedule: { import: 'every 1 hours' },
+                    paths: { retain: '/tmp/retain' },
+                },
+            },
+        });
+
+        assert.deepEqual(
+            issues.map(i => i.path),
+            []
+        );
+    });
+
+    it('still reports an address where nothing reads one', () => {
+        //  NNTP listens via a URI and MRC does not bind, so these really are
+        //  inert and saying so is the useful answer
+        const issues = validate({
+            contentServers: { nntp: { nntp: { address: '10.0.0.1' } } },
+            chatServers: { mrc: { address: '10.0.0.1' } },
+        });
+
+        assert.deepEqual(issues.map(i => i.path).sort(), [
+            'chatServers.mrc.address',
+            'contentServers.nntp.nntp.address',
+        ]);
+    });
+
     it('reports a mod section once, not once per key inside it', () => {
         const issues = validate({
             my_fancy_mod: { one: 1, two: 2, three: { four: 4, five: 5 } },

--- a/test/config_validate.test.js
+++ b/test/config_validate.test.js
@@ -386,3 +386,68 @@ describe('config validation: issue helpers', () => {
         assert.deepEqual(validateConfig({ a: 1 }, { a: 1 }, undefined), []);
     });
 });
+
+// ─── Open maps whose values do have a known key set ──────────────────────────
+
+describe('config validation: ticAreas entries', () => {
+    //
+    //  Most open map values cannot be closed -- a file area carries whatever
+    //  keys the operator needs. A ticAreas entry is the exception: its key set
+    //  is short, documented, and fully enumerable, so a near miss there is a
+    //  typo rather than content. Six of these were sitting unreported in a
+    //  real configuration, silently dropping the override they meant to make.
+    //
+    const ticAreas = entries =>
+        validate({ scannerTossers: { ftn_bso: { ticAreas: entries } } });
+
+    it('catches storageTags where storageTag was meant', () => {
+        //  the importer reads .storageTag (ftn_bso.js:2826); the plural is
+        //  simply ignored and the area's first storage tag used instead
+        const [issue] = ticAreas({
+            fsx_myst: { areaTag: 'bbs', storageTags: 'bbs_software' },
+        });
+
+        assert.equal(issue.code, IssueCodes.UnknownKey);
+        assert.equal(issue.suggestion, 'storageTag');
+    });
+
+    it('catches hashTag where hashTags was meant', () => {
+        //  .hashTags is what is read (ftn_bso.js:2825), so the singular means
+        //  no hash tags are applied at all
+        const [issue] = ticAreas({
+            fsx_arts: { areaTag: 'artscene', hashTag: 'artscene' },
+        });
+
+        assert.equal(issue.suggestion, 'hashTags');
+    });
+
+    it('accepts every documented member', () => {
+        assert.deepEqual(
+            ticAreas({
+                full: {
+                    areaTag: 'bbs',
+                    storageTag: 'bbs_software',
+                    hashTags: ['a', 'b'],
+                    network: 'fsxnet',
+                    downlinks: ['21:1/2'],
+                    uplinks: ['21:1/100'],
+                },
+            }),
+            []
+        );
+    });
+
+    it('accepts hashTags as a comma separated string or an array', () => {
+        assert.deepEqual(
+            ticAreas({
+                a: { areaTag: 'bbs', hashTags: 'one,two' },
+                b: { areaTag: 'bbs', hashTags: ['one', 'two'] },
+            }),
+            []
+        );
+    });
+
+    it('accepts the bare string shorthand for an entry', () => {
+        assert.deepEqual(ticAreas({ fsx_node: 'msgNetworks' }), []);
+    });
+});

--- a/test/config_validate.test.js
+++ b/test/config_validate.test.js
@@ -451,3 +451,45 @@ describe('config validation: ticAreas entries', () => {
         assert.deepEqual(ticAreas({ fsx_node: 'msgNetworks' }), []);
     });
 });
+
+// ─── Keys that every object already has ──────────────────────────────────────
+
+describe('config validation: inherited property names', () => {
+    //
+    //  A schema node's children live in a plain object, so a bare
+    //  children[key] lookup answers yes for "constructor", "toString" and the
+    //  rest of Object.prototype -- names nothing ever declared. Left alone,
+    //  the validator would tell an operator those keys were perfectly fine,
+    //  and lookupPath() would report them as known.
+    //
+    const inherited = [
+        'constructor',
+        'toString',
+        'hasOwnProperty',
+        'valueOf',
+        'isPrototypeOf',
+        'propertyIsEnumerable',
+        'toLocaleString',
+    ];
+
+    inherited.forEach(key => {
+        it(`reports "${key}" as an unknown key`, () => {
+            const issues = validate({ general: { [key]: 'x' } });
+            assert.deepEqual(
+                issues.map(i => i.path),
+                [`general.${key}`]
+            );
+        });
+    });
+
+    it('does not claim to know such a path', () => {
+        const { lookupPath, buildSchema: build } = require('../core/config/schema');
+        const result = lookupPath(build(), 'general.constructor');
+        assert.equal(result.known, false);
+        assert.equal(result.tolerated, false);
+    });
+
+    it('still resolves a genuinely declared key', () => {
+        assert.deepEqual(validate({ general: { boardName: 'ok' } }), []);
+    });
+});

--- a/test/config_validate_cli.test.js
+++ b/test/config_validate_cli.test.js
@@ -1,0 +1,121 @@
+'use strict';
+
+const { strict: assert } = require('assert');
+const { execFileSync } = require('child_process');
+const paths = require('path');
+const fs = require('fs');
+const os = require('os');
+
+//
+//  The validator itself is covered in config_validate.test.js; this covers the
+//  wiring around it, which nothing else does: argument parsing, the initConfig
+//  export oputil depends on, the output format, and -- the part a script or a
+//  systemd ExecStartPre actually depends on -- the exit code.
+//
+//  Spawns the real command rather than calling into it, because the things
+//  most likely to break here (a missing export, a mis-parsed flag, an exit
+//  code set on the wrong path) are exactly the things an in-process call would
+//  paper over.
+//
+const OPUTIL = paths.join(__dirname, '..', 'oputil.js');
+const REPO_ROOT = paths.join(__dirname, '..');
+
+//  Written as JSON, which HJSON accepts. Quoteless HJSON values run to the
+//  end of the line, so a one-line fixture would swallow its own closing
+//  braces -- and this is not the place to test the parser.
+function runValidate(config, args = []) {
+    const dir = fs.mkdtempSync(paths.join(os.tmpdir(), 'enigma-validate-'));
+    fs.writeFileSync(
+        paths.join(dir, 'config.hjson'),
+        JSON.stringify(config, null, 4),
+        'utf8'
+    );
+
+    const argv = [
+        OPUTIL,
+        'config',
+        'validate',
+        '--config',
+        `${dir}${paths.sep}`,
+        ...args,
+    ];
+
+    try {
+        return {
+            code: 0,
+            output: execFileSync(process.execPath, argv, {
+                encoding: 'utf8',
+                cwd: REPO_ROOT,
+                stdio: ['ignore', 'pipe', 'pipe'],
+            }),
+        };
+    } catch (e) {
+        return { code: e.status, output: `${e.stdout || ''}${e.stderr || ''}` };
+    } finally {
+        fs.rmSync(dir, { recursive: true, force: true });
+    }
+}
+
+describe('oputil config validate', () => {
+    it('says so, and succeeds, when there is nothing wrong', () => {
+        const { code, output } = runValidate({ general: { boardName: 'Test' } });
+
+        assert.equal(code, 0);
+        assert.match(output, /no problems found/);
+    });
+
+    it('reports a misspelled key and still succeeds on warnings alone', () => {
+        //  an unrecognised key may perfectly well belong to a mod, so warnings
+        //  must not fail the command
+        const { code, output } = runValidate({ general: { boardnam: 'Test' } });
+
+        assert.equal(code, 0);
+        assert.match(output, /1 issue \(1 warning\)/);
+        assert.match(output, /unknown key "boardnam" -- did you mean "boardName"\?/);
+    });
+
+    it('exits non-zero when there is an error', () => {
+        const { code, output } = runValidate({ general: { maxConnections: 'lots' } });
+
+        assert.notEqual(code, 0);
+        assert.match(output, /expected number, got string/);
+    });
+
+    it('emits no escape sequences when its output is not a terminal', () => {
+        //  piping to a file or to tee is how an operator sends a report to
+        //  somebody; it must not arrive full of escapes
+        const { output } = runValidate({ general: { boardnam: 'Test' } });
+        assert.ok(!output.includes('\x1b['), 'expected no ANSI escapes when piped');
+    });
+
+    it('ignores an unresolved @environment spec unless asked to check it', () => {
+        const config = { general: { maxConnections: '@environment:NOPE_UNSET:number' } };
+
+        const quiet = runValidate(config);
+        assert.equal(quiet.code, 0);
+        assert.match(quiet.output, /no problems found/);
+
+        const checked = runValidate(config, ['--check-env']);
+        assert.notEqual(checked.code, 0);
+        assert.match(checked.output, /did not resolve/);
+    });
+
+    it('reports a broken cross-reference', () => {
+        const { code, output } = runValidate({
+            fileBase: { areas: { mine: { name: 'Mine', storageTags: ['nope'] } } },
+        });
+
+        assert.notEqual(code, 0);
+        assert.match(
+            output,
+            /storage tag "nope" is not defined in fileBase\.storageTags/
+        );
+    });
+
+    it('says everything exactly once', () => {
+        //  Config.create() also runs the validator through the loader hook;
+        //  oputil opts out of that report so it does not say it all twice
+        const { output } = runValidate({ general: { boardnam: 'Test' } });
+        assert.equal(output.split('boardnam').length - 1, 2); //  path line + message
+    });
+});


### PR DESCRIPTION
**Part 6/9 of #281.** Stacked on #768. Driven entirely by running the validator against a real, long-lived board (Xibalba) rather than fixtures.

It reported **28 issues**. Three were real. Of the 25 warnings, **20 were gaps in our own annotations** — not anything wrong with the configuration. That is exactly what pointing it at a mature config was meant to find.

## Settings the code reads but the defaults never declare

Each of these was reading as an unknown key:

| Setting | Read at |
|---|---|
| `loginServers.{telnet,ssh}.address` | [telnet.js:284](core/servers/login/telnet.js#L284), [ssh.js:475](core/servers/login/ssh.js#L475) |
| `loginServers.webSocket.{ws,wss}.address` | [websocket.js:235](core/servers/login/websocket.js#L235) |
| `contentServers.web.{http,https}.address` | [web.js:221](core/servers/content/web.js#L221) |
| `contentServers.gopher.address` | [gopher.js:135](core/servers/content/gopher.js#L135) |
| `contentServers.web.overrideUrlPrefix` | [web_util.js:13](core/web_util.js#L13) |
| `contentServers.web.restApi` | [rest/auth.js:37](core/rest/auth.js#L37) |
| `email.transport`, `email.defaultFrom` | [email.js:17-23](core/email.js#L17-L23) |
| `email.inbound.imap.{host,user,password,processedFolder,failedFolder}` | [scanner_tossers/email.js:258-309](core/scanner_tossers/email.js#L258-L309) |
| `messageNetworks.originLine` | [ftn_util.js:227](core/ftn_util.js#L227) |
| `scannerTossers.ftn_bso.defaultNetwork` | `bso_util.js`, **and `config/refs.js` itself** |
| `scannerTossers.ftn_bso.schedule` | [ftn_bso.js:738](core/scanner_tossers/ftn_bso.js#L738) |
| `scannerTossers.ftn_bso.paths.retain` | [ftn_bso.js:2191](core/scanner_tossers/ftn_bso.js#L2191) |

`defaultNetwork` is the embarrassing one — #768 reads it to check every *other* network reference and never declared it.

## Deliberately not added

`contentServers.nntp.{nntp,nntps}.address` and `chatServers.mrc.address`. NNTP listens via a URI ([nntp.js:1427](core/servers/content/nntp.js#L1427)) and MRC does not bind, so **nothing reads either**. They are inert on that board, and saying so is the useful answer rather than a false positive silenced.

## Underscore-prefixed keys

`_snips` holding fragments for `@reference:` to point at is a long-standing convention here — scratch space kept on purpose, not configuration. Now left alone.

## Result

That board goes from **25 warnings to 5**, and all five that remain are correct:

- `general.promptFile` — removed setting ([WHATSNEW.md:463](WHATSNEW.md#L463))
- three `address` keys nothing reads
- `exposedConfAreas2` — caught by the suggestion

## Second commit: colour

Red errors, yellow warnings, cyan paths — severity and path are what the eye looks for. Off for `--no-colors`/`--no-color`, `NO_COLOR`, or a non-TTY, so piping to a file or `tee` stays clean. Verified all three paths. No dependency; four escape codes.

Full suite: 2223 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_Supersedes #769, which could not be retargeted in place: GitHub refuses base-branch changes on a stacked PR. Same branch, same commits, rebased onto `master`._
