### PR TITLE
feat(config): check themes and first menus, which live outside config.hjson

### DIFF
--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -23,6 +23,15 @@ This document attempts to track **major** changes and additions in ENiGMA½. For
 
   It also checks names that have to line up across sections — a file area naming a storage tag that was renamed, a `ticAreas` entry pointing at a file area that does not exist, an echo or a NetMail route naming a network spelled differently where it is defined, an NNTP conference or area exposed publicly that is not there. None of those produce an error today: the file quietly never lands, the echo is quietly never exported, and nothing in the log says why.
 
+  **A theme or a first menu that is not there is now reported too.** `theme.default`, `theme.preLogin` and each login server's `firstMenu` name things that live outside `config.hjson` — a directory under `paths.themes`, an entry in `menu.hjson` — so until now the only way to find a typo in one was to restart and watch what happened. A misnamed theme quietly falls back to whichever theme loads first; a misnamed first menu breaks that login server for everyone using it.
+
+  ```
+    error    theme.default
+             theme "lucian_blocktronics" is not defined in paths.themes -- did you mean "luciano_blocktronics"?
+  ```
+
+  Checked at startup, once the themes and menus are loaded, and by `oputil.js config validate` — which gathers both sets itself, so it can tell you before the restart rather than after. `*` still means "pick one at random" and is left alone, and a login server you have switched off is not checked at all, since a menu for a server nobody can reach is not a problem. If either set cannot be read, nothing is reported rather than everything.
+
   **Values are now checked, not just key names.** A port outside 1-65535, a `logging.rotatingFile.level` bunyan has never heard of, a negative idle timeout, a two factor method that is not implemented, a TIC `fileCase` that is neither `lower` nor `upper` — each of these is reported with the values that would have worked. Every one of them was taken from the code that reads the setting, and a test asserts that no constraint excludes the value ENiGMA½ itself ships, because a validator that fails a correct board is worse than none.
 
   **`achievements.hjson` is checked too** — at startup, on reload, and by `oputil.js config validate`, which now reports on both files and names each one. A `statname` written for `statName` has always meant the achievement is silently discarded at load and simply never fires, with nothing logged either way. The same goes for a `type` that is not one of the three the code implements, or a tier whose `points` are a string. An `achievements.hjson` that cannot be read at all is reported as a warning rather than a failure, because that is what the board itself does: it logs and carries on without achievements.

--- a/core/bbs.js
+++ b/core/bbs.js
@@ -313,6 +313,46 @@ function initialize(cb) {
                 const { ThemeManager } = require('./theme');
                 return ThemeManager.create(callback);
             },
+            function validateDeferredReferences(callback) {
+                //
+                //  theme.default and loginServers.*.firstMenu name things that
+                //  do not exist when config.hjson loads, so they are checked
+                //  here, once the themes and menu.hjson are in.
+                //
+                //  Advisory, like every other configuration check: a theme
+                //  that is not there falls back to another one and a bad first
+                //  menu breaks that login server, but neither is a reason to
+                //  refuse to start. Wrapped because a throw in an async.series
+                //  task propagates straight out and the callback never fires.
+                //
+                try {
+                    const Config = require('./config.js').get;
+                    const { isEnabled } = require('./config/report.js');
+
+                    if (isEnabled(Config())) {
+                        const theme = require('./theme.js');
+                        const {
+                            validateDeferredReferences,
+                        } = require('./config/refs.js');
+
+                        const issues = validateDeferredReferences(Config(), {
+                            themeIds: [...theme.getAvailableThemes().keys()],
+                            menuNames: theme.getMenuNames(),
+                        });
+
+                        require('./config/report.js').reportIssues(issues, {
+                            logOnly: true,
+                        });
+                    }
+                } catch (e) {
+                    logger.log.warn(
+                        { error: e.message },
+                        'Deferred configuration validation failed'
+                    );
+                }
+
+                return callback(null);
+            },
             function loadSysOpInformation(callback) {
                 //
                 //  Copy over some +op information from the user DB -> system properties.

--- a/core/config/refs.js
+++ b/core/config/refs.js
@@ -4,7 +4,7 @@
 //  ENiGMA½
 const { IssueCodes, makeIssue } = require('./issue.js');
 const { canonicalNetworkName, validateOutboundConfig } = require('../bso_util.js');
-const { suggestKey, keyDistance } = require('./validate.js');
+const { suggestKey, keyDistance, UNRESOLVED_SPEC } = require('./validate.js');
 const DefaultConfig = require('../config_default.js');
 
 //  deps
@@ -163,6 +163,18 @@ function crossNamespaceHint(config, kind, value) {
 //  walk already covers; saying so twice helps nobody.
 function checkExact(issues, config, spec) {
     if (!_.isString(spec.value) || 0 === spec.value.length) {
+        return;
+    }
+    //
+    //  An "@environment:", "@file:" or "@reference:" spec that did not resolve
+    //  is left in the configuration as its literal spec string, so it arrives
+    //  here looking like a name that does not exist. It is a resolution
+    //  problem, not a broken reference: the variable may simply not be set in
+    //  whatever shell is doing the checking, and reporting it would flag a
+    //  correct production configuration. validateConfig() already reports
+    //  these under --check-env, which is where they belong.
+    //
+    if (UNRESOLVED_SPEC.test(spec.value)) {
         return;
     }
     if (spec.candidates.includes(spec.value)) {

--- a/core/config/refs.js
+++ b/core/config/refs.js
@@ -40,7 +40,13 @@ const RefKind = {
     Network: 'FTN network',
     Conference: 'message conference',
     MessageArea: 'message area',
+    Theme: 'theme',
+    Menu: 'menu',
 };
+
+//  theme.default and theme.preLogin take this instead of a theme id, and pick
+//  one per user; see core/nua.js and core/servers/login/login_server_module.js
+const RANDOM_THEME = '*';
 
 function keysAt(config, path) {
     const value = _.get(config, path);
@@ -408,7 +414,107 @@ function validateReferences(mergedConfig) {
     return issues;
 }
 
+//
+//  ── Deferred references ─────────────────────────────────────────────────
+//
+//  Two couplings that cannot be checked from the configuration alone: a theme
+//  id names a directory under paths.themes, and a first menu names an entry in
+//  menu.hjson. Neither exists yet when config.hjson loads -- ThemeManager runs
+//  well after it -- so these are a second pass.
+//
+//  Both fail open. |themeIds| or |menuNames| being undefined means the caller
+//  could not gather that set reliably, and an unknown candidate list is a
+//  reason to say nothing rather than to report everything as missing.
+//
+
+function checkThemeReferences(issues, config, themeIds) {
+    if (!Array.isArray(themeIds) || 0 === themeIds.length) {
+        return;
+    }
+
+    ['theme.default', 'theme.preLogin'].forEach(path => {
+        const value = _.get(config, path);
+        if (RANDOM_THEME === value) {
+            return;
+        }
+
+        checkExact(issues, config, {
+            path,
+            value,
+            kind: RefKind.Theme,
+            //  the config knob that says where to look, not the directory
+            //  itself: it is the thing an operator would change
+            refPath: 'paths.themes',
+            candidates: themeIds,
+        });
+    });
+}
+
+function checkFirstMenus(issues, config, menuNames) {
+    if (!Array.isArray(menuNames) || 0 === menuNames.length) {
+        return;
+    }
+
+    //
+    //  Walked rather than listed, so a login server a mod adds is covered
+    //  without this having to know about it.
+    //
+    const servers = _.get(config, 'loginServers');
+    if (!_.isPlainObject(servers)) {
+        return;
+    }
+
+    Object.entries(servers).forEach(([serverName, server]) => {
+        if (!_.isPlainObject(server)) {
+            return;
+        }
+
+        //
+        //  Only a server that will actually run. A board with SSH switched
+        //  off still carries the defaulted firstMenu of "sshConnected", and
+        //  a custom menu.hjson has no reason to define a menu for a server
+        //  nobody can reach -- reporting that would be a false alarm on a
+        //  perfectly good configuration.
+        //
+        //  "false === enabled" rather than "true !== enabled", matching how a
+        //  login server module is skipped in core/module_util.js: an absent
+        //  key means enabled.
+        //
+        if (false === server.enabled) {
+            return;
+        }
+
+        ['firstMenu', 'firstMenuNewUser'].forEach(key => {
+            checkExact(issues, config, {
+                path: `loginServers.${serverName}.${key}`,
+                value: server[key],
+                kind: RefKind.Menu,
+                refPath: 'general.menuFile',
+                candidates: menuNames,
+            });
+        });
+    });
+}
+
+//
+//  |themeIds|  ids ThemeManager would consider available, or undefined
+//  |menuNames| top level keys of menu.hjson's "menus", or undefined
+//
+function validateDeferredReferences(mergedConfig, { themeIds, menuNames } = {}) {
+    const issues = [];
+
+    if (!_.isPlainObject(mergedConfig)) {
+        return issues;
+    }
+
+    checkThemeReferences(issues, mergedConfig, themeIds);
+    checkFirstMenus(issues, mergedConfig, menuNames);
+
+    return issues;
+}
+
 module.exports = {
     validateReferences,
+    validateDeferredReferences,
     RefKind,
 };

--- a/core/config/validate.js
+++ b/core/config/validate.js
@@ -357,4 +357,5 @@ module.exports = {
     validateConfig,
     suggestKey,
     keyDistance,
+    UNRESOLVED_SPEC,
 };

--- a/core/oputil/oputil_config.js
+++ b/core/oputil/oputil_config.js
@@ -442,6 +442,88 @@ function loadAchievementsConfig(cb) {
     });
 }
 
+//
+//  The two sets the deferred reference checks need. The running board gets
+//  these from ThemeManager, which is not usable here: it logs through a Log
+//  that only exists once the BBS has started.
+//
+//  Both are gathered leniently and hand back undefined when they cannot be
+//  gathered at all, because reporting every theme and menu as missing on a
+//  correct board would be far worse than checking neither.
+//
+
+//
+//  A theme is a directory under paths.themes holding a theme.hjson.
+//
+//  ThemeManager also requires info.name and info.author and honours
+//  info.enabled; only the last is applied here. A theme with a malformed info
+//  block is skipped by the real loader with a warning, and counting it as
+//  present merely means a theme.default pointing at it is not reported --
+//  a miss, where the alternative is a false alarm.
+//
+function gatherThemeIds() {
+    const conf = require('../../core/config.js');
+    const themeDir = _.get(conf.get(), 'paths.themes');
+
+    if (!themeDir) {
+        return undefined;
+    }
+
+    let entries;
+    try {
+        entries = fs.readdirSync(themeDir, { withFileTypes: true });
+    } catch (e) {
+        return undefined; //  no themes directory at all; say nothing
+    }
+
+    const ids = entries
+        .filter(entry => entry.isDirectory())
+        .map(entry => entry.name)
+        .filter(id => {
+            const themePath = paths.join(themeDir, id, 'theme.hjson');
+            try {
+                const theme = hjson.parse(fs.readFileSync(themePath, 'utf8'));
+                return false !== _.get(theme, 'info.enabled');
+            } catch (e) {
+                //  unreadable or unparseable: the real loader may still manage
+                //  it -- includes and @reference specs are not handled here --
+                //  so keep it as a candidate
+                return fs.existsSync(themePath);
+            }
+        });
+
+    return ids.length ? ids : undefined;
+}
+
+//
+//  Menu names, through the same ConfigLoader the board uses, so includes and
+//  "@reference:" specs behave identically.
+//
+function gatherMenuNames(cb) {
+    const conf = require('../../core/config.js');
+
+    const menuFile = _.get(conf.get(), 'general.menuFile');
+    if (!menuFile) {
+        return cb(undefined);
+    }
+
+    const { getConfigPath: qualify } = require('../../core/config_util.js');
+    const ConfigLoader = require('../../core/config_loader.js');
+
+    const loader = new ConfigLoader({ hotReload: false });
+
+    loader.init(qualify(menuFile), err => {
+        if (err) {
+            //  menu.hjson itself is not this command's business; the board
+            //  will complain loudly enough on its own
+            return cb(undefined);
+        }
+
+        const menus = _.get(loader.get(), 'menus');
+        return cb(_.isPlainObject(menus) ? Object.keys(menus) : undefined);
+    });
+}
+
 function validateCurrentConfig() {
     const { initConfig } = require('./oputil_common.js');
     const conf = require('../../core/config.js');
@@ -458,58 +540,72 @@ function validateCurrentConfig() {
 
         const { buildSchema } = require('../../core/config/schema.js');
         const { validateConfig } = require('../../core/config/validate.js');
-        const { validateReferences } = require('../../core/config/refs.js');
+        const {
+            validateReferences,
+            validateDeferredReferences,
+        } = require('../../core/config/refs.js');
 
         const checkEnv = true === argv['check-env'];
         const paint = colorPainter();
 
-        const issues = [
-            ...validateConfig(conf.getUserConfig(), conf.get(), buildSchema(), {
-                checkEnv,
-            }),
-            ...validateReferences(conf.get()),
-        ];
-
-        let errorCount = printReport(getConfigPath(), issues, paint);
-
-        loadAchievementsConfig((achErr, achPath, achLoader) => {
-            if (achErr) {
+        gatherMenuNames(menuNames => {
+            const issues = [
+                ...validateConfig(conf.getUserConfig(), conf.get(), buildSchema(), {
+                    checkEnv,
+                }),
+                ...validateReferences(conf.get()),
                 //
-                //  Not an error: module_util.js logs a warning and carries on
-                //  when a system module fails to initialise, so a board with an
-                //  unreadable achievements.hjson still starts -- it simply has
-                //  no achievements. Saying otherwise here would fail a systemd
-                //  ExecStartPre for something the board itself shrugs off.
+                //  Themes and menus are not in the configuration, so this is
+                //  the only surface besides startup that can check them -- and
+                //  the only one that can do it before a restart.
                 //
-                console.info('');
-                console.info(
-                    `${paint.yellow('warning ')} ${paint.cyan(achPath)}\n` +
-                        `           cannot be loaded, so achievements will be unavailable\n` +
-                        `           ${achErr.message}`
-                );
-            } else if (achLoader) {
-                const {
-                    buildAchievementSchema,
-                } = require('../../core/config/achievement_schema.js');
+                ...validateDeferredReferences(conf.get(), {
+                    themeIds: gatherThemeIds(),
+                    menuNames,
+                }),
+            ];
 
-                console.info('');
-                errorCount += printReport(
-                    achPath,
-                    validateConfig(
-                        achLoader.getUserConfig(),
-                        achLoader.get(),
-                        buildAchievementSchema(),
-                        { checkEnv }
-                    ),
-                    paint
-                );
-            }
+            let errorCount = printReport(getConfigPath(), issues, paint);
 
-            //
-            //  Warnings alone are not a failure: an unknown key may well be a
-            //  mod's own configuration block.
-            //
-            process.exitCode = errorCount > 0 ? ExitCodes.ERROR : ExitCodes.SUCCESS;
+            loadAchievementsConfig((achErr, achPath, achLoader) => {
+                if (achErr) {
+                    //
+                    //  Not an error: module_util.js logs a warning and carries on
+                    //  when a system module fails to initialise, so a board with an
+                    //  unreadable achievements.hjson still starts -- it simply has
+                    //  no achievements. Saying otherwise here would fail a systemd
+                    //  ExecStartPre for something the board itself shrugs off.
+                    //
+                    console.info('');
+                    console.info(
+                        `${paint.yellow('warning ')} ${paint.cyan(achPath)}\n` +
+                            `           cannot be loaded, so achievements will be unavailable\n` +
+                            `           ${achErr.message}`
+                    );
+                } else if (achLoader) {
+                    const {
+                        buildAchievementSchema,
+                    } = require('../../core/config/achievement_schema.js');
+
+                    console.info('');
+                    errorCount += printReport(
+                        achPath,
+                        validateConfig(
+                            achLoader.getUserConfig(),
+                            achLoader.get(),
+                            buildAchievementSchema(),
+                            { checkEnv }
+                        ),
+                        paint
+                    );
+                }
+
+                //
+                //  Warnings alone are not a failure: an unknown key may well be a
+                //  mod's own configuration block.
+                //
+                process.exitCode = errorCount > 0 ? ExitCodes.ERROR : ExitCodes.SUCCESS;
+            });
         });
     });
 }

--- a/core/theme.js
+++ b/core/theme.js
@@ -24,6 +24,7 @@ const assert = require('assert');
 
 exports.getThemeArt = getThemeArt;
 exports.getAvailableThemes = getAvailableThemes;
+exports.getMenuNames = getMenuNames;
 exports.getRandomTheme = getRandomTheme;
 exports.setClientTheme = setClientTheme;
 exports.displayPreparedArt = displayPreparedArt;
@@ -418,6 +419,25 @@ exports.ThemeManager = class ThemeManager {
 
 function getAvailableThemes() {
     return themeManagerInstance.getAvailableThemes();
+}
+
+//
+//  Every menu name the system knows, as menu.hjson declares them.
+//
+//  A theme may customise a menu but never add one: _finalizeTheme() starts
+//  from menu.hjson and iterates the keys already there, so this is the whole
+//  set regardless of which theme is in play.
+//
+//  Returns undefined before ThemeManager.create() has run -- an unknown set is
+//  a reason to check nothing rather than to report everything as missing.
+//
+function getMenuNames() {
+    if (!themeManagerInstance || !themeManagerInstance.menuConfig) {
+        return undefined;
+    }
+
+    const menus = _.get(themeManagerInstance.menuConfig.get(), 'menus');
+    return _.isPlainObject(menus) ? Object.keys(menus) : undefined;
 }
 
 function getRandomTheme() {

--- a/test/config_refs.test.js
+++ b/test/config_refs.test.js
@@ -396,6 +396,30 @@ describe('config cross-references: storage tags used as file areas', () => {
     });
 });
 
+describe('config references and unresolved "@" specs', () => {
+    it('does not read a literal spec string as a broken reference', () => {
+        //
+        //  The same defect as above, in the checks that shipped first: a
+        //  storage tag configured as "@environment:..." reads as a storage tag
+        //  that was never defined when the variable is not set here. Both go
+        //  through checkExact(), so both are fixed by the one exemption.
+        //
+        const config = _.merge(soundConfig(), {
+            fileBase: {
+                storageTags: { mine: '/tmp/x' },
+                areas: {
+                    spec_area: {
+                        name: 'Spec',
+                        storageTags: ['@environment:ENIGMA_STORAGE'],
+                    },
+                },
+            },
+        });
+
+        assert.deepEqual(validateReferences(config), []);
+    });
+});
+
 // ─── Deferred: names that live outside the configuration ─────────────────────
 
 describe('config deferred references', () => {
@@ -473,6 +497,22 @@ describe('config deferred references', () => {
 
         assert.equal(issues.length, 1);
         assert.equal(issues[0].path, 'loginServers.someMod.firstMenu');
+    });
+
+    it('leaves an unresolved "@" spec alone', () => {
+        //
+        //  _resolveAtSpecs() leaves the literal spec string in place when it
+        //  cannot resolve one, so it arrives here looking like a name that
+        //  does not exist. The variable may simply not be set in whatever
+        //  shell is running the check -- reporting it would flag a correct
+        //  production configuration. validateConfig() reports these under
+        //  --check-env, which is where they belong.
+        //
+        const config = sound();
+        config.theme.default = '@environment:ENIGMA_THEME';
+        config.loginServers.telnet.firstMenu = '@reference:menus.firstMenu';
+
+        assert.deepEqual(check(config), []);
     });
 
     it('says nothing when the caller could not gather the themes', () => {

--- a/test/config_refs.test.js
+++ b/test/config_refs.test.js
@@ -395,3 +395,152 @@ describe('config cross-references: storage tags used as file areas', () => {
         );
     });
 });
+
+// ─── Deferred: names that live outside the configuration ─────────────────────
+
+describe('config deferred references', () => {
+    const { validateDeferredReferences } = require('../core/config/refs');
+
+    const THEMES = ['luciano_blocktronics', 'mystery_skull'];
+    const MENUS = ['telnetConnected', 'sshConnected', 'sshConnectedNewUser'];
+
+    const sound = () => ({
+        theme: { default: 'luciano_blocktronics', preLogin: 'mystery_skull' },
+        loginServers: {
+            telnet: { firstMenu: 'telnetConnected' },
+            ssh: {
+                firstMenu: 'sshConnected',
+                firstMenuNewUser: 'sshConnectedNewUser',
+            },
+        },
+    });
+
+    const check = config =>
+        validateDeferredReferences(config, { themeIds: THEMES, menuNames: MENUS });
+
+    it('says nothing about a configuration that lines up', () => {
+        assert.deepEqual(check(sound()), []);
+    });
+
+    it('catches a theme that is not installed', () => {
+        const config = sound();
+        config.theme.default = 'lucian_blocktronics';
+
+        const issues = check(config);
+
+        assert.equal(issues.length, 1);
+        assert.equal(issues[0].code, IssueCodes.UnresolvedRef);
+        assert.equal(issues[0].severity, Severity.Error);
+        assert.equal(issues[0].path, 'theme.default');
+        assert.match(
+            describeIssue(issues[0]).message,
+            /theme "lucian_blocktronics" is not defined in paths\.themes -- did you mean "luciano_blocktronics"\?/
+        );
+    });
+
+    it('leaves "*" alone, since it means pick one at random', () => {
+        //  core/nua.js and core/servers/login/login_server_module.js both
+        //  special-case it; treating it as a theme id would report every board
+        //  that uses it
+        const config = sound();
+        config.theme.default = '*';
+        config.theme.preLogin = '*';
+
+        assert.deepEqual(check(config), []);
+    });
+
+    it('catches a first menu that menu.hjson does not define', () => {
+        const config = sound();
+        config.loginServers.ssh.firstMenuNewUser = 'sshConnectdNewUser';
+
+        const issues = check(config);
+
+        assert.equal(issues.length, 1);
+        assert.equal(issues[0].path, 'loginServers.ssh.firstMenuNewUser');
+        assert.match(
+            describeIssue(issues[0]).message,
+            /menu "sshConnectdNewUser" is not defined in general\.menuFile/
+        );
+        assert.equal(issues[0].suggestion, 'sshConnectedNewUser');
+    });
+
+    it('checks a login server it has never heard of', () => {
+        //  walked rather than listed, so a mod's own login server is covered
+        const config = sound();
+        config.loginServers.someMod = { firstMenu: 'nowhere' };
+
+        const issues = check(config);
+
+        assert.equal(issues.length, 1);
+        assert.equal(issues[0].path, 'loginServers.someMod.firstMenu');
+    });
+
+    it('says nothing when the caller could not gather the themes', () => {
+        //
+        //  Fail open. An unknown candidate set is a reason to check nothing:
+        //  reporting every theme as missing because a directory could not be
+        //  read would be far worse than checking neither.
+        //
+        const config = sound();
+        config.theme.default = 'not_installed';
+
+        assert.deepEqual(validateDeferredReferences(config, { menuNames: MENUS }), []);
+        assert.deepEqual(validateDeferredReferences(config, {}), []);
+        assert.deepEqual(validateDeferredReferences(config), []);
+    });
+
+    it('says nothing when the gathered sets are empty', () => {
+        const config = sound();
+        config.theme.default = 'not_installed';
+        config.loginServers.telnet.firstMenu = 'not_a_menu';
+
+        assert.deepEqual(
+            validateDeferredReferences(config, { themeIds: [], menuNames: [] }),
+            []
+        );
+    });
+
+    it('ignores a login server that is switched off', () => {
+        //
+        //  A board with SSH off still carries the defaulted "sshConnected",
+        //  and a custom menu.hjson has no reason to define a menu for a server
+        //  nobody can reach. Reporting it would be a false alarm on a
+        //  perfectly good configuration -- and SSH ships disabled, so this
+        //  would have fired on most boards.
+        //
+        const config = sound();
+        config.loginServers.ssh = {
+            enabled: false,
+            firstMenu: 'sshConnected',
+            firstMenuNewUser: 'nowhere_at_all',
+        };
+
+        assert.deepEqual(check(config), []);
+    });
+
+    it('checks a login server that is switched on', () => {
+        const config = sound();
+        config.loginServers.ssh.enabled = true;
+        config.loginServers.ssh.firstMenu = 'nowhere_at_all';
+
+        const issues = check(config);
+
+        assert.equal(issues.length, 1);
+        assert.equal(issues[0].path, 'loginServers.ssh.firstMenu');
+    });
+
+    it('checks a login server that says nothing about being enabled', () => {
+        //  matching core/module_util.js: only an explicit false disables one
+        const config = sound();
+        config.loginServers.someMod = { firstMenu: 'nowhere_at_all' };
+
+        assert.equal(check(config).length, 1);
+    });
+
+    it('says nothing about a login server with no first menu', () => {
+        const config = sound();
+        delete config.loginServers.telnet.firstMenu;
+
+        assert.deepEqual(check(config), []);
+    });
+});

--- a/test/config_validate_cli.test.js
+++ b/test/config_validate_cli.test.js
@@ -23,8 +23,14 @@ const REPO_ROOT = paths.join(__dirname, '..');
 //  Written as JSON, which HJSON accepts. Quoteless HJSON values run to the
 //  end of the line, so a one-line fixture would swallow its own closing
 //  braces -- and this is not the place to test the parser.
+//  |config| may be a function, called with the temporary directory, for a case
+//  that needs to point at files inside it.
 function runValidate(config, args = [], achievements) {
     const dir = fs.mkdtempSync(paths.join(os.tmpdir(), 'enigma-validate-'));
+
+    if ('function' === typeof config) {
+        config = config(dir);
+    }
 
     if (achievements) {
         //
@@ -191,6 +197,82 @@ describe('oputil config validate', () => {
         assert.equal(code, 0);
         assert.match(output, /not-here\.hjson/);
         assert.match(output, /achievements will be unavailable/);
+    });
+
+    it('checks themes and first menus, which are not in the configuration', () => {
+        //
+        //  The whole point of the deferred pass: neither a theme id nor a menu
+        //  name can be checked when config.hjson loads, so before this the only
+        //  way to find out was to restart and watch what happened.
+        //
+        const { code, output } = runValidate(dir => {
+            fs.mkdirSync(paths.join(dir, 'themes', 'nice_theme'), { recursive: true });
+            fs.writeFileSync(
+                paths.join(dir, 'themes', 'nice_theme', 'theme.hjson'),
+                JSON.stringify({ info: { name: 'Nice', author: 'Someone' } }),
+                'utf8'
+            );
+            fs.writeFileSync(
+                paths.join(dir, 'menu.hjson'),
+                JSON.stringify({ menus: { telnetConnected: {} } }),
+                'utf8'
+            );
+
+            return {
+                general: { boardName: 'Test', menuFile: paths.join(dir, 'menu.hjson') },
+                paths: { themes: paths.join(dir, 'themes') },
+                theme: { default: 'nice_them', preLogin: 'nice_theme' },
+                loginServers: { telnet: { firstMenu: 'telnetConnectd' } },
+            };
+        });
+
+        assert.notEqual(code, 0);
+        assert.match(output, /theme "nice_them" is not defined in paths\.themes/);
+        assert.match(output, /did you mean "nice_theme"\?/);
+        assert.match(output, /menu "telnetConnectd" is not defined in general\.menuFile/);
+        assert.match(output, /did you mean "telnetConnected"\?/);
+    });
+
+    it('says nothing when the theme and menu both line up', () => {
+        const { code, output } = runValidate(dir => {
+            fs.mkdirSync(paths.join(dir, 'themes', 'nice_theme'), { recursive: true });
+            fs.writeFileSync(
+                paths.join(dir, 'themes', 'nice_theme', 'theme.hjson'),
+                JSON.stringify({ info: { name: 'Nice', author: 'Someone' } }),
+                'utf8'
+            );
+            fs.writeFileSync(
+                paths.join(dir, 'menu.hjson'),
+                JSON.stringify({ menus: { telnetConnected: {} } }),
+                'utf8'
+            );
+
+            return {
+                general: { boardName: 'Test', menuFile: paths.join(dir, 'menu.hjson') },
+                paths: { themes: paths.join(dir, 'themes') },
+                theme: { default: 'nice_theme', preLogin: '*' },
+                loginServers: { telnet: { firstMenu: 'telnetConnected' } },
+            };
+        });
+
+        assert.equal(code, 0);
+        assert.match(output, /config\.hjson: no problems found/);
+    });
+
+    it('checks no themes at all rather than reporting them all missing', () => {
+        //
+        //  Fail open: paths.themes pointing somewhere unreadable means the
+        //  candidate set is unknown, and an unknown set is a reason to say
+        //  nothing. Reporting a correct theme as missing would be far worse.
+        //
+        const { code, output } = runValidate(dir => ({
+            general: { boardName: 'Test' },
+            paths: { themes: paths.join(dir, 'no-such-directory') },
+            theme: { default: 'whatever_this_is' },
+        }));
+
+        assert.equal(code, 0);
+        assert.ok(!output.includes('whatever_this_is'), output);
     });
 
     it('says everything exactly once', () => {


### PR DESCRIPTION
Closes the implementation work on #281. Based on `master`, follows #774 and #775.

`theme.default`, `theme.preLogin` and each login server's `firstMenu` name things that live **outside** `config.hjson` — a directory under `paths.themes`, an entry in `menu.hjson`. Neither exists when the configuration loads, so until now the only way to find a typo in one was to restart and watch what happened.

Both fail quietly. A misnamed theme falls back to whichever theme loads first (`core/theme.js`, `setClientTheme`); a misnamed first menu breaks that login server for everyone using it.

```
  error    theme.default
           theme "lucian_blocktronics" is not defined in paths.themes -- did you mean "luciano_blocktronics"?

  error    loginServers.telnet.firstMenu
           menu "telnetConnectd" is not defined in general.menuFile -- did you mean "telnetConnected"?
```

## Two surfaces

**At startup**, a step after `initMenusAndThemes`, reported to the log — ids from `ThemeManager`, menu names from `menu.hjson` as loaded. Wrapped in `try/catch`, since a throw in an `async.series` task propagates straight out and the callback never fires.

**In `oputil.js config validate`**, gathered from disk instead, so a sysop hears about it *before* the restart rather than after. `ThemeManager` cannot be used there: it logs through a `Log` that only exists once the BBS has started.

Menu names come from `menu.hjson` alone, and that is the whole set — a theme may *customise* a menu but never add one, because `_finalizeTheme()` starts from `menu.hjson` and iterates the keys already there.

## Everything about this fails open

The cost of being wrong is asymmetric: reporting a correct theme as missing is far worse than missing an incorrect one. So:

- **An ungathered or empty candidate set means check nothing.** oputil hands back `undefined` for an unreadable themes directory or a `menu.hjson` it cannot load. A `theme.hjson` it cannot parse stays a candidate, because the real loader resolves `includes` and `@reference:` specs that the gathering here does not.
- **`*` is left alone.** `core/nua.js` and `login_server_module.js` both special-case it to pick a theme at random.
- **A login server that is switched off is not checked.** This one was found by testing rather than by reasoning: SSH ships disabled and carries a defaulted `firstMenu` of `sshConnected`, so a board with a custom `menu.hjson` and no SSH would have been told about a menu nobody can reach. Skipped on `false === enabled` rather than `true !== enabled`, matching how `core/module_util.js` decides not to load a login server module — an absent key means enabled.

First menus are found by **walking** `loginServers` rather than from a list, so a login server a mod adds is covered without this knowing about it.

## Testing

`npm test` — **2314 passing** (up from 2300), live suite included. `npm run lint` and `prettier --check` clean.

Verified against a booted instance rather than only in tests:

```
50 theme.default            | Configuration: theme "lucian_blocktronics" is not defined in paths.themes -- did you mean "luciano_blocktronics"?
50 loginServers.telnet.firstMenu | Configuration: menu "telnetConnectd" is not defined in general.menuFile -- did you mean "telnetConnected"?
```

The board started regardless, which is the advisory-only contract every check in this series holds to.

Not yet run against a large production configuration. That is worth doing before merge — the switched-off-server rule above is exactly the kind of thing a real board finds and a fixture does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
