### PR TITLE
fix(theme): correct customizations that were silently doing nothing

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -22,6 +22,27 @@ Refer to [Upgrading](./docs/_docs/admin/upgrading.md) for details around this pr
 
 ## 0.5.0-beta to 0.5.1-beta
 
+* **Eight customizations in the `luciano_blocktronics` theme were named wrongly and have been corrected.** `ThemeManager` starts from your `menu.hjson` and looks each menu up in the theme, so a customization naming a menu that does not exist is never consulted — it silently does nothing. Seven menu blocks and one prompt block in the theme we ship named nothing at all. Three were renamed to the menus they were meant for and four were removed.
+
+  **This only affects you if you use `luciano_blocktronics` unmodified *and* your `menu.hjson` predates the menu renames.** If so, these blocks stop applying to your board:
+
+  | Was | Now | If your menu.hjson still has the old name |
+  |---|---|---|
+  | `messageSearch` | `messageBaseSearch` | rename the menu, or copy the block into your own theme |
+  | `messageBaseReplyPost` | `messageAreaReplyPost` | same |
+  | `messageMenuCommand` (prompt) | `messageBaseMenuPrompt` | same |
+  | `qwkExportPacketCurrentConfig`, `fileBase`, `irc`, `activityPubPostPublicMessage` | *removed* | copy the block into your own theme if you have such a menu |
+
+  The safest check is to compare the theme's menu names against your own: anything in `customization.menus` that is not a key under `menus` in your `menu.hjson` was already doing nothing, before or after this change.
+
+  One correction is a **fix rather than a removal**: `MSGPMPT.ANS` contains a `%TL1` placeholder and the theme supplies its text, but under the wrong name — so the message area command prompt has been missing its hint line. It now renders. If you have themed `messageBaseMenuPrompt` yourself, check it still looks right.
+
+  **If you maintain your own theme, nothing here affects you.**
+
+* **Configuration problems are now reported at startup** ([#281](https://github.com/NuSkooler/enigma-bbs/issues/281)). A mistyped key in `config.hjson` has never been reported — because your file is merged *into* the defaults, a typo lands quietly beside the correct key and the setting you wrote is simply never read. Those are now listed on the console at startup and to the log on a hot reload.
+
+  **Expect to see output you have not seen before**, possibly naming real mistakes that have been silently inert for years. **Nothing blocks**: a configuration with problems is applied exactly as before, and the board starts. Run `./oputil.js config validate` for the full report, and set `general.configValidation` to `off` to silence the startup output — the command keeps working either way. There is deliberately no strict mode.
+
 * **A TIC whose file has not arrived yet is now held instead of rejected** ([#735](https://github.com/NuSkooler/enigma-bbs/issues/735)). A `.tic` and the file it announces routinely arrive in *separate* mailer sessions, minutes or hours apart. Until now the announcement was processed the instant it landed, failed because the file was not there, and was archived to `paths.reject` — so when the file did arrive there was nothing left to pair it with, and it sat in the inbound forever. For a large file from a given peer this could fail every single time. Such a TIC is now kept and retried on later import passes, bounded by the new `scannerTossers.ftn_bso.tic.holdMaxAgeMs` (default 48 hours; `0` holds indefinitely). **No action is required.**
 
   **Check your inbound for files this already stranded.** Anything in `mail/ftn_secin/` (or `mail/ftn_in/`) that is not a `.pkt`, a bundle or a `.tic` is very likely an orphaned TIC payload. The matching announcement is in `mail/reject/` as `reject-tic--<timestamp>-<name>.tic`; the simplest recovery is to move *both* back into the secure inbound and let the next import pass pick them up, now that the pairing works. Re-announcement by the peer is not needed.

--- a/art/themes/luciano_blocktronics/theme.hjson
+++ b/art/themes/luciano_blocktronics/theme.hjson
@@ -428,16 +428,6 @@
 				}
 			}
 
-			qwkExportPacketCurrentConfig: {
-				mci: {
-					TL1: {
-						width: 70
-					}
-					TL2: {
-						width: 70
-					}
-				}
-			}
 
 			privateMailMenuCreateMessage: {
 				0: {
@@ -673,7 +663,7 @@
 				}
 			}
 
-			messageSearch: {
+			messageBaseSearch: {
 				0: {
 					mci: {
 						ET1: {
@@ -802,7 +792,7 @@
 				}
 			}
 
-			messageBaseReplyPost: {
+			messageAreaReplyPost: {
 				0: {
 					mci: {
 						TL1: { width: 19, textOverflow: "..." }
@@ -900,14 +890,6 @@
 
 			//////////////////// file base ////////////////////////////////
 
-			fileBase: {
-				mci: {
-					FN4: {
-						width: 18
-						textOverflow: ...
-					}
-				}
-			}
 
 			fileBaseListEntries: {
 				config: {
@@ -1512,22 +1494,6 @@
 				}
 			}
 
-			activityPubPostPublicMessage: {
-				0: {
-					mci: {
-						TL1: { width: 19, textOverflow: "..." }
-						ET2: { width: 19, textOverflow: "..." }
-						ET3: { width: 19, textOverflow: "..." }
-						ET4: { width: 21, textOverflow: "..." }
-						//TL4: { width: 25 }
-					}
-				}
-				1: {
-					mci: {
-						MT1: { height: 14 }
-					}
-				}
-			}
 
 			activityPubMsgBrowser: {
 				config: {
@@ -1773,40 +1739,10 @@
 				}
 			}
 
-			irc: {
-				config: {
-					messageFormat: "|00|10<|02{fromUserName}|10>|00 |03{message}|00"
-					privateMessageFormat: "|00|10<|02{fromUserName}|15->{toUserName}|10>|00 |03{message}|00"
-				}
-				0: {
-					mci: {
-						MT1: {
-							width: 72
-							height: 17
-						}
-                        ET2: {
-                            width: 69 // fnarr!
-                            maxLength: 140
-                        }
-                        TL3: {
-                            width: 20
-                        }
-                        TL4: {
-                            width: 20
-                        }
-						TL5: {
-                            width: 2
-                        }
-                        TL6: {
-                            width: 2
-                        }
-					}
-				}
-			}
 		}
 
 		prompts: {
-			messageMenuCommand: {
+			messageBaseMenuPrompt: {
 				mci: {
 					TL1: {
 						text: "|00|15|MD|08: |03|MC|08>>|11|MA"


### PR DESCRIPTION
`ThemeManager._finalizeTheme()` starts from `menu.hjson` and iterates **the menu's** keys, looking each one up in the theme:

```js
const mergedTheme = structuredClone(this.menuConfig.get());        //  core/theme.js:193
Object.keys(mergedTheme[sectionName]).forEach(entryName => {
    const menuTheme = _.get(theme, ['customization', sectionName, entryName]);
```

So a customization naming a menu that does not exist is **never consulted**. No error, no log — the theming simply does not happen.

Seven menu customizations and one prompt customization in the theme we ship named nothing at all. Diagnosed per entry against the MCI code set each targets, rather than removed wholesale.

## Renamed — the menu was renamed in `misc/menu_templates` and the theme was not followed along

| Was | Now | Evidence |
|---|---|---|
| `messageSearch` | `messageBaseSearch` | MCI sets are **identical**: `ET1 BT2 SM3 SM4 ET5 ET6 BT7` |
| `messageBaseReplyPost` | `messageAreaReplyPost` | form 0 `TL1 ET2 ET3 TL4` and form 1 `HM1` both present in the target |
| `messageMenuCommand` (prompt) | `messageBaseMenuPrompt` | see below |

The last is the most visible, and is a **fix rather than a tidy-up**: `MSGPMPT.ANS` contains a `%TL1` placeholder and the customization supplies its text, so the message area command prompt has been missing its hint line on every install using this theme. Its two siblings, `fileMenuCommand` and `activityPubMenuCommand`, are named correctly and do render.

## Deleted — no such menu ships

| Removed | Why |
|---|---|
| `irc` | `mrc` is already customized, and this block's `config` sets `messageFormat` / `privateMessageFormat`, read at `core/mrc.js:755-769`. There has never been an IRC module. |
| `activityPubPostPublicMessage` | `activityPubCompose` is already customized; same module, `msg_area_post_fse` |
| `qwkExportPacketCurrentConfig` | no QWK menu exists in `misc/menu_templates` at all |
| `fileBase` | no such menu, and `FN4` appears in no template |

## Left alone

`preAuthFeedback`. The `pre_auth_feedback` module exists and generated menu files define the menu, but `misc/menu_templates/` does not — **that is a gap in the template rather than a stale theme entry**, and it gets its own issue.

## Result

7 menu + 1 prompt orphans → **1 menu** (`preAuthFeedback`, above) and **0 prompts**.

## Testing

`npm test` — 2316 passing, live suite included. `npm run lint` clean. Verified on a real boot: `Theme loaded luciano_blocktronics`, no theme warnings.

`UPGRADE.md` carries a note, because this **can** bite: a board using `luciano_blocktronics` unmodified whose `menu.hjson` predates the renames loses those three customizations and the four removed ones. A board maintaining its own theme is unaffected.

## How this was found

While sizing `menu.hjson` / `theme.hjson` validation as the successor to #281. Nothing in the tree can catch this today, which is rather the point — measured across three menu files (a stock install, a dev install and a production board), the shipped theme had 7, 6 and 16 dead customizations respectively, while a board's own actively-maintained theme had zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
