### PR TITLE
fix(doors): write the DOOR32.SYS comm fields the door is actually given

### DIFF
--- a/core/abracadabra.js
+++ b/core/abracadabra.js
@@ -156,6 +156,8 @@ exports.getModule = class AbracadabraModule extends MenuModule {
 
                     self.dropFile = new DropFile(self.client, {
                         fileType: self.config.dropFileType,
+                        commType:
+                            'socket' === (self.config.io || 'stdio') ? 'socket' : 'local',
                     });
 
                     return self.dropFile.createFile(callback);

--- a/core/dropfile.js
+++ b/core/dropfile.js
@@ -27,11 +27,18 @@ const { mkdirs } = require('fs-extra');
 module.exports = class DropFile {
     constructor(
         client,
-        { fileType = 'DORINFO', baseDir = Config().paths.dropFiles } = {}
+        {
+            fileType = 'DORINFO',
+            baseDir = Config().paths.dropFiles,
+            commType = 'local',
+        } = {}
     ) {
         this.client = client;
         this.fileType = fileType.toUpperCase();
         this.baseDir = baseDir;
+        //  'local', 'serial', or 'socket' -- what the dropfile reports, which
+        //  is not ENiGMA's |io| type: Door accepts only stdio and socket
+        this.commType = commType;
     }
 
     static dropFileDirectory(baseDir, client) {
@@ -178,19 +185,24 @@ module.exports = class DropFile {
         //  * http://wiki.bbses.info/index.php/DOOR32.SYS
         //  * https://github.com/NuSkooler/ansi-bbs/blob/master/docs/dropfile_formats/door32_sys.txt
         //
-        //  :TODO: local/serial/telnet need to be configurable -- which also changes socket handle!
         const Door32CommTypes = {
             Local: 0,
             Serial: 1,
             Telnet: 2,
         };
 
-        const commType = Door32CommTypes.Telnet;
+        const commType =
+            {
+                socket: Door32CommTypes.Telnet,
+                serial: Door32CommTypes.Serial,
+            }[this.commType] ?? Door32CommTypes.Local;
+        //  ENiGMA shares a socket server, not a descriptor; bivrost bridges it
+        const commHandle = 'socket' === this.commType ? '-1' : '0';
 
         return iconv.encode(
             [
                 commType.toString(),
-                '-1',
+                commHandle,
                 '115200',
                 Config().general.boardName,
                 this.client.user.userId.toString(),

--- a/core/v86_door/v86_door.js
+++ b/core/v86_door/v86_door.js
@@ -209,6 +209,7 @@ exports.getModule = class V86DoorModule extends MenuModule {
                     if (hasDropFile) {
                         const dropFile = new DropFile(self.client, {
                             fileType: dropFileType,
+                            commType: 'serial',
                         });
                         if (!dropFile.isSupported()) {
                             return callback(

--- a/test/dropfile_door32.test.js
+++ b/test/dropfile_door32.test.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const { strict: assert } = require('assert');
+const os = require('os');
+
+const DropFile = require('../core/dropfile.js');
+
+function makeClient() {
+    return {
+        node: 1,
+        user: {
+            userId: 1,
+            getSanitizedName: which => ('real' === which ? 'Test User' : 'testuser'),
+            getLegacySecurityLevel: () => 30,
+        },
+    };
+}
+
+function door32Lines(commType) {
+    const opts = { fileType: 'DOOR32', baseDir: os.tmpdir() };
+    if (commType) {
+        opts.commType = commType;
+    }
+    const dropFile = new DropFile(makeClient(), opts);
+    return dropFile.getContents().toString('latin1').split('\r\n');
+}
+
+describe('DOOR32.SYS comm type', () => {
+    it('reports local mode with no handle for a door on standard streams', () => {
+        const lines = door32Lines('local');
+        assert.equal(lines[0], '0', 'comm type should be local');
+        assert.equal(lines[1], '0', 'there is no descriptor to hand over');
+    });
+
+    it('defaults to local when the caller says nothing', () => {
+        assert.deepEqual(door32Lines().slice(0, 2), ['0', '0']);
+    });
+
+    it('keeps the telnet spelling when a socket is shared', () => {
+        const lines = door32Lines('socket');
+        assert.equal(lines[0], '2', 'comm type should be telnet');
+        assert.equal(lines[1], '-1');
+    });
+
+    it('reports serial for a door on an emulated COM port', () => {
+        const lines = door32Lines('serial');
+        assert.equal(lines[0], '1', 'comm type should be serial');
+        assert.equal(lines[1], '0', 'a serial port carries no socket descriptor');
+    });
+
+    it('never claims a socket while supplying no handle', () => {
+        for (const mode of ['local', undefined, 'socket', 'serial']) {
+            const [commType, handle] = door32Lines(mode);
+            if ('2' === commType) {
+                assert.notEqual(handle, '0');
+            } else {
+                assert.equal(handle, '0');
+            }
+        }
+    });
+});


### PR DESCRIPTION
> Written by Claude (Opus 5), an LLM made by Anthropic, at andy5995's
> direction.

getDoor32Buffer wrote comm type 2 (telnet) with handle -1 whatever the door was actually given, which the code carried as a TODO. Under abracadabra's default that tells a door it has a socket and then gives it no way to reach one, so a door that validates the pair refuses to start rather than read the wrong stream.

DropFile now takes a commType of its own -- local, serial or socket. It is deliberately not Door's io type, which is only ever stdio or socket: abracadabra maps its io onto it, and v86 reports serial, since it bridges the user to the guest's emulated COM1.

Found with [Immortal Barons](https://github.com/andy5995/immortal-barons), which checks the pair: it exited with "line 2 (socket handle): socket mode needs a handle, got -1" and reaches its menus once the dropfile reports local.