### PR TITLE
feat(config): check that a menu's module can actually be loaded

### DIFF
--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -40,6 +40,8 @@ This document attempts to track **major** changes and additions in ENiGMA½. For
 
   **`menu.hjson` and your themes are checked too.** They carry the same silent failure as `config.hjson`, and one of them is worse: `ThemeManager` starts from your menu file and looks each menu up in the theme, so a `customization` naming a menu that does not exist is **never consulted** — the theming simply does not happen, with nothing logged. The theme ENiGMA½ ships had eight such blocks; they are fixed, and a check now reports any that remain as a warning.
 
+  **A menu naming a module that cannot be loaded is reported too**, for both built-in modules and your own under `paths.mods`. That found the sysop `!BINKP` command pointing at `binkp_poll`, which has never existed — the module is `binkp/binkp_poll_module` — so the command has failed since native BinkP support landed.
+
   Menu files get their structure checked — a misspelled `modul` for `module`, an `acs` where only `config.acs` is read — along with every menu name they reference, wherever it appears: `next`, a submit handler, an action key. That last one immediately found the `S` command in the ActivityPub menu pointing at a menu that has never existed.
 
   `config{}`, `form{}` and MCI blocks are deliberately **not** checked: those belong to the modules that read them and to the art they position, and claiming to know them would report most menus on most boards.

--- a/core/config/issue.js
+++ b/core/config/issue.js
@@ -139,6 +139,13 @@ function describeIssue(issue) {
             break;
 
         case IssueCodes.DeadCustomization:
+            if (undefined !== issue.count) {
+                message =
+                    `${issue.count} of ${issue.total} ${issue.refKind} customizations name something this system does not define, ` +
+                    'so they are never applied -- this theme looks written for a different menu file';
+                break;
+            }
+
             message = `no ${issue.refKind} named "${issue.value}" -- this customization is never applied`;
             if (issue.suggestion) {
                 message += `; did you mean "${issue.suggestion}"?`;

--- a/core/config/module_resolver.js
+++ b/core/config/module_resolver.js
@@ -1,0 +1,78 @@
+/* jslint node: true */
+'use strict';
+
+//  deps
+const fs = require('graceful-fs');
+const paths = require('path');
+
+//
+//  Can a menu's "module" actually be loaded?
+//
+//  Mirrors what core/menu_util.js:79-90 asks of it and what
+//  core/module_util.js loadModuleEx() then does with the answer:
+//
+//    * the value goes through asset.getAssetWithShorthand(spec,
+//      'systemModule'), so a bare name is a system module and "@userModule:"
+//      names one under Config().paths.mods;
+//
+//    * a module may live at <path>/<name>.js or, so that it can carry its own
+//      package.json and dependencies, at <path>/<name>/<name>.js.
+//
+//  A resolver rather than a name set, because a module name may be a relative
+//  path -- "activitypub/ap_search" and "./activitypub/activity_pub_msg_list"
+//  are both in the shipped templates -- and enumerating those as names would
+//  mean reimplementing the lookup rather than asking it.
+//
+//  Kept out of refs.js on purpose: that module answers questions from the
+//  configuration alone and touches no filesystem.
+//
+
+function makeModuleResolver({ systemPath, userPath } = {}) {
+    if (!systemPath) {
+        return undefined; //  nothing to resolve against; check nothing
+    }
+
+    const exists = candidate => {
+        try {
+            return fs.statSync(candidate).isFile();
+        } catch (e) {
+            return false;
+        }
+    };
+
+    return asset => {
+        const base = 'userModule' === asset.type ? userPath : systemPath;
+        if (!base) {
+            return true; //  no mods directory configured; do not object
+        }
+
+        //
+        //  A name may contain path separators, so resolve and confirm the
+        //  result is still under its base: "../../etc/passwd" is not a module
+        //  name, and neither is anything else that escapes.
+        //
+        const root = paths.resolve(base);
+        const direct = paths.resolve(root, `${asset.asset}.js`);
+        const contained = paths.resolve(root, asset.asset, `${paths.basename(asset.asset)}.js`);
+
+        if (!direct.startsWith(root + paths.sep)) {
+            return false;
+        }
+
+        return exists(direct) || exists(contained);
+    };
+}
+
+//  Where core/menu_util.js looks: __dirname there is core/, and mods come from
+//  the configured paths.mods.
+function defaultModuleResolver(config) {
+    return makeModuleResolver({
+        systemPath: paths.join(__dirname, '..'),
+        userPath: config ? config.paths && config.paths.mods : undefined,
+    });
+}
+
+module.exports = {
+    makeModuleResolver,
+    defaultModuleResolver,
+};

--- a/core/config/module_resolver.js
+++ b/core/config/module_resolver.js
@@ -47,19 +47,28 @@ function makeModuleResolver({ systemPath, userPath } = {}) {
         }
 
         //
-        //  A name may contain path separators, so resolve and confirm the
-        //  result is still under its base: "../../etc/passwd" is not a module
-        //  name, and neither is anything else that escapes.
+        //  Coerced because _.isString() -- the gate in refs.js -- is true for
+        //  a boxed String, which path.basename() then refuses outright.
         //
+        const name = String(asset.asset);
+
         const root = paths.resolve(base);
-        const direct = paths.resolve(root, `${asset.asset}.js`);
-        const contained = paths.resolve(root, asset.asset, `${paths.basename(asset.asset)}.js`);
+        const direct = paths.resolve(root, `${name}.js`);
+        const contained = paths.resolve(root, name, `${paths.basename(name)}.js`);
 
-        if (!direct.startsWith(root + paths.sep)) {
-            return false;
-        }
+        //
+        //  A name may contain path separators, so *each* candidate has to be
+        //  confirmed still under the base. Checking only the first is not
+        //  enough: given "..", appending ".js" makes a filename inside the
+        //  root while the nested form climbs out of it, so the escape happens
+        //  on the candidate that was not being looked at.
+        //
+        const under = candidate => candidate.startsWith(root + paths.sep);
 
-        return exists(direct) || exists(contained);
+        return (
+            (under(direct) && exists(direct)) ||
+            (under(contained) && exists(contained))
+        );
     };
 }
 

--- a/core/config/refs.js
+++ b/core/config/refs.js
@@ -43,11 +43,17 @@ const RefKind = {
     Theme: 'theme',
     Menu: 'menu',
     Prompt: 'prompt',
+    Module: 'menu module',
 };
 
 //  theme.default and theme.preLogin take this instead of a theme id, and pick
 //  one per user; see core/nua.js and core/servers/login/login_server_module.js
 const RANDOM_THEME = '*';
+
+//  Above this proportion dead, a theme is reported once as mismatched rather
+//  than entry by entry; below it, each one is likely a typo worth naming.
+const AGGREGATE_ABOVE = 0.5;
+const AGGREGATE_MIN = 4;
 
 function keysAt(config, path) {
     const value = _.get(config, path);
@@ -658,6 +664,105 @@ function validateMenuReferences(menuConfig) {
 }
 
 //
+//  A menu's "module". core/menu_util.js:79 runs it through
+//  asset.getAssetWithShorthand(spec, 'systemModule'), so a bare name is a
+//  system module and "@userModule:" names one under paths.mods.
+//
+//  Parsed here rather than by requiring core/asset.js, which pulls in
+//  stat_log.js -- and that captures a database handle at load time, which has
+//  no business happening because somebody validated a configuration.
+//  test/config_menu_modules.test.js asserts this stays in step with
+//  core/asset.js.
+//
+const MODULE_ASSET_SPEC = /^@([A-Za-z]+):(?:([^:]+):)?([A-Za-z0-9_\-./]+)$/;
+const MODULE_ASSET_TYPES = ['systemModule', 'userModule'];
+
+//
+//  Never returns undefined: every caller reads .type off the result, and an
+//  empty or unparseable value is a thing to report rather than a reason to
+//  crash. "module: ''" is exactly the sort of half-finished edit this is
+//  meant to catch.
+//
+function moduleAssetFrom(spec) {
+    if (!_.isString(spec) || 0 === spec.length) {
+        return { type: 'malformed', asset: spec };
+    }
+
+    if ('@' !== spec[0]) {
+        return { type: 'systemModule', asset: spec };
+    }
+
+    const match = MODULE_ASSET_SPEC.exec(spec);
+    if (!match) {
+        return { type: 'malformed', asset: spec };
+    }
+
+    return { type: match[1], asset: match[3] };
+}
+
+//
+//  |moduleExists| is a predicate over a parsed asset; see
+//  core/config/module_resolver.js. Undefined means the caller could not build
+//  one, and an unknown answer is a reason to say nothing.
+//
+function validateMenuModules(menuConfig, moduleExists) {
+    const issues = [];
+
+    if (!_.isPlainObject(menuConfig) || !_.isFunction(moduleExists)) {
+        return issues;
+    }
+
+    const menus = _.isPlainObject(menuConfig.menus) ? menuConfig.menus : {};
+
+    Object.entries(menus).forEach(([name, menu]) => {
+        if (!_.isPlainObject(menu) || !_.isString(menu.module)) {
+            return;
+        }
+
+        const path = `menus.${name}.module`;
+        const asset = moduleAssetFrom(menu.module);
+
+        //
+        //  getModuleAsset() asserts the type is one of these, and an assert
+        //  throws straight out of the waterfall that loads the menu -- so this
+        //  is worse than a module that is merely missing.
+        //
+        if (!MODULE_ASSET_TYPES.includes(asset.type)) {
+            issues.push(
+                makeIssue(IssueCodes.UnresolvedRef, path, {
+                    value: menu.module,
+                    refKind: RefKind.Module,
+                    refPath: 'the core modules',
+                    candidates: [],
+                    hint:
+                        'malformed' === asset.type
+                            ? 'a menu module must be a bare name or "@userModule:"'
+                            : `"@${asset.type}:" does not name a module; use a bare name or "@userModule:"`,
+                })
+            );
+            return;
+        }
+
+        if (moduleExists(asset)) {
+            return;
+        }
+
+        issues.push(
+            makeIssue(IssueCodes.UnresolvedRef, path, {
+                value: menu.module,
+                refKind: RefKind.Module,
+                refPath:
+                    'userModule' === asset.type ? 'paths.mods' : 'the core modules',
+                candidates: [],
+                hint: `no "${asset.asset}.js" there, nor "${asset.asset}/${asset.asset.split('/').pop()}.js"`,
+            })
+        );
+    });
+
+    return issues;
+}
+
+//
 //  |theme| is a loaded theme.hjson. |menuNames| and |promptNames| come from
 //  menu.hjson. Both undefined means check nothing -- the usual fail-open rule.
 //
@@ -678,11 +783,32 @@ function validateThemeReferences(theme, { menuNames, menuPromptNames } = {}) {
             return;
         }
 
-        Object.keys(customized).forEach(name => {
-            if (names.includes(name)) {
-                return;
-            }
+        const all = Object.keys(customized);
+        const orphans = all.filter(name => !names.includes(name));
 
+        if (0 === orphans.length) {
+            return;
+        }
+
+        //
+        //  A handful of these are typos or a menu that was renamed, and naming
+        //  each one is the useful thing. Most of them being dead is a
+        //  different fact: the theme was written against another menu file
+        //  entirely, and listing seventy of them buries every other finding
+        //  and gets the whole check switched off.
+        //
+        if (all.length >= AGGREGATE_MIN && orphans.length / all.length > AGGREGATE_ABOVE) {
+            issues.push(
+                makeIssue(IssueCodes.DeadCustomization, `customization.${section}`, {
+                    refKind: kind,
+                    count: orphans.length,
+                    total: all.length,
+                })
+            );
+            return;
+        }
+
+        orphans.forEach(name => {
             issues.push(
                 makeIssue(
                     IssueCodes.DeadCustomization,
@@ -707,6 +833,7 @@ module.exports = {
     validateReferences,
     validateDeferredReferences,
     validateMenuReferences,
+    validateMenuModules,
     validateThemeReferences,
     RefKind,
 };

--- a/core/oputil/oputil_config.js
+++ b/core/oputil/oputil_config.js
@@ -361,6 +361,25 @@ function colorPainter() {
 }
 
 //
+//  A bug in a validator is not the operator's problem, and it must not stop
+//  the other files being checked.
+//
+//  The boot and hot reload paths are covered by ConfigLoader._validate()'s own
+//  try/catch, but this command calls the validators directly -- so without
+//  this a single throw kills the process with a raw stack trace, skips every
+//  remaining file, and leaves process.exitCode as Node's uncaught-exception
+//  code rather than the one the command meant to set.
+//
+function collectIssues(label, produce) {
+    try {
+        return produce();
+    } catch (e) {
+        console.error(`  (could not check ${label}: ${e.message})`);
+        return [];
+    }
+}
+
+//
 //  One file's worth of report. Returns how many of its issues were errors,
 //  since only those decide the exit code.
 //
@@ -548,7 +567,7 @@ function validateCurrentConfig() {
                 ? Object.keys(menuConfig.prompts)
                 : undefined;
 
-            const issues = [
+            const issues = collectIssues('config.hjson', () => [
                 ...validateConfig(conf.getUserConfig(), conf.get(), buildSchema(), {
                     checkEnv,
                 }),
@@ -562,7 +581,7 @@ function validateCurrentConfig() {
                     themeIds: themeIds.length ? themeIds : undefined,
                     menuNames,
                 }),
-            ];
+            ]);
 
             let errorCount = printReport(getConfigPath(), issues, paint);
 
@@ -580,7 +599,7 @@ function validateCurrentConfig() {
                 console.info('');
                 errorCount += printReport(
                     menu.path,
-                    [
+                    collectIssues(menu.path, () => [
                         ...validateConfig(
                             menu.loader.getUserConfig(),
                             menuConfig,
@@ -592,7 +611,7 @@ function validateCurrentConfig() {
                             menuConfig,
                             defaultModuleResolver(conf.get())
                         ),
-                    ],
+                    ]),
                     paint
                 );
             }
@@ -607,13 +626,13 @@ function validateCurrentConfig() {
                     console.info('');
                     errorCount += printReport(
                         path,
-                        [
+                        collectIssues(path, () => [
                             ...validateConfig(theme, theme, themeSchema, { checkEnv }),
                             ...validateThemeReferences(theme, {
                                 menuNames,
                                 menuPromptNames,
                             }),
-                        ],
+                        ]),
                         paint
                     );
                 });
@@ -642,11 +661,13 @@ function validateCurrentConfig() {
                     console.info('');
                     errorCount += printReport(
                         achPath,
-                        validateConfig(
-                            achLoader.getUserConfig(),
-                            achLoader.get(),
-                            buildAchievementSchema(),
-                            { checkEnv }
+                        collectIssues(achPath, () =>
+                            validateConfig(
+                                achLoader.getUserConfig(),
+                                achLoader.get(),
+                                buildAchievementSchema(),
+                                { checkEnv }
+                            )
                         ),
                         paint
                     );

--- a/core/oputil/oputil_config.js
+++ b/core/oputil/oputil_config.js
@@ -569,7 +569,13 @@ function validateCurrentConfig() {
             //  menu.hjson, then each theme
             if (menu) {
                 const { buildMenuSchema } = require('../../core/config/menu_schema.js');
-                const { validateMenuReferences } = require('../../core/config/refs.js');
+                const {
+                    validateMenuReferences,
+                    validateMenuModules,
+                } = require('../../core/config/refs.js');
+                const {
+                    defaultModuleResolver,
+                } = require('../../core/config/module_resolver.js');
 
                 console.info('');
                 errorCount += printReport(
@@ -582,6 +588,10 @@ function validateCurrentConfig() {
                             { checkEnv }
                         ),
                         ...validateMenuReferences(menuConfig),
+                        ...validateMenuModules(
+                            menuConfig,
+                            defaultModuleResolver(conf.get())
+                        ),
                     ],
                     paint
                 );

--- a/core/theme.js
+++ b/core/theme.js
@@ -86,11 +86,16 @@ exports.ThemeManager = class ThemeManager {
 
                 const { validateConfig } = require('./config/validate.js');
                 const { buildMenuSchema } = require('./config/menu_schema.js');
-                const { validateMenuReferences } = require('./config/refs.js');
+                const {
+                    validateMenuReferences,
+                    validateMenuModules,
+                } = require('./config/refs.js');
+                const { defaultModuleResolver } = require('./config/module_resolver.js');
 
                 return [
                     ...validateConfig(userConfig, mergedConfig, buildMenuSchema()),
                     ...validateMenuReferences(mergedConfig),
+                    ...validateMenuModules(mergedConfig, defaultModuleResolver(Config())),
                 ];
             },
             onValidation: issues => {

--- a/misc/menu_templates/main.in.hjson
+++ b/misc/menu_templates/main.in.hjson
@@ -350,7 +350,7 @@
 
         sysopBinkpPollNow: {
             desc: "BinkP Poll"
-            module: binkp_poll
+            module: binkp/binkp_poll_module
         }
 
         mrc: {

--- a/test/config_menu_modules.test.js
+++ b/test/config_menu_modules.test.js
@@ -90,6 +90,43 @@ describe('menu module resolution', () => {
         assert.equal(resolver()({ type: 'systemModule', asset: '../package' }), false);
     });
 
+    it('refuses one where only the nested candidate escapes', () => {
+        //
+        //  Found by review: the containment check looked at "<name>.js" and
+        //  not at "<name>/<basename>.js". Given "..", appending ".js" makes a
+        //  filename inside the root -- so that candidate looks contained --
+        //  while the nested form climbs out of it. The test above never
+        //  covered this, because "../package" escapes on the first candidate.
+        //
+        const escaping = paths.resolve(CORE, '..', '...js');
+        fs.writeFileSync(escaping, 'module.exports = {};');
+
+        try {
+            ['..', './..', 'foo/../..'].forEach(asset => {
+                assert.equal(
+                    resolver()({ type: 'systemModule', asset }),
+                    false,
+                    `accepted "${asset}", which resolves outside core/`
+                );
+            });
+        } finally {
+            fs.unlinkSync(escaping);
+        }
+    });
+
+    it('does not choke on a boxed String', () => {
+        //
+        //  _.isString() -- the gate in refs.js -- is true for one, and
+        //  path.basename() then refuses it outright. Unreachable through
+        //  hjson, which yields primitives, but it is the mechanism that made
+        //  the unguarded oputil path a crash rather than a report.
+        //
+        assert.equal(
+            resolver()({ type: 'systemModule', asset: new String('show_art') }),
+            true
+        );
+    });
+
     it('checks nothing when it has nowhere to look', () => {
         assert.equal(makeModuleResolver({}), undefined);
         assert.equal(makeModuleResolver(), undefined);

--- a/test/config_menu_modules.test.js
+++ b/test/config_menu_modules.test.js
@@ -1,0 +1,223 @@
+'use strict';
+
+const { strict: assert } = require('assert');
+const paths = require('path');
+const fs = require('fs');
+const hjson = require('hjson');
+
+const { validateMenuModules } = require('../core/config/refs');
+const {
+    makeModuleResolver,
+    defaultModuleResolver,
+} = require('../core/config/module_resolver');
+const { describeIssue } = require('../core/config/issue');
+
+const CORE = paths.join(__dirname, '..', 'core');
+const MODS = paths.join(__dirname, '..', 'mods');
+
+const resolver = () => makeModuleResolver({ systemPath: CORE, userPath: MODS });
+
+function stockMenus() {
+    const dir = paths.join(__dirname, '../misc/menu_templates');
+    const menus = {};
+
+    fs.readdirSync(dir)
+        .filter(f => f.endsWith('.in.hjson'))
+        .forEach(f => {
+            const text = fs
+                .readFileSync(paths.join(dir, f), 'utf8')
+                .replace(/%INCLUDE_FILES%/g, '')
+                .replace(/XXXXX/g, 'x');
+            Object.assign(menus, hjson.parse(text).menus || {});
+        });
+
+    return { menus };
+}
+
+describe('menu modules against the shipped templates', () => {
+    const stock = stockMenus();
+
+    it('is reading something', () => {
+        const modules = new Set(
+            Object.values(stock.menus)
+                .map(m => m.module)
+                .filter(Boolean)
+        );
+        assert.ok(modules.size > 40, `expected many modules, found ${modules.size}`);
+    });
+
+    it('every module they name can actually be loaded', () => {
+        //
+        //  This found sysopBinkpPollNow naming "binkp_poll", which has never
+        //  existed -- the module is core/binkp/binkp_poll_module.js -- on a
+        //  menu reachable from the sysop "!BINKP" command.
+        //
+        const issues = validateMenuModules(stock, resolver());
+
+        assert.deepEqual(
+            issues.map(i => `${i.path} -> ${i.value}`),
+            []
+        );
+    });
+});
+
+describe('menu module resolution', () => {
+    it('finds a module at <name>.js', () => {
+        assert.equal(resolver()({ type: 'systemModule', asset: 'show_art' }), true);
+    });
+
+    it('finds one down a relative path, as the templates use', () => {
+        //  activitypub/ap_search and ./activitypub/... both appear in real files
+        assert.equal(
+            resolver()({ type: 'systemModule', asset: 'binkp/binkp_poll_module' }),
+            true
+        );
+        assert.equal(
+            resolver()({ type: 'systemModule', asset: './activitypub/ap_search' }),
+            true
+        );
+    });
+
+    it('does not find one that is not there', () => {
+        assert.equal(
+            resolver()({ type: 'systemModule', asset: 'no_such_module_at_all' }),
+            false
+        );
+    });
+
+    it('refuses a name that climbs out of its directory', () => {
+        //  a module name may contain separators, so this has to be said
+        assert.equal(resolver()({ type: 'systemModule', asset: '../package' }), false);
+    });
+
+    it('checks nothing when it has nowhere to look', () => {
+        assert.equal(makeModuleResolver({}), undefined);
+        assert.equal(makeModuleResolver(), undefined);
+    });
+
+    it('does not object to a user module when no mods path is configured', () => {
+        const r = makeModuleResolver({ systemPath: CORE });
+        assert.equal(r({ type: 'userModule', asset: 'anything_at_all' }), true);
+    });
+
+    it('takes its system path from where menu_util looks', () => {
+        //  core/menu_util.js:83 uses its own __dirname, which is core/
+        const r = defaultModuleResolver({ paths: { mods: MODS } });
+        assert.equal(r({ type: 'systemModule', asset: 'show_art' }), true);
+    });
+});
+
+describe('menu module validation', () => {
+    const withModule = module => ({ menus: { testMenu: { desc: 'T', module } } });
+
+    it('says nothing about a module that is there', () => {
+        assert.deepEqual(validateMenuModules(withModule('show_art'), resolver()), []);
+    });
+
+    it('catches a module that is not', () => {
+        const issues = validateMenuModules(withModule('no_such_module'), resolver());
+
+        assert.equal(issues.length, 1);
+        assert.equal(issues[0].path, 'menus.testMenu.module');
+        assert.match(
+            describeIssue(issues[0]).message,
+            /no "no_such_module\.js" there, nor "no_such_module\/no_such_module\.js"/
+        );
+    });
+
+    it('catches a spec that is not a module spec at all', () => {
+        //
+        //  getModuleAsset() asserts the type is systemModule or userModule, and
+        //  an assert throws straight out of the waterfall that loads the menu.
+        //  Worse than a module that is merely missing.
+        //
+        const issues = validateMenuModules(withModule('@method:notAModule'), resolver());
+
+        assert.equal(issues.length, 1);
+        assert.match(
+            describeIssue(issues[0]).message,
+            /"@method:" does not name a module/
+        );
+    });
+
+    it('looks for a user module under the mods path', () => {
+        const r = makeModuleResolver({ systemPath: CORE, userPath: '/nonexistent' });
+        const issues = validateMenuModules(withModule('@userModule:whatever'), r);
+
+        assert.equal(issues.length, 1);
+        assert.equal(issues[0].refPath, 'paths.mods');
+    });
+
+    it('reports rather than crashes on a module value that is not a spec', () => {
+        //
+        //  Found by review: the caller checks _.isString but not emptiness, so
+        //  "module: ''" returned undefined from the parser and the next line
+        //  read .type off it. That escaped oputil's nested callbacks entirely
+        //  and killed the process with a raw stack trace.
+        //
+        ['', '   ', '@', '@@@', '@:', '@menu'].forEach(module => {
+            const issues = validateMenuModules(withModule(module), resolver());
+            assert.ok(
+                issues.length >= 0,
+                `threw or misbehaved on ${JSON.stringify(module)}`
+            );
+        });
+
+        const empty = validateMenuModules(withModule(''), resolver());
+        assert.equal(empty.length, 1);
+        assert.match(
+            describeIssue(empty[0]).message,
+            /a menu module must be a bare name or "@userModule:"/
+        );
+    });
+
+    it('says nothing when there is no resolver', () => {
+        //  fail open, as everywhere else
+        assert.deepEqual(validateMenuModules(withModule('no_such_module')), []);
+        assert.deepEqual(
+            validateMenuModules(withModule('no_such_module'), undefined),
+            []
+        );
+    });
+
+    it('says nothing about a menu with no module', () => {
+        assert.deepEqual(
+            validateMenuModules({ menus: { m: { desc: 'x' } } }, resolver()),
+            []
+        );
+    });
+});
+
+describe('module asset parsing', () => {
+    it('recognises the same asset types core/asset.js does', () => {
+        //
+        //  refs.js parses the spec itself rather than requiring core/asset.js,
+        //  which pulls in stat_log.js and its load-time database handle. That
+        //  copy needs watching.
+        //
+        const asset = require('../core/asset');
+
+        //  bare name, and each accepted "@" form, must agree with getAssetWithShorthand
+        [
+            'show_art',
+            '@systemModule:show_art',
+            '@userModule:some_mod',
+            '@method:notAModule',
+        ].forEach(spec => {
+            const theirs = asset.getAssetWithShorthand(spec, 'systemModule');
+            const issues = validateMenuModules(
+                { menus: { m: { module: spec } } },
+                () => true //  resolve everything; only the type matters here
+            );
+
+            const weAccept = 0 === issues.length;
+            const theyAccept = ['systemModule', 'userModule'].includes(theirs.type);
+
+            assert.equal(
+                weAccept,
+                theyAccept,
+                `disagreement on "${spec}": core/asset.js says ${theirs.type}`
+            );
+        });
+    });
+});

--- a/test/config_theme_schema.test.js
+++ b/test/config_theme_schema.test.js
@@ -195,6 +195,41 @@ describe('theme references', () => {
         assert.equal(issues[0].suggestion, 'menuCommand');
     });
 
+    it('reports a wholly mismatched theme once, not entry by entry', () => {
+        //
+        //  A handful of dead entries are typos worth naming. Most of them
+        //  being dead is a different fact -- the theme was written against
+        //  another menu file -- and listing seventy of them buries every other
+        //  finding and gets the whole check switched off.
+        //
+        const customization = { menus: {} };
+        for (let i = 0; i < 20; ++i) {
+            customization.menus[`someOtherMenu${i}`] = {};
+        }
+        customization.menus.mainMenu = {};
+
+        const issues = validateThemeReferences(themeWith(customization), names);
+
+        assert.equal(issues.length, 1);
+        assert.equal(issues[0].path, 'customization.menus');
+        assert.equal(
+            describeIssue(issues[0]).message,
+            '20 of 21 menu customizations name something this system does not define, ' +
+                'so they are never applied -- this theme looks written for a different menu file'
+        );
+    });
+
+    it('still names them individually when only a few are dead', () => {
+        const customization = {
+            menus: { mainMenu: {}, fileBaseSearch: {}, mainMenuu: {} },
+        };
+
+        const issues = validateThemeReferences(themeWith(customization), names);
+
+        assert.equal(issues.length, 1);
+        assert.equal(issues[0].path, 'customization.menus.mainMenuu');
+    });
+
     it('says nothing when the menu names could not be gathered', () => {
         const theme = themeWith({ menus: { nothingLikeThis: {} } });
 


### PR DESCRIPTION
PR B of the menu.hjson work, following #784. Completes the menu/theme validation sized in the vault.

A menu's `module` names something that has to be loadable. `core/config/module_resolver.js` mirrors what `core/menu_util.js:79-90` asks of the value and what `core/module_util.js` `loadModuleEx()` then does with it:

- a bare name is a system module under `core/`, `@userModule:` names one under `paths.mods`;
- either may live at `<name>.js` or, so a module can carry its own `package.json`, at `<name>/<name>.js`.

**A resolver rather than a name set**, because a module name may be a relative path — `activitypub/ap_search` and `./activitypub/activity_pub_msg_list` are both in the shipped templates — so enumerating names would mean reimplementing the lookup instead of asking it. It also refuses a name that resolves outside its own directory, since separators are legal in one.

## It found a broken sysop command on its first run

`sysopBinkpPollNow` names `module: binkp_poll`. **No such module has ever existed.** The real one is `core/binkp/binkp_poll_module.js` — *BinkP Poll, "Trigger an immediate BinkP outbound poll"*.

And the menu is reachable. `main.in.hjson:164-171`:

```hjson
{
    value: { command: "!BINKP" }
    action: [
        {
            acs: SU
            action: @menu:sysopBinkpPollNow
        }
    ]
}
```

So the sysop `!BINKP` command has failed with `MODULE_NOT_FOUND` since #682 added it. One word, fixed here — the templates have to be clean for the check to be shippable.

## Two things are reported

A module that is not there, and a value that is **not a module spec at all**. The second matters more than it looks: `getModuleAsset()` asserts the type is `systemModule` or `userModule`, and an assert throws straight out of the waterfall that loads the menu — so `@method:foo` in a module position is worse than a missing file.

```
error    menus.missing.module
         menu module "no_such_module_at_all" is not defined in the core modules
         -- no "no_such_module_at_all.js" there, nor "no_such_module_at_all/no_such_module_at_all.js"

error    menus.wrongType.module
         menu module "@method:notAModule" is not defined in the core modules
         -- "@method:" does not name a module; use a bare name or "@userModule:"
```

The spec is parsed in `refs.js` rather than by requiring `core/asset.js`, which pulls in `stat_log.js` and its load-time database handle — that has no business happening because somebody validated a configuration. A test asserts the copy still agrees with `core/asset.js` on every form.

## A warning flood, prevented

Pointing `oputil config validate` at a minimal menu file produced **66 dead-customization warnings** against the stock theme. Every line was true, and the result was unusable — the exact "wall of text, so it gets switched off" outcome #281's plan warns about.

A theme whose customizations *mostly* name nothing is now reported once:

```
warning  customization.menus
         66 of 66 menu customizations name something this system does not define,
         so they are never applied -- this theme looks written for a different menu file
```

A handful of dead entries are typos worth naming individually; seventy is a different fact.

## Measured

| | Result |
|---|---|
| Stock templates | clean after the `binkp_poll` fix |
| **Production board, 253 menus** | **all 56 modules resolve** — including its own `mods/` and eight `@`-form specs. Nothing reported. |

## Testing

`npm test` — **2372 passing**, live suite included. `npm run lint` and `prettier --check` clean; both artifacts reproduce.

Includes a crash fix found by the review of #784: `module: ""` made the parser return `undefined` and the next line read `.type` off it, escaping oputil's nested callbacks and killing the process with a raw stack trace. The parser now never returns `undefined`, and `''`, `'   '`, `'@'`, `'@@@'`, `'@:'`, `'@menu'` are each reported rather than thrown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
