### PR TITLE
fix(views): hold every write to a mask edit field to the same rules

### DIFF
--- a/core/mask_edit_text_view.js
+++ b/core/mask_edit_text_view.js
@@ -148,11 +148,13 @@ class MaskEditTextView extends TextView {
     //  -- a literal is consumed when the caller supplied it and skipped when
     //  they did not -- so setText(getData()) round trips.
     //
-    //  Characters are held to the same regex the keyboard path applies. The
-    //  walk stops at the first one that does not fit rather than skipping past
-    //  it, so a value that does not belong in this field is dropped instead of
-    //  being reassembled out of whichever parts happened to match. Rejection is
-    //  silent, as it is when the same character is typed.
+    //  Characters get the same treatment the keyboard path gives them: styled
+    //  by |textStyle| first, then held to their slot's regex. The walk stops at
+    //  the first one that does not fit rather than skipping past it, so a value
+    //  that does not belong in this field is dropped instead of being
+    //  reassembled out of whichever parts happened to match. Rejection is
+    //  silent, as it is when the same character is typed. Literals are matched
+    //  unstyled: they come from the mask, not from the caller's data.
     //
     //  A literal that is also a legal slot character is ambiguous: for '&&/&&',
     //  "ab/cd" is either a supplied '/' or four data characters. The supplied
@@ -165,10 +167,12 @@ class MaskEditTextView extends TextView {
             const pat = this.patternArray[pos];
 
             if (_.isRegExp(pat)) {
-                if (!text[i].match(pat)) {
+                const ch = strUtil.stylizeString(text[i], this.textStyle);
+                if (!ch.match(pat)) {
                     break;
                 }
-                raw += text[i++];
+                raw += ch;
+                ++i;
             } else if (text[i] === pat) {
                 ++i; //  literal supplied by the caller
             }

--- a/core/mask_edit_text_view.js
+++ b/core/mask_edit_text_view.js
@@ -141,6 +141,43 @@ class MaskEditTextView extends TextView {
         return pos;
     }
 
+    //  Slot characters from |text|, which reaches us in either of two shapes:
+    //  bare slot characters, as a form restoring "19900101" supplies, or with
+    //  the mask's literals already in place, as getData() returns them
+    //  ("1990/01/01"). Walking the pattern and the text together accepts both
+    //  -- a literal is consumed when the caller supplied it and skipped when
+    //  they did not -- so setText(getData()) round trips.
+    //
+    //  Characters are held to the same regex the keyboard path applies. The
+    //  walk stops at the first one that does not fit rather than skipping past
+    //  it, so a value that does not belong in this field is dropped instead of
+    //  being reassembled out of whichever parts happened to match. Rejection is
+    //  silent, as it is when the same character is typed.
+    //
+    //  A literal that is also a legal slot character is ambiguous: for '&&/&&',
+    //  "ab/cd" is either a supplied '/' or four data characters. The supplied
+    //  literal wins. No mask that ships is shaped that way.
+    _slotCharsFromText(text) {
+        let raw = '';
+        let i = 0;
+
+        for (let pos = 0; pos < this.patternArray.length && i < text.length; ++pos) {
+            const pat = this.patternArray[pos];
+
+            if (_.isRegExp(pat)) {
+                if (!text[i].match(pat)) {
+                    break;
+                }
+                raw += text[i++];
+            } else if (text[i] === pat) {
+                ++i; //  literal supplied by the caller
+            }
+            //  literal not supplied: skip it and keep reading slot characters
+        }
+
+        return raw;
+    }
+
     //  ── Overrides ────────────────────────────────────────────────────────────
 
     setText(text, redraw) {
@@ -149,7 +186,8 @@ class MaskEditTextView extends TextView {
         super.setText(text, redraw); //  pass through redraw; TextView ctor calls with false
 
         if (this.lineBuffer) {
-            const raw = (text == null ? '' : String(text)).slice(0, this.maxLength);
+            //  Bounded by the pattern, so no separate maxLength truncation.
+            const raw = this._slotCharsFromText(text == null ? '' : String(text));
             this.lineBuffer.lines[0] = {
                 chars: raw,
                 attrs: new Uint32Array(raw.length),

--- a/core/mask_edit_text_view.js
+++ b/core/mask_edit_text_view.js
@@ -22,8 +22,8 @@ const _ = require('lodash');
 //
 //  :TODO:
 //  * Hint, e.g. YYYY/MM/DD
-//  * Return values with literals in place
-//  * Tab in/out results in oddities such as cursor placement & ability to type in non-pattern chars
+//  * Editing within the field: arrow keys, insert/overwrite at a slot other
+//    than the last. Input is currently append/truncate only.
 
 class MaskEditTextView extends TextView {
     constructor(options) {
@@ -45,10 +45,14 @@ class MaskEditTextView extends TextView {
         //  buildPattern sets this.maxLength (number of input slots)
         this.buildPattern();
 
-        this.patternArrayPos = this._patternPosForLength(0);
-
         //  LineBuffer initialized after buildPattern so maxLength is correct
         this.lineBuffer = new LineBuffer({ width: this.maxLength });
+
+        //  TextView's constructor already called setText(), but that ran before
+        //  buildPattern() and before lineBuffer existed, so both guards in our
+        //  override skipped and any initial text never reached the buffer.
+        //  Replay it now; this establishes patternArrayPos as well.
+        this.setText(options.text || '', false); //  false=do not redraw now
     }
 
     //  ── Internal helpers ─────────────────────────────────────────────────────
@@ -140,6 +144,8 @@ class MaskEditTextView extends TextView {
     //  ── Overrides ────────────────────────────────────────────────────────────
 
     setText(text, redraw) {
+        redraw = _.isBoolean(redraw) ? redraw : true; //  match TextView's default
+
         super.setText(text, redraw); //  pass through redraw; TextView ctor calls with false
 
         if (this.lineBuffer) {
@@ -160,6 +166,14 @@ class MaskEditTextView extends TextView {
                 this.lineBuffer ? this.lineBuffer.lines[0].chars.length : 0
             );
         }
+
+        //  A redraw leaves the terminal cursor past the end of the field, which
+        //  is only where the next keypress lands if the field is full. Callers
+        //  that follow with setFocus() get this anyway; those that don't would
+        //  otherwise type at one column and echo at another.
+        if (redraw && this.hasFocus) {
+            this._positionCursor(true);
+        }
     }
 
     setMaskPattern(pattern) {
@@ -168,7 +182,12 @@ class MaskEditTextView extends TextView {
         this.buildPattern();
         //  Reinitialize lineBuffer now that maxLength is updated
         this.lineBuffer = new LineBuffer({ width: this.maxLength });
-        this.patternArrayPos = this._patternPosForLength(0);
+
+        //  Drop any text carried over from the old pattern: its characters no
+        //  longer line up with the new slots, getData() would not return it,
+        //  and drawing it against a shorter pattern trips the assert in
+        //  drawText(). setText() resets patternArrayPos along with it.
+        this.setText('', false); //  false=caller redraws when it is ready
     }
 
     getData() {
@@ -215,8 +234,9 @@ class MaskEditTextView extends TextView {
                     this._syncFromBuffer();
                     this.patternArrayPos = this._patternPosForLength(textLen - 1);
 
-                    //  The goto is a no-op when the cursor already sits on the
-                    //  slot being cleared; it matters when the deletion walks
+                    //  clientBackspace() steps left before it writes, so this
+                    //  targets one column past the slot being cleared. That is
+                    //  where the cursor already sits unless the deletion walked
                     //  back over one or more literals.
                     this.client.term.write(
                         ansi.goto(this.position.row, this.getEndOfTextColumn() + 1)

--- a/test/views.test.js
+++ b/test/views.test.js
@@ -486,6 +486,53 @@ describe('MaskEditTextView', () => {
             assert.equal(view.maxLength, 3);
             assert.equal(view.patternArray.length, 3);
         });
+
+        it('setMaskPattern() drops text belonging to the previous pattern', () => {
+            const view = makeMaskView({ maskPattern: '####' });
+            view.setText('1234');
+            assert.equal(view.getData(), '1234');
+
+            view.setMaskPattern('##');
+
+            //  Those characters no longer line up with the new slots.
+            assert.equal(view.text, '');
+            assert.equal(view.lineBuffer.lines[0].chars, '');
+            assert.equal(view.getData(), '');
+            assert.equal(view.patternArrayPos, 0);
+        });
+
+        it('setMaskPattern() to a shorter pattern leaves the view drawable', () => {
+            const view = makeMaskView({ maskPattern: '####' });
+            view.setText('1234');
+
+            //  Text left over from the wider pattern would trip the length
+            //  assert in drawText().
+            view.setMaskPattern('##');
+
+            assert.doesNotThrow(() => view.redraw());
+        });
+    });
+
+    // ── initial text ─────────────────────────────────────────────────────────
+
+    describe('initial text', () => {
+        it('text: option reaches the lineBuffer', () => {
+            //  TextView's constructor calls setText() before buildPattern() has
+            //  run and before lineBuffer exists, so the view has to replay it.
+            const view = makeMaskView({ maskPattern: '####/##/##', text: '1990' });
+
+            assert.equal(view.lineBuffer.lines[0].chars, '1990');
+            assert.equal(view.text, '1990');
+            //  Four slots filled; the separator at index 4 is skipped.
+            assert.equal(view.patternArrayPos, 5);
+        });
+
+        it('text: option is truncated to the input slot count', () => {
+            const view = makeMaskView({ maskPattern: '####', text: '123456' });
+
+            assert.equal(view.lineBuffer.lines[0].chars, '1234');
+            assert.equal(view.getData(), '1234');
+        });
     });
 
     // ── getData() ────────────────────────────────────────────────────────────
@@ -622,6 +669,35 @@ describe('MaskEditTextView', () => {
             //  Four slots filled; the separator at index 4 is skipped so the
             //  next input lands on index 5.
             assert.equal(view.patternArrayPos, 5);
+        });
+
+        it('a mask starting with a literal accepts input', () => {
+            const h = makeTrackingView('(###) ###-####');
+            h.view.setFocus(true);
+
+            //  Index 0 is the '(': matching a keypress against it means
+            //  building a RegExp out of '(', which throws.
+            assert.doesNotThrow(() => h.view.onKeyPress('5', null));
+
+            assert.equal(h.view.lineBuffer.lines[0].chars, '5');
+            assert.equal(h.cursor.col, COL + 2);
+        });
+
+        it('setText() moves the visible cursor without waiting for a refocus', () => {
+            const h = makeTrackingView('####/##/##');
+            h.view.setFocus(true);
+            '1990'.split('').forEach(ch => h.view.onKeyPress(ch, null));
+            assert.equal(h.cursor.col, COL + 5);
+
+            //  No setFocus() here: the redraw alone leaves the cursor past the
+            //  end of the field, which is not where the next keypress lands.
+            h.view.setText('');
+
+            assert.equal(h.cursor.col, COL);
+
+            h.view.onKeyPress('2', null);
+            assert.equal(fieldText(h, 10), '2   /  /  ');
+            assert.equal(h.cursor.col, COL + 1);
         });
 
         it('typing after clearText() keeps the cursor on the character just typed', () => {

--- a/test/views.test.js
+++ b/test/views.test.js
@@ -601,6 +601,36 @@ describe('MaskEditTextView', () => {
             assert.equal(view.patternArrayPos, 6);
         });
 
+        it('setText() applies textStyle, as typing does', () => {
+            const view = makeMaskView({ maskPattern: 'A', textStyle: 'upper' });
+            view.setText('m');
+
+            assert.equal(view.getData(), 'M');
+        });
+
+        it('setText() and typing agree on a styled field', () => {
+            const set = makeMaskView({ maskPattern: 'AAA', textStyle: 'upper' });
+            set.setText('abc');
+
+            const typed = makeMaskView({ maskPattern: 'AAA', textStyle: 'upper' });
+            typed.specialKeyMap = {};
+            typed.acceptsInput = true;
+            typed.hasFocus = true;
+            'abc'.split('').forEach(ch => typed.onKeyPress(ch, null));
+
+            assert.equal(set.getData(), typed.getData());
+            assert.equal(set.getData(), 'ABC');
+        });
+
+        it('styling is applied before the slot is checked', () => {
+            //  'upper' cannot turn a letter into a digit, so the numeric slot
+            //  still rejects it.
+            const view = makeMaskView({ maskPattern: '#', textStyle: 'upper' });
+            view.setText('a');
+
+            assert.equal(view.getData(), '');
+        });
+
         it('setText() holds characters to the mask, as typing does', () => {
             //  The keyboard path checks every character against its slot; a
             //  programmatic set used to bypass the mask entirely.

--- a/test/views.test.js
+++ b/test/views.test.js
@@ -535,6 +535,84 @@ describe('MaskEditTextView', () => {
         });
     });
 
+    // ── setText() input handling ─────────────────────────────────────────────
+
+    describe('setText() input handling', () => {
+        //  A value reaches setText() either as bare slot characters (a form
+        //  restoring '19900101') or with the mask's literals already in place
+        //  (getData() returns '1990/01/01'). Both must land the same way.
+        const cases = [
+            ['####/##/##', '19900101', '19900101', 'bare slot characters'],
+            ['####/##/##', '1990/01/01', '19900101', 'literals in place'],
+            ['####/##/##', '1990/0/', '19900', 'partial value, dangling literals'],
+            ['####/##/##', '1990', '1990', 'partial value, bare'],
+            ['####/##/##', 'Invalid date', '', "moment()'s invalid-date string"],
+            ['####/##/##', '', '', 'empty'],
+            ['####/##/##', '199001011234', '19900101', 'over-long, bounded by pattern'],
+            ['####', 'ABCD', '', 'letters into a numeric mask'],
+            ['####', '12AB', '12', 'stops at the first character that does not fit'],
+            ['####', '    ', '', "clearText()'s fillChar pass"],
+            ['A', '7', '', 'digit into an alpha mask'],
+            ['A', 'M', 'M', 'alpha into an alpha mask'],
+            ['##', '9', '9', 'single digit into a two-slot mask'],
+            ['@@-@@', 'AB-CD', 'ABCD', 'literal supplied'],
+            ['@@-@@', 'ABCD', 'ABCD', 'same value, literal omitted'],
+            [
+                '(###) ###-####',
+                '(555) 867-5309',
+                '5558675309',
+                'leading literal, formatted',
+            ],
+            ['(###) ###-####', '5558675309', '5558675309', 'leading literal, bare'],
+        ];
+
+        cases.forEach(([maskPattern, input, expected, note]) => {
+            it(`${maskPattern} <- ${JSON.stringify(input)}: ${note}`, () => {
+                const view = makeMaskView({ maskPattern });
+                view.setText(input);
+
+                assert.equal(view.lineBuffer.lines[0].chars, expected);
+                assert.equal(view.text, expected);
+            });
+        });
+
+        it('setText(getData()) round trips a full field', () => {
+            const view = makeMaskView({ maskPattern: '####/##/##' });
+            view.setText('19900101');
+            const formatted = view.getData();
+            assert.equal(formatted, '1990/01/01');
+
+            view.setText(formatted);
+
+            assert.equal(view.getData(), formatted);
+            assert.equal(view.lineBuffer.lines[0].chars, '19900101');
+        });
+
+        it('setText(getData()) round trips a partly filled field', () => {
+            const view = makeMaskView({ maskPattern: '####/##/##' });
+            view.setText('19900');
+            const formatted = view.getData();
+
+            view.setText(formatted);
+
+            assert.equal(view.getData(), formatted);
+            assert.equal(view.lineBuffer.lines[0].chars, '19900');
+            //  Five slots filled; the separator at index 7 is not reached.
+            assert.equal(view.patternArrayPos, 6);
+        });
+
+        it('setText() holds characters to the mask, as typing does', () => {
+            //  The keyboard path checks every character against its slot; a
+            //  programmatic set used to bypass the mask entirely.
+            const view = makeMaskView({ maskPattern: '####' });
+
+            view.setText('<*!>');
+
+            assert.equal(view.getData(), '');
+            assert.equal(view.patternArrayPos, 0);
+        });
+    });
+
     // ── getData() ────────────────────────────────────────────────────────────
 
     describe('getData()', () => {


### PR DESCRIPTION
Follow-ups to #782. That PR made `patternArrayPos` derive from `lineBuffer` at every site that changes it; these finish the job for the other two pieces of state the view carries — `this.text` (what gets drawn) and the mask itself, which only the keyboard path was enforcing.

Three commits, each independently reviewable and independently covered.

### `setMaskPattern()` no longer strands `this.text`

It reset the buffer and the pattern position but left `this.text` holding characters typed against the old mask.

```
mask '####', type '1234', setMaskPattern('##')
  before: this.text="1234" buf=""  → next redraw: AssertionError in drawText()
  after : this.text=""     buf=""  → renders empty
```

Retargeting to a longer pattern was the quiet version: the field drew `(123) 4  -` while `getData()` returned `""`. Nothing shipped changes a mask after construction, but an `assert()` on a live connection takes the caller's session with it.

### A `text:` constructor option now reaches the buffer

`TextView`'s constructor calls `setText()` before `buildPattern()` has run and before `lineBuffer` exists, so both guards in the override skipped: the field drew the text and `getData()` returned `""`. The constructor replays `setText()` once both are in place, which establishes the initial pattern position as well — #782's new constructor line was correct only while the buffer started empty.

`setText()` also repositions the cursor when the view has focus, so it no longer depends on every caller remembering to `setFocus()` afterwards.

### `setText()` is held to the mask, literals and all

It treated its argument as bare slot characters truncated to the slot count, which got two things wrong at once.

**Literals were stored as data.** `drawText()` interleaves the mask's literals itself, so a value arriving with them had them rendered a second time — and `getData()` produces exactly that shape, so `setText(getData())` did not round trip:

```
mask ####/##/##
  before  setText("1990/01/01") → drawn=[1990//0/1/]  getData="1990//0/1/"
  after   setText("1990/01/01") → drawn=[1990/01/01]  getData="1990/01/01"
```

**The mask was not applied at all.** The keyboard path checks every character against its slot regex; a programmatic set checked nothing, so a `####` field accepted `"ABCD"` and an `A` field accepted `"7"` — the hole #782 closed for typing, still open on the other side. It is reachable: `user_config` prefills the birthdate with `moment(properties.birthdate).format('YYYYMMDD')`, and a corrupt or imported property makes that moment's `"Invalid date"` string, which the field drew as `Inva/li/d ` instead of coming up empty.

Both fall out of walking the pattern and the text together — a literal is consumed when the caller supplied it and skipped when they did not, so `"19900101"` and `"1990/01/01"` land identically. The walk stops at the first character that does not fit rather than skipping past it, and rejection is silent, as it is when the same character is typed.

One shape is ambiguous: a literal that is also a legal slot character, `&&/&&` given `"ab/cd"`. The supplied-literal reading wins, and the comment says so. No mask that ships is built that way.

The third commit closes the last gap in the same direction: `textStyle` was applied when a character was typed but not when the field was set, so an `A` field carrying `textStyle: upper` stored `"M"` from the keyboard and `"m"` from `setText()`. The slot walk now styles each character before the regex check — the keyboard's rule exactly.

### Verification

- **2422 passing**, up from 2399 on master; 23 new tests, and I checked that they fail with the source changes stashed rather than assuming it.
- The `setText()` table covers both shapes of the same value across five masks, `setText(getData())` round trips full and partial, and the `user_config` and NUA prefill paths are byte-identical to before.
- `prettier --check` and `eslint` clean.

Note this repo squashes on merge — rebase-merge instead if the three commits are worth keeping separate on master.

🤖 Generated with [Claude Code](https://claude.com/claude-code)