### PR TITLE
ci: stop the publishing workflows from racing

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,13 @@ on:
 
   workflow_dispatch:
 
+concurrency:
+  #  One mutable tag, so runs collapse rather than racing: a build that has
+  #  been superseded can only publish a :latest older than the one that
+  #  superseded it.
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   buildx:
     runs-on: ubuntu-latest

--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -8,6 +8,13 @@ on:
       # It is highly recommended that you only run this action on push to a 
         # specific branch, eg. master or source (if on *.github.io repo)
     
+concurrency:
+  #  One deployed site, so runs collapse rather than racing. Queued rather
+  #  than cancelled: this pushes to gh-pages, and a deploy interrupted part
+  #  way is worse than a build that waits ~80s for the one ahead of it.
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
 jobs:
   jekyll:
     runs-on: ubuntu-latest # can change this to ubuntu-latest if you prefer


### PR DESCRIPTION
Follow-up to #788. That PR gave Test, Lint and CodeQL a concurrency group and left Docker and Jekyll alone, on the grounds that neither has a `pull_request` trigger and so has nothing to supersede.

That is true of *superseding* — but these two are the workflows where overlap costs correctness rather than minutes. Both publish, and both publish to a single mutable target.

## It has already happened

Two pushes landed on master seconds apart on 2026-09-08 and their Docker builds overlapped. The older commit's build finished last:

| commit | | `Build and push` step | |
|---|---|---|---|
| `5807da09` | master HEAD | 15:57:36 → 16:01:09 | |
| `af25b6af` | its parent | 15:57:20 → **16:01:21** | ← won by 12s |

Both push `enigmabbs/enigma-bbs:latest`, so the tag came to rest one commit behind master and stayed there until the next push rebuilt it. (It self-healed when #788 merged, so nothing is broken right now — the race is latent, not biting.)

Jekyll has the same shape: concurrent `peaceiris/actions-gh-pages` runs deploy in whatever order they happen to finish, and can also fail outright contending on the push to `gh-pages`. It landed the right way round that day by luck.

## The group is deliberately the opposite of #788's

```yaml
group: ${{ github.workflow }}
```

No sha. In #788 the sha is what gives every master push a group of its own, so that none is ever cancelled by the next — the right call there, and the run history backs it. Here different commits have to **share** a group, or the runs never collapse at all. Worth calling out so it doesn't read as an inconsistency with the change that just landed.

## Why they differ on `cancel-in-progress`

**Docker cancels.** A superseded multi-arch QEMU build is four minutes of work whose output is stale before it starts. Interrupting it cannot corrupt the tag: a registry push writes content-addressed blobs and moves the tag only on the final manifest, so a killed push orphans blobs and leaves `:latest` untouched.

**Jekyll queues.** The build is ~80s, so waiting costs nothing, and a deploy is better left uninterrupted mid-push. This is also the GitHub Pages convention. Queueing still ends with the newest commit deployed — GitHub keeps one pending run per group and drops older pending ones.

## Testing

Both files parse, and `concurrency` sits at top level with the triggers intact. `.github` is in `.prettierignore`, so `pretty:check` does not touch these — jekyll.yml's existing indentation and trailing whitespace are left as they are rather than tidied into the diff. The two workflow names (`Docker`, `Build and deploy jekyll site`) are distinct, so the name-only groups cannot collide with each other or with the three from #788.

Note this cannot be exercised on the PR itself — neither workflow has a `pull_request` trigger, so CI here will show only Test, Lint and CodeQL. The real test is the next pair of back-to-back master pushes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
