### PR TITLE
fix(docker): build each architecture for real, not amd64 four times

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,6 +38,9 @@ jobs:
         with:
           tags: enigmabbs/enigma-bbs:latest
           file: docker/Dockerfile
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v8
+          #  linux/arm/v8 is not a platform the base image publishes -- arm64
+          #  is already ARMv8 -- and asking for it now fails the build rather
+          #  than silently resolving to amd64 as it used to.
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
           push: true
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,8 @@
-FROM --platform=${BUILDPLATFORM:-linux/amd64} node:22-bookworm-slim
-
-ARG TARGETPLATFORM
-ARG BUILDPLATFORM
-ARG TARGETOS
-ARG TARGETBRANCH
+#  No --platform here on purpose. Pinning this to BUILDPLATFORM builds every
+#  target on the builder's own architecture, which is only correct if the rest
+#  of the file then cross compiles -- and it does not, it just runs npm install
+#  and copies the tree. The result was four tags whose contents were all amd64.
+FROM node:22-bookworm-slim
 
 LABEL maintainer="dave@force9.org"
 


### PR DESCRIPTION
`enigmabbs/enigma-bbs:latest` advertises four platforms. All four are amd64.

## The evidence

The official base image begins with a different layer on each architecture:

| `node:22-bookworm-slim` | first layer |
|---|---|
| amd64 | `a8ac7f6c67ab` |
| arm/v7 | `441f33fd84d9` |
| arm64/v8 | `75782e20ea1f` |

Every one of our four platform manifests begins with **`a8ac7f6c67ab`** — the amd64 base. The first six layers, `npm install` among them, are byte-identical across the amd64, arm64 and arm/v7 manifests.

Two images for genuinely different architectures cannot share a base layer. The arm tags are amd64 images wearing arm labels, and anyone pulling on a Pi or an Apple Silicon box has been getting one.

## The cause

```dockerfile
FROM --platform=${BUILDPLATFORM:-linux/amd64} node:22-bookworm-slim
```

Building every target on `BUILDPLATFORM` is the standard opening for a *cross-compiled* Dockerfile. This one never cross-compiles — it runs `npm install` and copies a tree — so whatever it produces is native to the builder, which on the runner is amd64. Dropping the pin lets buildx resolve the base per target and run each build under QEMU.

The four ARGs that went with it (`TARGETPLATFORM`, `BUILDPLATFORM`, `TARGETOS`, and the invented `TARGETBRANCH`) were never referenced by anything, so they go too.

## `linux/arm/v8` has to go, and that part is not tidying

arm64 already *is* ARMv8, and the base image publishes no such variant — the platform list above is the complete set. Until now nothing noticed, because the pin meant the base was never resolved per target. Once it is, asking for a platform the base does not have **fails the build**. So this is a required half of the change, not a cleanup.

## Build time

Slower, but less so than the toolchain in this file suggests. The two heavyweight native dependencies both ship prebuilts for the arm targets:

- `better-sqlite3@12.9.0` publishes Node 22 ABI (`v127`) binaries for `linux-arm64` **and** `linux-arm`
- `sharp` ships `@img` prebuilts for both

So the SQLite amalgamation and libvips are downloads, not compiles, on every target. What actually builds under emulation is `node-pty`, `cpu-features` and `dtrace-provider` — all small.

Worth noting #793 helps here rather than hurting: sharp 0.25 fell back to compiling libvips from source when a prebuilt was missing, which under QEMU would have been brutal.

## Testing, and its limits

I built the image locally with #793 applied on top — the post-merge state — and it builds clean. Inside it:

```
image arch      : x64 linux
node            : v22.23.2
sharp           : 0.35.4
avatar-generator: 2.0.4 (declares sharp ^0.25.2)
libvips         : 8.18.6
```

That also settles a claim #793 makes on its own: `.dockerignore` excludes `package-lock.json`, so the image resolves from `package.json` alone — and the override does survive that install. Avatar generation runs end to end in the container (640x640 png, 4 channels).

**What I could not test: the arm images themselves.** This host has no QEMU binfmt handlers registered and the docker CLI has no buildx plugin, so only the amd64 build could run locally. Everything above about arm rests on registry manifests, not on a booted arm container. The first real proof is the next master build — after which `docker run --platform linux/arm64 enigmabbs/enigma-bbs:latest uname -m` should finally say `aarch64`.

## One follow-up worth considering separately

If emulated build times turn out to be painful, GitHub now offers free native arm64 runners for public repos. A matrix across `ubuntu-latest` and `ubuntu-24.04-arm` with a manifest merge at the end would be both correct and fast, leaving only arm/v7 emulated. Bigger change, and best judged once we can see what the honest build actually costs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
