### PR TITLE
refactor(msg): lift the offline export flow out of the QWK module

### DIFF
--- a/core/message_base_offline_export.js
+++ b/core/message_base_offline_export.js
@@ -1,0 +1,598 @@
+/* jslint node: true */
+'use strict';
+
+//  ENiGMA½
+const { MenuModule } = require('./menu_module.js');
+const Message = require('./message.js');
+const { Errors } = require('./enig_error.js');
+const {
+    getMessageAreaByTag,
+    getMessageConferenceByTag,
+    hasMessageConfAndAreaRead,
+    getAllAvailableMessageAreaTags,
+} = require('./message_area.js');
+const FileArea = require('./file_base_area.js');
+const { renderSubstr } = require('./string_util.js');
+const FileEntry = require('./file_entry.js');
+const DownloadQueue = require('./download_queue.js');
+const { getISOTimestampString } = require('./database.js');
+const { safeMoveFile } = require('./file_util.js');
+
+//  deps
+const async = require('async');
+const _ = require('lodash');
+const fse = require('fs-extra');
+const temptmp = require('temptmp');
+const paths = require('path');
+const { randomUUID } = require('crypto');
+const moment = require('moment');
+
+const FormIds = {
+    main: 0,
+};
+
+const MciViewIds = {
+    main: {
+        status: 1,
+        progressBar: 2,
+
+        customRangeStart: 10,
+    },
+};
+
+//
+//  The flow every offline mail packet export shares: gather the areas the
+//  caller asked for, walk the new messages in each into a packet writer,
+//  then hand the finished packet to their download queue.
+//
+//  A format supplies a writer and a few names by overriding the hooks below.
+//  A writer is expected to emit 'ready', 'packet', 'finished', 'error' and
+//  'warning', and to take messages through appendMessage().
+//
+module.exports = class MessageBaseOfflineExport extends MenuModule {
+    constructor(options) {
+        super(options);
+
+        this.config = Object.assign(
+            {},
+            _.get(options, 'menuConfig.config'),
+            options.extraArgs
+        );
+
+        this.config.progBarChar = renderSubstr(this.config.progBarChar || '▒', 0, 1);
+
+        this.sysTempDownloadArea = FileArea.getFileAreaByTag(
+            FileArea.WellKnownAreaTags.TempDownloads
+        );
+    }
+
+    //  Hooks. Those with no default here are required; _missingHook()
+    //  checks for them before an export touches the session.
+
+    //  'QWK', 'Blue Wave', ... -- names the format in status text and logs
+    get packetFormatName() {
+        throw Errors.MissingParam('packetFormatName is required');
+    }
+
+    //  where this format keeps the caller's export settings
+    get userProperties() {
+        throw Errors.MissingParam('userProperties is required');
+    }
+
+    createPacketWriter(/*options*/) {
+        throw Errors.MissingParam('createPacketWriter() is required');
+    }
+
+    //  what the caller gets before they have chosen anything
+    defaultExportOptions() {
+        return { archiveFormat: 'application/zip' };
+    }
+
+    //  MCI views the menu must carry; a format whose art has none returns []
+    requiredViewIds() {
+        return [MciViewIds.main.status, MciViewIds.main.progressBar];
+    }
+
+    noResultsMenuName() {
+        throw Errors.MissingParam('noResultsMenuName() is required');
+    }
+
+    //
+    //  A format that lists areas in the packet declares them here, before any
+    //  message is gathered -- Blue Wave lists an area that had no new mail so
+    //  a reader can still post into it.
+    //
+    prepareAreaForExport(/*packetWriter, { areaTag, area, conf }*/) {}
+
+    //  the extension the writer chose is kept: it is part of what a reader
+    //  recognizes
+    tempDownloadFileName(packetInfo) {
+        return `${randomUUID().substr(-8).toUpperCase()}${paths.extname(
+            packetInfo.path
+        )}`;
+    }
+
+    mciReady(mciData, cb) {
+        super.mciReady(mciData, err => {
+            if (err) {
+                return cb(err);
+            }
+
+            async.waterfall(
+                [
+                    callback => {
+                        this.prepViewController(
+                            'main',
+                            FormIds.main,
+                            mciData.menu,
+                            err => {
+                                return callback(err);
+                            }
+                        );
+                    },
+                    callback => {
+                        const required = this.requiredViewIds();
+                        if (!required.length) {
+                            return callback(null);
+                        }
+                        return this.validateMCIByViewIds('main', required, callback);
+                    },
+                    callback => {
+                        this.temptmp = temptmp.createTrackedSession('offlineexport');
+                        this.temptmp.mkdir(
+                            { prefix: 'enigofflineexport-' },
+                            (err, tempDir) => {
+                                if (err) {
+                                    return callback(err);
+                                }
+
+                                this.tempPacketDir = tempDir;
+
+                                const sysTempDownloadDir =
+                                    FileArea.getAreaDefaultStorageDirectory(
+                                        this.sysTempDownloadArea
+                                    );
+
+                                //  ensure dir exists
+                                fse.mkdirs(sysTempDownloadDir, err => {
+                                    return callback(err, sysTempDownloadDir);
+                                });
+                            }
+                        );
+                    },
+                    (sysTempDownloadDir, callback) => {
+                        this._performExport(sysTempDownloadDir, err => {
+                            return callback(err);
+                        });
+                    },
+                ],
+                err => {
+                    this.temptmp.cleanup();
+
+                    if (err) {
+                        //  :TODO: doesn't do anything currently:
+                        if ('NORESULTS' === err.reasonCode) {
+                            return this.gotoMenu(
+                                this.menuConfig.config.noResultsMenu ||
+                                    this.noResultsMenuName()
+                            );
+                        }
+
+                        return this.prevMenu();
+                    }
+                    return cb(err);
+                }
+            );
+        });
+    }
+
+    finishedLoading() {
+        this.prevMenu();
+    }
+
+    _getUserExportOptions() {
+        let options = this.client.user.getProperty(this.userProperties.ExportOptions);
+        try {
+            options = JSON.parse(options);
+        } catch (e) {
+            options = this.defaultExportOptions();
+        }
+        return options;
+    }
+
+    _getUserExportAreas() {
+        let exportAreas = this.client.user.getProperty(this.userProperties.ExportAreas);
+        try {
+            exportAreas = JSON.parse(exportAreas).map(exportArea => {
+                if (exportArea.newerThanTimestamp) {
+                    exportArea.newerThanTimestamp = moment(exportArea.newerThanTimestamp);
+                }
+                return exportArea;
+            });
+        } catch (e) {
+            //  default to all public and private without 'since'
+            exportAreas = getAllAvailableMessageAreaTags(this.client).map(areaTag => {
+                return { areaTag };
+            });
+
+            //  Include user's private area
+            exportAreas.push({
+                areaTag: Message.WellKnownAreaTags.Private,
+            });
+        }
+
+        return exportAreas;
+    }
+
+    //  a writer that fails here must end the wait, not leave the caller on
+    //  the export screen until their session times out
+    _finishPacket(packetWriter, cb) {
+        let packetInfo;
+        const done = _.once(err => cb(err, packetInfo));
+
+        packetWriter.once('packet', info => {
+            packetInfo = info;
+        });
+        packetWriter.once('finished', () => done(null));
+        packetWriter.once('error', err => done(err));
+
+        packetWriter.finish(this.tempPacketDir);
+    }
+
+    //
+    //  A hook a format forgot must be caught here rather than from inside a
+    //  callback: by then the idle monitor is stopped and a key press listener
+    //  is attached, and the throw leaves the session wedged with neither
+    //  undone.
+    //
+    _missingHook() {
+        try {
+            void this.packetFormatName;
+            void this.userProperties;
+            void this.noResultsMenuName();
+        } catch (e) {
+            return e;
+        }
+
+        if (
+            this.createPacketWriter ===
+            MessageBaseOfflineExport.prototype.createPacketWriter
+        ) {
+            return Errors.MissingParam('createPacketWriter() is required');
+        }
+
+        return null;
+    }
+
+    //
+    //  The finished packet into the caller's download queue, valid until
+    //  their session ends.
+    //
+    _deliverPacket(packetInfo, sysTempDownloadDir, cb) {
+        const sysDownloadPath = paths.join(
+            sysTempDownloadDir,
+            this.tempDownloadFileName(packetInfo)
+        );
+
+        safeMoveFile(packetInfo.path, sysDownloadPath, err => {
+            if (err) {
+                return cb(err);
+            }
+
+            const newEntry = new FileEntry({
+                areaTag: this.sysTempDownloadArea.areaTag,
+                fileName: paths.basename(sysDownloadPath),
+                storageTag: this.sysTempDownloadArea.storageTags[0],
+                meta: {
+                    upload_by_username: this.client.user.username,
+                    upload_by_user_id: this.client.user.userId,
+                    byte_size: packetInfo.stats.size,
+                    session_temp_dl: 1, //  download is valid until session is over
+
+                    //  :TODO: something like this: allow to override the displayed/downloaded as filename
+                    //  separate from the actual on disk filename. E.g. we could always download as "ENIGMA.QWK"
+                    //visible_filename    : paths.basename(packetInfo.path),
+                },
+            });
+
+            newEntry.desc = `${this.packetFormatName} Export`;
+
+            newEntry.persist(err => {
+                if (!err) {
+                    //  queue it!
+                    DownloadQueue.get(this.client).addTemporaryDownload(newEntry);
+                }
+                return cb(err);
+            });
+        });
+    }
+
+    _performExport(sysTempDownloadDir, cb) {
+        const missingHook = this._missingHook();
+        if (missingHook) {
+            this.client.log.error(
+                { error: missingHook.message },
+                'Cannot export: the packet format is incomplete'
+            );
+            return cb(missingHook);
+        }
+
+        const statusView = this.viewControllers.main.getView(MciViewIds.main.status);
+        const updateStatus = status => {
+            if (statusView) {
+                statusView.setText(status);
+            }
+        };
+
+        const progBarView = this.viewControllers.main.getView(
+            MciViewIds.main.progressBar
+        );
+        const updateProgressBar = (curr, total) => {
+            if (progBarView) {
+                const prog = Math.floor((curr / total) * progBarView.dimens.width);
+                progBarView.setText(this.config.progBarChar.repeat(prog));
+            }
+        };
+
+        let cancel = false;
+
+        let lastProgUpdate = 0;
+        const progressHandler = (state, next) => {
+            //  we can produce a TON of updates; only update progress at most every 3/4s
+            if (Date.now() - lastProgUpdate > 750) {
+                switch (state.step) {
+                    case 'next_area':
+                        updateStatus(state.status);
+                        updateProgressBar(0, 0);
+                        this.updateCustomViewTextsWithFilter(
+                            'main',
+                            MciViewIds.main.customRangeStart,
+                            state
+                        );
+                        break;
+
+                    case 'message':
+                        updateStatus(state.status);
+                        updateProgressBar(state.current, state.total);
+                        this.updateCustomViewTextsWithFilter(
+                            'main',
+                            MciViewIds.main.customRangeStart,
+                            state
+                        );
+                        break;
+
+                    default:
+                        break;
+                }
+                lastProgUpdate = Date.now();
+            }
+
+            return next(cancel ? Errors.UserInterrupt('User canceled') : null);
+        };
+
+        const keyPressHandler = (ch, key) => {
+            if ('escape' === key.name) {
+                cancel = true;
+                this.client.removeListener('key press', keyPressHandler);
+            }
+        };
+
+        let totalExported = 0;
+        const processMessagesWithFilter = (filter, cb) => {
+            Message.findMessages(filter, (err, messageIds) => {
+                if (err) {
+                    return cb(err);
+                }
+
+                let current = 1;
+                async.eachSeries(
+                    messageIds,
+                    (messageId, nextMessageId) => {
+                        const message = new Message();
+                        message.load({ messageId }, err => {
+                            if (err) {
+                                return nextMessageId(err);
+                            }
+
+                            const progress = {
+                                message,
+                                step: 'message',
+                                total: ++totalExported,
+                                areaCurrent: current,
+                                areaCount: messageIds.length,
+                                status: `${_.truncate(message.subject, {
+                                    length: 25,
+                                })} (${current} / ${messageIds.length})`,
+                            };
+
+                            progressHandler(progress, err => {
+                                if (err) {
+                                    return nextMessageId(err);
+                                }
+
+                                packetWriter.appendMessage(message);
+                                current += 1;
+
+                                return nextMessageId(null);
+                            });
+                        });
+                    },
+                    err => {
+                        return cb(err);
+                    }
+                );
+            });
+        };
+
+        const packetWriter = this.createPacketWriter(
+            Object.assign(this._getUserExportOptions(), {
+                user: this.client.user,
+            })
+        );
+
+        packetWriter.on('warning', warning => {
+            this.client.log.warn(
+                { warning },
+                `${this.packetFormatName} packet writer warning`
+            );
+        });
+
+        async.waterfall(
+            [
+                callback => {
+                    //  don't count idle monitor while processing
+                    this.client.stopIdleMonitor();
+
+                    //  let user cancel
+                    this.client.on('key press', keyPressHandler);
+
+                    //  a writer that fails to start ends the export here, for
+                    //  the same reason a writer that fails to finish does
+                    const started = _.once(callback);
+
+                    packetWriter.once('ready', () => started(null));
+
+                    packetWriter.on('error', err => {
+                        this.client.log.error(
+                            { error: err.message },
+                            `${this.packetFormatName} packet writer error`
+                        );
+                        cancel = true;
+                        started(err);
+                    });
+
+                    packetWriter.init();
+                },
+                callback => {
+                    //  For each public area -> for each message
+                    const userExportAreas = this._getUserExportAreas();
+
+                    const publicExportAreas = userExportAreas.filter(exportArea => {
+                        return exportArea.areaTag !== Message.WellKnownAreaTags.Private;
+                    });
+                    async.eachSeries(
+                        publicExportAreas,
+                        (exportArea, nextExportArea) => {
+                            const area = getMessageAreaByTag(exportArea.areaTag);
+                            let conf;
+                            if (area) {
+                                conf = getMessageConferenceByTag(area.confTag);
+                            }
+                            if (!area || !conf) {
+                                //  :TODO: remove from user properties - this area does not exist
+                                this.client.log.warn(
+                                    { areaTag: exportArea.areaTag },
+                                    `Cannot ${this.packetFormatName} export area as it does not exist`
+                                );
+                                return nextExportArea(null);
+                            }
+
+                            if (!hasMessageConfAndAreaRead(this.client, area)) {
+                                this.client.log.warn(
+                                    { areaTag: area.areaTag },
+                                    `Cannot ${this.packetFormatName} export area due to ACS`
+                                );
+                                return nextExportArea(null);
+                            }
+
+                            this.prepareAreaForExport(packetWriter, {
+                                areaTag: exportArea.areaTag,
+                                area,
+                                conf,
+                            });
+
+                            const progress = {
+                                conf,
+                                area,
+                                step: 'next_area',
+                                status: `Gathering in ${conf.name} - ${area.name}...`,
+                            };
+
+                            progressHandler(progress, err => {
+                                if (err) {
+                                    return nextExportArea(err);
+                                }
+
+                                const filter = {
+                                    resultType: 'id',
+                                    areaTag: exportArea.areaTag,
+                                    newerThanTimestamp: exportArea.newerThanTimestamp,
+                                };
+
+                                processMessagesWithFilter(filter, err => {
+                                    return nextExportArea(err);
+                                });
+                            });
+                        },
+                        err => {
+                            return callback(err, userExportAreas);
+                        }
+                    );
+                },
+                (userExportAreas, callback) => {
+                    //  Private messages to current user if the user has
+                    //  elected to export private messages
+                    const privateExportArea = userExportAreas.find(
+                        exportArea =>
+                            exportArea.areaTag === Message.WellKnownAreaTags.Private
+                    );
+                    if (!privateExportArea) {
+                        return callback(null);
+                    }
+
+                    this.prepareAreaForExport(packetWriter, {
+                        areaTag: Message.WellKnownAreaTags.Private,
+                    });
+
+                    const filter = {
+                        resultType: 'id',
+                        privateTagUserId: this.client.user.userId,
+                        newerThanTimestamp: privateExportArea.newerThanTimestamp,
+                    };
+                    return processMessagesWithFilter(filter, callback);
+                },
+                callback => {
+                    return this._finishPacket(packetWriter, callback);
+                },
+                (packetInfo, callback) => {
+                    if (0 === totalExported) {
+                        return callback(Errors.NothingToDo('No messages exported'));
+                    }
+
+                    return this._deliverPacket(packetInfo, sysTempDownloadDir, callback);
+                },
+                callback => {
+                    //  update user's export area dates; they can always change/reset them again
+                    const updatedUserExportAreas = this._getUserExportAreas().map(
+                        exportArea => {
+                            return Object.assign(exportArea, {
+                                newerThanTimestamp: getISOTimestampString(),
+                            });
+                        }
+                    );
+
+                    return this.client.user.persistProperty(
+                        this.userProperties.ExportAreas,
+                        JSON.stringify(updatedUserExportAreas),
+                        callback
+                    );
+                },
+            ],
+            err => {
+                this.client.startIdleMonitor(); //  re-enable
+                this.client.removeListener('key press', keyPressHandler);
+
+                if (!err) {
+                    updateStatus(
+                        `A ${this.packetFormatName} packet has been placed in your download queue`
+                    );
+                } else if (err.code === Errors.NothingToDo().code) {
+                    updateStatus('No messages to export with current criteria');
+                    err = null;
+                }
+
+                return cb(err);
+            }
+        );
+    }
+};

--- a/core/message_base_offline_export.js
+++ b/core/message_base_offline_export.js
@@ -93,8 +93,10 @@ module.exports = class MessageBaseOfflineExport extends MenuModule {
         return [MciViewIds.main.status, MciViewIds.main.progressBar];
     }
 
+    //  Optional: the NORESULTS branch that consumes this is currently dead
+    //  (see mciReady()), so a format need not supply one.
     noResultsMenuName() {
-        throw Errors.MissingParam('noResultsMenuName() is required');
+        return null;
     }
 
     //
@@ -249,7 +251,6 @@ module.exports = class MessageBaseOfflineExport extends MenuModule {
         try {
             void this.packetFormatName;
             void this.userProperties;
-            void this.noResultsMenuName();
         } catch (e) {
             return e;
         }
@@ -540,8 +541,17 @@ module.exports = class MessageBaseOfflineExport extends MenuModule {
                         return callback(null);
                     }
 
+                    //  private mail is a real area (system_internal /
+                    //  private_mail), so the hook gets the same shape it does
+                    //  for public areas
+                    const privateArea = getMessageAreaByTag(
+                        Message.WellKnownAreaTags.Private
+                    );
                     this.prepareAreaForExport(packetWriter, {
                         areaTag: Message.WellKnownAreaTags.Private,
+                        area: privateArea,
+                        conf:
+                            privateArea && getMessageConferenceByTag(privateArea.confTag),
                     });
 
                     const filter = {

--- a/core/message_base_qwk_export.js
+++ b/core/message_base_qwk_export.js
@@ -1,43 +1,10 @@
 //  ENiGMA½
-const { MenuModule } = require('./menu_module');
-const Message = require('./message');
-const { Errors } = require('./enig_error');
-const {
-    getMessageAreaByTag,
-    getMessageConferenceByTag,
-    hasMessageConfAndAreaRead,
-    getAllAvailableMessageAreaTags,
-} = require('./message_area');
-const FileArea = require('./file_base_area');
-const { QWKPacketWriter } = require('./qwk_mail_packet');
-const { renderSubstr } = require('./string_util');
-const Config = require('./config').get;
-const FileEntry = require('./file_entry');
-const DownloadQueue = require('./download_queue');
-const { getISOTimestampString } = require('./database');
-const { safeMoveFile } = require('./file_util');
+const MessageBaseOfflineExport = require('./message_base_offline_export.js');
+const { QWKPacketWriter } = require('./qwk_mail_packet.js');
+const Config = require('./config.js').get;
 
 //  deps
-const async = require('async');
 const _ = require('lodash');
-const fse = require('fs-extra');
-const temptmp = require('temptmp');
-const paths = require('path');
-const { randomUUID } = require('crypto');
-const moment = require('moment');
-
-const FormIds = {
-    main: 0,
-};
-
-const MciViewIds = {
-    main: {
-        status: 1,
-        progressBar: 2,
-
-        customRangeStart: 10,
-    },
-};
 
 const UserProperties = {
     ExportOptions: 'qwk_export_options',
@@ -50,442 +17,40 @@ exports.moduleInfo = {
     author: 'NuSkooler',
 };
 
-exports.getModule = class MessageBaseQWKExport extends MenuModule {
+exports.getModule = class MessageBaseQWKExport extends MessageBaseOfflineExport {
     constructor(options) {
         super(options);
 
-        this.config = Object.assign(
-            {},
-            _.get(options, 'menuConfig.config'),
-            options.extraArgs
-        );
-
-        this.config.progBarChar = renderSubstr(this.config.progBarChar || '▒', 0, 1);
         this.config.bbsID =
             this.config.bbsID || _.get(Config(), 'messageNetworks.qwk.bbsID', 'ENIGMA');
-
-        this.tempName = `${randomUUID().substr(-8).toUpperCase()}.QWK`;
-        this.sysTempDownloadArea = FileArea.getFileAreaByTag(
-            FileArea.WellKnownAreaTags.TempDownloads
-        );
     }
 
-    mciReady(mciData, cb) {
-        super.mciReady(mciData, err => {
-            if (err) {
-                return cb(err);
-            }
-
-            async.waterfall(
-                [
-                    callback => {
-                        this.prepViewController(
-                            'main',
-                            FormIds.main,
-                            mciData.menu,
-                            err => {
-                                return callback(err);
-                            }
-                        );
-                    },
-                    callback => {
-                        return this.validateMCIByViewIds(
-                            'main',
-                            [MciViewIds.main.status, MciViewIds.main.progressBar],
-                            callback
-                        );
-                    },
-                    callback => {
-                        this.temptmp = temptmp.createTrackedSession('qwkuserexp');
-                        this.temptmp.mkdir(
-                            { prefix: 'enigqwkwriter-' },
-                            (err, tempDir) => {
-                                if (err) {
-                                    return callback(err);
-                                }
-
-                                this.tempPacketDir = tempDir;
-
-                                const sysTempDownloadDir =
-                                    FileArea.getAreaDefaultStorageDirectory(
-                                        this.sysTempDownloadArea
-                                    );
-
-                                //  ensure dir exists
-                                fse.mkdirs(sysTempDownloadDir, err => {
-                                    return callback(err, sysTempDownloadDir);
-                                });
-                            }
-                        );
-                    },
-                    (sysTempDownloadDir, callback) => {
-                        this._performExport(sysTempDownloadDir, err => {
-                            return callback(err);
-                        });
-                    },
-                ],
-                err => {
-                    this.temptmp.cleanup();
-
-                    if (err) {
-                        //  :TODO: doesn't do anything currently:
-                        if ('NORESULTS' === err.reasonCode) {
-                            return this.gotoMenu(
-                                this.menuConfig.config.noResultsMenu ||
-                                    'qwkExportNoResults'
-                            );
-                        }
-
-                        return this.prevMenu();
-                    }
-                    return cb(err);
-                }
-            );
-        });
+    get packetFormatName() {
+        return 'QWK';
     }
 
-    finishedLoading() {
-        this.prevMenu();
+    get userProperties() {
+        return UserProperties;
     }
 
-    _getUserQWKExportOptions() {
-        let qwkOptions = this.client.user.getProperty(UserProperties.ExportOptions);
-        try {
-            qwkOptions = JSON.parse(qwkOptions);
-        } catch (e) {
-            qwkOptions = {
-                enableQWKE: true,
-                enableHeadersExtension: true,
-                enableAtKludges: true,
-                archiveFormat: 'application/zip',
-            };
-        }
-        return qwkOptions;
+    defaultExportOptions() {
+        return {
+            enableQWKE: true,
+            enableHeadersExtension: true,
+            enableAtKludges: true,
+            archiveFormat: 'application/zip',
+        };
     }
 
-    _getUserQWKExportAreas() {
-        let qwkExportAreas = this.client.user.getProperty(UserProperties.ExportAreas);
-        try {
-            qwkExportAreas = JSON.parse(qwkExportAreas).map(exportArea => {
-                if (exportArea.newerThanTimestamp) {
-                    exportArea.newerThanTimestamp = moment(exportArea.newerThanTimestamp);
-                }
-                return exportArea;
-            });
-        } catch (e) {
-            //  default to all public and private without 'since'
-            qwkExportAreas = getAllAvailableMessageAreaTags(this.client).map(areaTag => {
-                return { areaTag };
-            });
-
-            //  Include user's private area
-            qwkExportAreas.push({
-                areaTag: Message.WellKnownAreaTags.Private,
-            });
-        }
-
-        return qwkExportAreas;
+    noResultsMenuName() {
+        return 'qwkExportNoResults';
     }
 
-    _performExport(sysTempDownloadDir, cb) {
-        const statusView = this.viewControllers.main.getView(MciViewIds.main.status);
-        const updateStatus = status => {
-            if (statusView) {
-                statusView.setText(status);
-            }
-        };
-
-        const progBarView = this.viewControllers.main.getView(
-            MciViewIds.main.progressBar
-        );
-        const updateProgressBar = (curr, total) => {
-            if (progBarView) {
-                const prog = Math.floor((curr / total) * progBarView.dimens.width);
-                progBarView.setText(this.config.progBarChar.repeat(prog));
-            }
-        };
-
-        let cancel = false;
-
-        let lastProgUpdate = 0;
-        const progressHandler = (state, next) => {
-            //  we can produce a TON of updates; only update progress at most every 3/4s
-            if (Date.now() - lastProgUpdate > 750) {
-                switch (state.step) {
-                    case 'next_area':
-                        updateStatus(state.status);
-                        updateProgressBar(0, 0);
-                        this.updateCustomViewTextsWithFilter(
-                            'main',
-                            MciViewIds.main.customRangeStart,
-                            state
-                        );
-                        break;
-
-                    case 'message':
-                        updateStatus(state.status);
-                        updateProgressBar(state.current, state.total);
-                        this.updateCustomViewTextsWithFilter(
-                            'main',
-                            MciViewIds.main.customRangeStart,
-                            state
-                        );
-                        break;
-
-                    default:
-                        break;
-                }
-                lastProgUpdate = Date.now();
-            }
-
-            return next(cancel ? Errors.UserInterrupt('User canceled') : null);
-        };
-
-        const keyPressHandler = (ch, key) => {
-            if ('escape' === key.name) {
-                cancel = true;
-                this.client.removeListener('key press', keyPressHandler);
-            }
-        };
-
-        let totalExported = 0;
-        const processMessagesWithFilter = (filter, cb) => {
-            Message.findMessages(filter, (err, messageIds) => {
-                if (err) {
-                    return cb(err);
-                }
-
-                let current = 1;
-                async.eachSeries(
-                    messageIds,
-                    (messageId, nextMessageId) => {
-                        const message = new Message();
-                        message.load({ messageId }, err => {
-                            if (err) {
-                                return nextMessageId(err);
-                            }
-
-                            const progress = {
-                                message,
-                                step: 'message',
-                                total: ++totalExported,
-                                areaCurrent: current,
-                                areaCount: messageIds.length,
-                                status: `${_.truncate(message.subject, {
-                                    length: 25,
-                                })} (${current} / ${messageIds.length})`,
-                            };
-
-                            progressHandler(progress, err => {
-                                if (err) {
-                                    return nextMessageId(err);
-                                }
-
-                                packetWriter.appendMessage(message);
-                                current += 1;
-
-                                return nextMessageId(null);
-                            });
-                        });
-                    },
-                    err => {
-                        return cb(err);
-                    }
-                );
-            });
-        };
-
-        const packetWriter = new QWKPacketWriter(
-            Object.assign(this._getUserQWKExportOptions(), {
-                user: this.client.user,
+    createPacketWriter(options) {
+        return new QWKPacketWriter(
+            Object.assign(options, {
                 bbsID: this.config.bbsID,
             })
-        );
-
-        packetWriter.on('warning', warning => {
-            this.client.log.warn({ warning }, 'QWK packet writer warning');
-        });
-
-        async.waterfall(
-            [
-                callback => {
-                    //  don't count idle monitor while processing
-                    this.client.stopIdleMonitor();
-
-                    //  let user cancel
-                    this.client.on('key press', keyPressHandler);
-
-                    packetWriter.once('ready', () => {
-                        return callback(null);
-                    });
-
-                    packetWriter.once('error', err => {
-                        this.client.log.error(
-                            { error: err.message },
-                            'QWK packet writer error'
-                        );
-                        cancel = true;
-                    });
-
-                    packetWriter.init();
-                },
-                callback => {
-                    //  For each public area -> for each message
-                    const userExportAreas = this._getUserQWKExportAreas();
-
-                    const publicExportAreas = userExportAreas.filter(exportArea => {
-                        return exportArea.areaTag !== Message.WellKnownAreaTags.Private;
-                    });
-                    async.eachSeries(
-                        publicExportAreas,
-                        (exportArea, nextExportArea) => {
-                            const area = getMessageAreaByTag(exportArea.areaTag);
-                            let conf;
-                            if (area) {
-                                conf = getMessageConferenceByTag(area.confTag);
-                            }
-                            if (!area || !conf) {
-                                //  :TODO: remove from user properties - this area does not exist
-                                this.client.log.warn(
-                                    { areaTag: exportArea.areaTag },
-                                    'Cannot QWK export area as it does not exist'
-                                );
-                                return nextExportArea(null);
-                            }
-
-                            if (!hasMessageConfAndAreaRead(this.client, area)) {
-                                this.client.log.warn(
-                                    { areaTag: area.areaTag },
-                                    'Cannot QWK export area due to ACS'
-                                );
-                                return nextExportArea(null);
-                            }
-
-                            const progress = {
-                                conf,
-                                area,
-                                step: 'next_area',
-                                status: `Gathering in ${conf.name} - ${area.name}...`,
-                            };
-
-                            progressHandler(progress, err => {
-                                if (err) {
-                                    return nextExportArea(err);
-                                }
-
-                                const filter = {
-                                    resultType: 'id',
-                                    areaTag: exportArea.areaTag,
-                                    newerThanTimestamp: exportArea.newerThanTimestamp,
-                                };
-
-                                processMessagesWithFilter(filter, err => {
-                                    return nextExportArea(err);
-                                });
-                            });
-                        },
-                        err => {
-                            return callback(err, userExportAreas);
-                        }
-                    );
-                },
-                (userExportAreas, callback) => {
-                    //  Private messages to current user if the user has
-                    //  elected to export private messages
-                    const privateExportArea = userExportAreas.find(
-                        exportArea =>
-                            exportArea.areaTag === Message.WellKnownAreaTags.Private
-                    );
-                    if (!privateExportArea) {
-                        return callback(null);
-                    }
-
-                    const filter = {
-                        resultType: 'id',
-                        privateTagUserId: this.client.user.userId,
-                        newerThanTimestamp: privateExportArea.newerThanTimestamp,
-                    };
-                    return processMessagesWithFilter(filter, callback);
-                },
-                callback => {
-                    let packetInfo;
-                    packetWriter.once('packet', info => {
-                        packetInfo = info;
-                    });
-
-                    packetWriter.once('finished', () => {
-                        return callback(null, packetInfo);
-                    });
-
-                    packetWriter.finish(this.tempPacketDir);
-                },
-                (packetInfo, callback) => {
-                    if (0 === totalExported) {
-                        return callback(Errors.NothingToDo('No messages exported'));
-                    }
-
-                    const sysDownloadPath = paths.join(sysTempDownloadDir, this.tempName);
-                    safeMoveFile(packetInfo.path, sysDownloadPath, err => {
-                        return callback(err, sysDownloadPath, packetInfo);
-                    });
-                },
-                (sysDownloadPath, packetInfo, callback) => {
-                    const newEntry = new FileEntry({
-                        areaTag: this.sysTempDownloadArea.areaTag,
-                        fileName: paths.basename(sysDownloadPath),
-                        storageTag: this.sysTempDownloadArea.storageTags[0],
-                        meta: {
-                            upload_by_username: this.client.user.username,
-                            upload_by_user_id: this.client.user.userId,
-                            byte_size: packetInfo.stats.size,
-                            session_temp_dl: 1, //  download is valid until session is over
-
-                            //  :TODO: something like this: allow to override the displayed/downloaded as filename
-                            //  separate from the actual on disk filename. E.g. we could always download as "ENIGMA.QWK"
-                            //visible_filename    : paths.basename(packetInfo.path),
-                        },
-                    });
-
-                    newEntry.desc = 'QWK Export';
-
-                    newEntry.persist(err => {
-                        if (!err) {
-                            //  queue it!
-                            DownloadQueue.get(this.client).addTemporaryDownload(newEntry);
-                        }
-                        return callback(err);
-                    });
-                },
-                callback => {
-                    //  update user's export area dates; they can always change/reset them again
-                    const updatedUserExportAreas = this._getUserQWKExportAreas().map(
-                        exportArea => {
-                            return Object.assign(exportArea, {
-                                newerThanTimestamp: getISOTimestampString(),
-                            });
-                        }
-                    );
-
-                    return this.client.user.persistProperty(
-                        UserProperties.ExportAreas,
-                        JSON.stringify(updatedUserExportAreas),
-                        callback
-                    );
-                },
-            ],
-            err => {
-                this.client.startIdleMonitor(); //  re-enable
-                this.client.removeListener('key press', keyPressHandler);
-
-                if (!err) {
-                    updateStatus('A QWK packet has been placed in your download queue');
-                } else if (err.code === Errors.NothingToDo().code) {
-                    updateStatus('No messages to export with current criteria');
-                    err = null;
-                }
-
-                return cb(err);
-            }
         );
     }
 };

--- a/test/message_base_offline_export.test.js
+++ b/test/message_base_offline_export.test.js
@@ -3,6 +3,8 @@
 const { strict: assert } = require('assert');
 const { EventEmitter } = require('events');
 
+const configModule = require('../core/config.js');
+
 const MessageBaseOfflineExport = require('../core/message_base_offline_export.js');
 const QWKExport = require('../core/message_base_qwk_export.js').getModule;
 
@@ -259,8 +261,9 @@ describe('offline packet export flow', () => {
         createPacketWriter() {
             return this.writer;
         }
-        prepareAreaForExport(packetWriter, { areaTag }) {
-            this.declared.push(areaTag);
+        prepareAreaForExport(packetWriter, info) {
+            this.declared.push(info.areaTag);
+            this.declaredInfo.push(info);
         }
     }
 
@@ -270,6 +273,7 @@ describe('offline packet export flow', () => {
         mod.writer = new FakeWriter(startup);
         mod.tempPacketDir = '/tmp/packet-work';
         mod.declared = [];
+        mod.declaredInfo = [];
         mod.delivered = null;
         mod.status = [];
         mod.warnings = [];
@@ -349,6 +353,36 @@ describe('offline packet export flow', () => {
         const mod = makeExport([10]);
         mod._performExport('/tmp/downloads', () => {
             assert.deepEqual(mod.declared, [Message.WellKnownAreaTags.Private]);
+            done();
+        });
+    });
+
+    //  the hook gets one shape: private mail is a real area, so |area| and
+    //  |conf| are populated for it exactly as they are for a public one
+    it('hands the private area its area and conference', done => {
+        const previousConfig = configModule._pushTestConfig({
+            debug: { assertsEnabled: false },
+            menus: { cls: false },
+            general: { boardName: 'ENiGMA½ BBS' },
+            messageConferences: {
+                system_internal: {
+                    name: 'System Internal',
+                    areas: {
+                        private_mail: { name: 'Private Mail' },
+                    },
+                },
+            },
+        });
+
+        const mod = makeExport([10]);
+        mod._performExport('/tmp/downloads', () => {
+            configModule._popTestConfig(previousConfig);
+
+            assert.equal(mod.declaredInfo.length, 1);
+            const info = mod.declaredInfo[0];
+            assert.equal(info.areaTag, Message.WellKnownAreaTags.Private);
+            assert.equal(info.area.name, 'Private Mail');
+            assert.equal(info.conf.name, 'System Internal');
             done();
         });
     });

--- a/test/message_base_offline_export.test.js
+++ b/test/message_base_offline_export.test.js
@@ -1,0 +1,477 @@
+'use strict';
+
+const { strict: assert } = require('assert');
+const { EventEmitter } = require('events');
+
+const MessageBaseOfflineExport = require('../core/message_base_offline_export.js');
+const QWKExport = require('../core/message_base_qwk_export.js').getModule;
+
+//
+//  The module is exercised through its prototype: constructing it wants a live
+//  menu stack and a file area, and none of this touches either.
+//
+function makeModule(Module, { properties = {}, config = {} } = {}) {
+    const mod = Object.create(Module.prototype);
+    mod.config = config;
+    mod.tempPacketDir = '/tmp/does-not-matter';
+    mod.client = {
+        user: {
+            getProperty: name => properties[name],
+        },
+    };
+    return mod;
+}
+
+//  a stand-in for a packet writer, which is an EventEmitter either way
+class FakeWriter extends EventEmitter {
+    constructor(outcome) {
+        super();
+        this.outcome = outcome;
+    }
+
+    finish() {
+        process.nextTick(() => {
+            if ('error' === this.outcome) {
+                return this.emit('error', new Error('archiver failed'));
+            }
+            this.emit('packet', { path: '/tmp/ENIGMA.QWK', stats: { size: 42 } });
+            this.emit('finished');
+        });
+    }
+}
+
+describe('offline packet export', () => {
+    //
+    //  A writer that fails while finishing used to leave the caller sitting on
+    //  the export screen: the only 'error' handler recorded the failure and
+    //  the step waited on 'finished', which never came.
+    //
+    it('ends the wait when the writer fails while finishing', done => {
+        const mod = makeModule(MessageBaseOfflineExport);
+        mod._finishPacket(new FakeWriter('error'), err => {
+            assert.ok(err, 'expected an error');
+            assert.equal(err.message, 'archiver failed');
+            done();
+        });
+    });
+
+    it('hands back the packet when the writer finishes', done => {
+        const mod = makeModule(MessageBaseOfflineExport);
+        mod._finishPacket(new FakeWriter('ok'), (err, packetInfo) => {
+            assert.equal(err, null);
+            assert.equal(packetInfo.path, '/tmp/ENIGMA.QWK');
+            done();
+        });
+    });
+
+    it('answers only once, however many events arrive', done => {
+        const mod = makeModule(MessageBaseOfflineExport);
+        const writer = new FakeWriter('ok');
+        let calls = 0;
+
+        mod._finishPacket(writer, () => {
+            calls += 1;
+        });
+
+        setTimeout(() => {
+            writer.emit('error', new Error('and then it failed too'));
+            assert.equal(calls, 1);
+            done();
+        }, 10);
+    });
+
+    //  the extension is part of what a reader recognizes
+    it('keeps the extension the writer chose', () => {
+        const mod = makeModule(MessageBaseOfflineExport);
+        const name = mod.tempDownloadFileName({ path: '/tmp/work/ENIGMA.MO4' });
+        assert.ok(name.endsWith('.MO4'), name);
+        assert.equal(name.length, 8 + '.MO4'.length);
+    });
+
+    it('falls back to the format defaults when the caller has chosen nothing', () => {
+        const mod = makeModule(QWKExport);
+        assert.deepEqual(mod._getUserExportOptions(), {
+            enableQWKE: true,
+            enableHeadersExtension: true,
+            enableAtKludges: true,
+            archiveFormat: 'application/zip',
+        });
+    });
+
+    it('reads the options the caller has stored', () => {
+        const mod = makeModule(QWKExport, {
+            properties: { qwk_export_options: '{"archiveFormat":"application/x-7z"}' },
+        });
+        assert.deepEqual(mod._getUserExportOptions(), {
+            archiveFormat: 'application/x-7z',
+        });
+    });
+
+    it('reads the areas the caller has stored', () => {
+        const mod = makeModule(QWKExport, {
+            properties: {
+                qwk_export_msg_areas: JSON.stringify([
+                    { areaTag: 'general', newerThanTimestamp: '2026-09-09T00:00:00Z' },
+                ]),
+            },
+        });
+
+        const areas = mod._getUserExportAreas();
+        assert.equal(areas.length, 1);
+        assert.equal(areas[0].areaTag, 'general');
+        assert.ok(areas[0].newerThanTimestamp.isValid(), 'parsed as a moment');
+    });
+
+    //  a format that supplies none of them cannot export, and says so
+    it('requires a format to name itself and its writer', () => {
+        const mod = makeModule(MessageBaseOfflineExport);
+        assert.throws(() => mod.packetFormatName, /packetFormatName/);
+        assert.throws(() => mod.userProperties, /userProperties/);
+        assert.throws(() => mod.createPacketWriter({}), /createPacketWriter/);
+    });
+
+    //
+    //  The hook whose breakage is silent: a writer built without the board's
+    //  packet ID produces a packet named for the wrong system rather than an
+    //  error.
+    //
+    it('hands the packet ID to the writer it builds', () => {
+        const mod = makeModule(QWKExport, { config: { bbsID: 'TESTBBS' } });
+        const writer = mod.createPacketWriter({ user: null });
+        assert.equal(writer.options.bbsID, 'TESTBBS');
+        writer.temptmp.cleanup(); //  the constructor tracks a session of its own
+    });
+
+    //  a menu whose art carries neither view is a format's own business
+    it('asks for the status and progress views by default', () => {
+        assert.deepEqual(makeModule(MessageBaseOfflineExport).requiredViewIds(), [1, 2]);
+    });
+
+    //
+    //  A missing hook used to surface from inside a callback, after the idle
+    //  monitor was stopped and a key press listener attached, leaving the
+    //  session wedged with neither undone.
+    //
+    it('names the hook a format forgot, before the export starts', () => {
+        class Incomplete extends MessageBaseOfflineExport {
+            get packetFormatName() {
+                return 'Incomplete';
+            }
+            get userProperties() {
+                return { ExportOptions: 'x', ExportAreas: 'y' };
+            }
+            noResultsMenuName() {
+                return 'x';
+            }
+        }
+
+        const missing = makeModule(Incomplete)._missingHook();
+        assert.ok(missing, 'expected a missing hook');
+        assert.match(missing.message, /createPacketWriter/);
+
+        assert.match(
+            makeModule(MessageBaseOfflineExport)._missingHook().message,
+            /packetFormatName/
+        );
+        assert.equal(makeModule(QWKExport)._missingHook(), null);
+    });
+
+    it('carries the QWK names through to the base', () => {
+        const mod = makeModule(QWKExport);
+        assert.equal(mod.packetFormatName, 'QWK');
+        assert.deepEqual(mod.userProperties, {
+            ExportOptions: 'qwk_export_options',
+            ExportAreas: 'qwk_export_msg_areas',
+        });
+    });
+});
+
+//
+//  The export flow itself. The public area walk needs a live message base, so
+//  what this reaches is the caller's private mail and everything after it:
+//  the writer's start and finish, the counting, the delivery and the export
+//  high-water mark.
+//
+describe('offline packet export flow', () => {
+    const Message = require('../core/message.js');
+
+    //
+    //  Message is required as an object, so its statics can be stood in for.
+    //  The originals are captured ONCE here, at require time: capturing them
+    //  inside the factory would grab a stub the moment one test patched twice,
+    //  and afterEach would then restore the stub for every later test file.
+    //
+    const realFindMessages = Message.findMessages;
+    const realLoad = Message.prototype.load;
+
+    afterEach(() => {
+        Message.findMessages = realFindMessages;
+        Message.prototype.load = realLoad;
+    });
+
+    //  a writer that reaches 'ready' and 'finished' the way a real one does
+    class FakeWriter extends EventEmitter {
+        constructor(startup = 'ready') {
+            super();
+            this.startup = startup;
+            this.messages = [];
+            this.finishedIn = null;
+        }
+
+        init() {
+            process.nextTick(() => {
+                if ('error' === this.startup) {
+                    return this.emit('error', new Error('no temp directory'));
+                }
+                this.emit('ready');
+                //  a writer that starts and then fails while gathering
+                if ('lateError' === this.startup) {
+                    process.nextTick(() =>
+                        this.emit('error', new Error('the stream closed'))
+                    );
+                }
+            });
+        }
+
+        appendMessage(message) {
+            this.messages.push(message.subject);
+        }
+
+        finish(packetDirectory) {
+            this.finishedIn = packetDirectory;
+            process.nextTick(() => {
+                this.emit('packet', { path: '/tmp/TEST.QWK', stats: { size: 7 } });
+                this.emit('finished');
+            });
+        }
+    }
+
+    class FakeExport extends MessageBaseOfflineExport {
+        get packetFormatName() {
+            return 'Test';
+        }
+        get userProperties() {
+            return { ExportOptions: 'test_options', ExportAreas: 'test_areas' };
+        }
+        noResultsMenuName() {
+            return 'testNoResults';
+        }
+        createPacketWriter() {
+            return this.writer;
+        }
+        prepareAreaForExport(packetWriter, { areaTag }) {
+            this.declared.push(areaTag);
+        }
+    }
+
+    function makeExport(messageIds, { Module = FakeExport, startup = 'ready' } = {}) {
+        const mod = Object.create(Module.prototype);
+        mod.config = { progBarChar: '▒' };
+        mod.writer = new FakeWriter(startup);
+        mod.tempPacketDir = '/tmp/packet-work';
+        mod.declared = [];
+        mod.delivered = null;
+        mod.status = [];
+        mod.warnings = [];
+        mod.idle = [];
+        mod.persisted = {};
+
+        //  the delivery tail wants the file base; the flow above it does not
+        mod._deliverPacket = (packetInfo, dir, cb) => {
+            mod.delivered = { packetInfo, dir };
+            return cb(null);
+        };
+
+        //  a view that records what it is told, so the progress path runs
+        const view = {
+            dimens: { width: 10 },
+            setText: text => mod.status.push(text),
+        };
+        mod.viewControllers = { main: { getView: () => view } };
+        mod.updateCustomViewTextsWithFilter = () => {};
+
+        mod.client = {
+            log: {
+                warn: ctx => mod.warnings.push(ctx),
+                error: () => {},
+            },
+            stopIdleMonitor: () => mod.idle.push('stop'),
+            startIdleMonitor: () => mod.idle.push('start'),
+            on: () => {},
+            removeListener: () => {},
+            user: {
+                userId: 1,
+                username: 'testuser',
+                getProperty: name =>
+                    'test_areas' === name
+                        ? JSON.stringify([{ areaTag: Message.WellKnownAreaTags.Private }])
+                        : undefined,
+                persistProperty: (name, value, cb) => {
+                    mod.persisted[name] = value;
+                    return cb(null);
+                },
+            },
+        };
+
+        Message.findMessages = (filter, cb) => {
+            mod.lastFilter = filter;
+            return cb(null, messageIds);
+        };
+        Message.prototype.load = function (options, cb) {
+            this.subject = `Message ${options.messageId}`;
+            return cb(null);
+        };
+
+        return mod;
+    }
+
+    it('walks the caller private mail into the writer and delivers the packet', done => {
+        const mod = makeExport([10, 11, 12]);
+
+        mod._performExport('/tmp/downloads', err => {
+            assert.equal(err, null);
+            assert.deepEqual(mod.writer.messages, [
+                'Message 10',
+                'Message 11',
+                'Message 12',
+            ]);
+            assert.equal(mod.lastFilter.privateTagUserId, 1);
+            assert.equal(mod.writer.finishedIn, '/tmp/packet-work');
+            assert.ok(mod.delivered, 'the packet was delivered');
+            assert.equal(mod.delivered.packetInfo.path, '/tmp/TEST.QWK');
+            assert.equal(mod.delivered.dir, '/tmp/downloads');
+            done();
+        });
+    });
+
+    //  a format that lists areas in the packet is told about the private one too
+    it('declares the private area to the writer', done => {
+        const mod = makeExport([10]);
+        mod._performExport('/tmp/downloads', () => {
+            assert.deepEqual(mod.declared, [Message.WellKnownAreaTags.Private]);
+            done();
+        });
+    });
+
+    it('tells the caller where the packet went', done => {
+        const mod = makeExport([10]);
+        mod._performExport('/tmp/downloads', () => {
+            assert.match(
+                mod.status[mod.status.length - 1],
+                /A Test packet has been placed in your download queue/
+            );
+            done();
+        });
+    });
+
+    //  a stopped idle monitor that is never restarted leaves a node that
+    //  cannot time out
+    it('restarts the idle monitor whatever happens', done => {
+        const mod = makeExport([10]);
+        mod._performExport('/tmp/downloads', () => {
+            assert.deepEqual(mod.idle, ['stop', 'start']);
+            done();
+        });
+    });
+
+    it('records how far each area was exported, so the next packet carries only what is new', done => {
+        const mod = makeExport([10]);
+        mod._performExport('/tmp/downloads', () => {
+            const areas = JSON.parse(mod.persisted.test_areas);
+            assert.equal(areas.length, 1);
+            assert.equal(areas[0].areaTag, Message.WellKnownAreaTags.Private);
+            assert.ok(
+                new Date(areas[0].newerThanTimestamp).getTime() > 0,
+                'a usable timestamp was written'
+            );
+            done();
+        });
+    });
+
+    //  nothing to export is not an error the caller should see
+    it('says so, and does not deliver a packet, when there is nothing to export', done => {
+        const mod = makeExport([]);
+        mod._performExport('/tmp/downloads', err => {
+            assert.equal(err, null, 'swallowed rather than raised');
+            assert.equal(mod.delivered, null);
+            assert.match(mod.status[mod.status.length - 1], /No messages to export/);
+            done();
+        });
+    });
+
+    //
+    //  A writer that fails to start used to leave the caller on the export
+    //  screen: the error handler recorded the failure and the step went on
+    //  waiting for 'ready'.
+    //
+    it('ends the export when the writer fails to start', done => {
+        const mod = makeExport([10], { startup: 'error' });
+        mod._performExport('/tmp/downloads', err => {
+            assert.ok(err, 'expected an error');
+            assert.equal(err.message, 'no temp directory');
+            assert.equal(mod.delivered, null);
+            assert.deepEqual(mod.idle, ['stop', 'start'], 'and cleans up after itself');
+            done();
+        });
+    });
+
+    //
+    //  The writer's error handler answers the step that started it. Once the
+    //  step has been answered a later failure must not answer it again: the
+    //  waterfall would run its next step twice.
+    //
+    it('answers the start of the export once, even if the writer fails later', done => {
+        const mod = makeExport([10], { startup: 'lateError' });
+        let calls = 0;
+
+        mod._performExport('/tmp/downloads', () => {
+            calls += 1;
+        });
+
+        setTimeout(() => {
+            assert.equal(calls, 1);
+            done();
+        }, 50);
+    });
+
+    it('logs a warning the writer raises', done => {
+        const mod = makeExport([10]);
+        mod.writer.once('ready', () =>
+            mod.writer.emit('warning', new Error('an area was too large'))
+        );
+
+        mod._performExport('/tmp/downloads', () => {
+            assert.equal(mod.warnings.length, 1);
+            assert.equal(mod.warnings[0].warning.message, 'an area was too large');
+            done();
+        });
+    });
+
+    //
+    //  A format missing a hook has to fail before the export touches the
+    //  session: past that point the idle monitor is stopped and a key press
+    //  listener is attached, and neither is undone by a throw.
+    //
+    it('refuses a format that has not supplied its hooks, before it starts', done => {
+        class Incomplete extends MessageBaseOfflineExport {
+            get packetFormatName() {
+                return 'Incomplete';
+            }
+            get userProperties() {
+                return { ExportOptions: 'x', ExportAreas: 'y' };
+            }
+            noResultsMenuName() {
+                return 'x';
+            }
+        }
+
+        const mod = makeExport([10], { Module: Incomplete });
+        mod._performExport('/tmp/downloads', err => {
+            assert.ok(err, 'expected an error');
+            assert.match(err.message, /createPacketWriter/);
+            assert.deepEqual(mod.idle, [], 'the idle monitor was never stopped');
+            assert.equal(mod.delivered, null);
+            done();
+        });
+    });
+});


### PR DESCRIPTION
> Written by Claude (Opus 5), an LLM made by Anthropic, at andy5995's
> direction.

The packet-gathering flow -- areas, progress, cancel, the download queue handoff -- is not QWK's; a second format needs all of it. Moving it to a base class also fixes an export that failed while finishing: the only 'error' handler recorded the failure and the step went on waiting for 'finished', leaving the caller on the export screen until their session timed out.