### PR TITLE
fix(msg): answer the export when a packet stream dies

### DIFF
--- a/core/bluewave_mail_packet.js
+++ b/core/bluewave_mail_packet.js
@@ -13,6 +13,7 @@ const { AddressFlavor, WellKnownAreaTags } = require('./message_const.js');
 const StatLog = require('./stat_log.js');
 const SysProps = require('./system_property.js');
 const ArchiveUtil = require('./archive_util.js');
+const { endWriteStream } = require('./file_util.js');
 
 //  deps
 const fs = require('graceful-fs');
@@ -368,10 +369,7 @@ class BlueWavePacketWriter extends EventEmitter {
     writePacketFiles(cb) {
         async.series(
             [
-                callback => {
-                    this.datStream.on('close', () => callback(null));
-                    this.datStream.end();
-                },
+                callback => endWriteStream(this.datStream, callback),
                 callback => this._writeIndexes(callback),
                 callback => this._writeInf(callback),
             ],

--- a/core/file_util.js
+++ b/core/file_util.js
@@ -4,6 +4,7 @@
 //  ENiGMA½
 const EnigAssert = require('./enigma_assert.js');
 const Logger = require('./logger.js');
+const { Errors } = require('./enig_error.js');
 
 //  deps
 const fs = require('graceful-fs');
@@ -16,6 +17,7 @@ exports.copyFileWithCollisionHandling = copyFileWithCollisionHandling;
 exports.safeCopyFile = safeCopyFile;
 exports.safeMoveFile = safeMoveFile;
 exports.pathWithTerminatingSeparator = pathWithTerminatingSeparator;
+exports.endWriteStream = endWriteStream;
 
 //
 //  fs.copyFile / fs-extra.copy both invoke utimensat() on the destination to
@@ -117,6 +119,34 @@ function _streamCopy(src, dst, cb) {
     ws.on('error', finish);
     ws.on('close', () => finish(null));
     rs.pipe(ws);
+}
+
+//
+//  Finishing a write stream means waiting for 'close', but a stream that has
+//  already failed will never emit it again: the error fired earlier and the
+//  stream destroyed itself, taking 'close' with it. A listener attached after
+//  that waits forever, and whatever was driving the stream is never answered.
+//
+//  Answer exactly once on either event, and refuse a stream that is already
+//  gone rather than waiting on it.
+//
+function endWriteStream(ws, cb) {
+    let done = false;
+    const finish = err => {
+        if (done) {
+            return;
+        }
+        done = true;
+        return cb(err || null);
+    };
+
+    if (ws.destroyed) {
+        return finish(Errors.General('Stream closed before it could be finished'));
+    }
+
+    ws.once('error', finish);
+    ws.once('close', () => finish(null));
+    ws.end();
 }
 
 function moveOrCopyFileWithCollisionHandling(src, dst, operation, cb) {

--- a/core/qwk_mail_packet.js
+++ b/core/qwk_mail_packet.js
@@ -1,4 +1,5 @@
 const ArchiveUtil = require('./archive_util');
+const { endWriteStream } = require('./file_util');
 const { Errors } = require('./enig_error');
 const Message = require('./message');
 const { splitTextAtTerms } = require('./string_util');
@@ -1290,20 +1291,12 @@ class QWKPacketWriter extends EventEmitter {
     finish(packetDirectory) {
         async.series(
             [
-                callback => {
-                    this.messagesStream.on('close', () => {
-                        return callback(null);
-                    });
-                    this.messagesStream.end();
-                },
+                callback => endWriteStream(this.messagesStream, callback),
                 callback => {
                     if (!this.headersDatStream) {
                         return callback(null);
                     }
-                    this.headersDatStream.on('close', () => {
-                        return callback(null);
-                    });
-                    this.headersDatStream.end();
+                    return endWriteStream(this.headersDatStream, callback);
                 },
                 callback => {
                     return this._createControlData(callback);
@@ -1501,14 +1494,6 @@ class QWKPacketWriter extends EventEmitter {
         );
         controlStream.setDefaultEncoding('ascii');
 
-        controlStream.on('close', () => {
-            return cb(null);
-        });
-
-        controlStream.on('error', err => {
-            return cb(err);
-        });
-
         const initialControlData = [
             Config().general.boardName,
             'Earth',
@@ -1546,7 +1531,7 @@ class QWKPacketWriter extends EventEmitter {
             controlStream.write(`${trailer}\r\n`);
         });
 
-        controlStream.end();
+        return endWriteStream(controlStream, cb);
     }
 
     _createIndexes(cb) {
@@ -1574,11 +1559,7 @@ class QWKPacketWriter extends EventEmitter {
                         appendIndexData(indexStream, offset)
                     );
 
-                    indexStream.on('close', err => {
-                        return callback(err);
-                    });
-
-                    indexStream.end();
+                    return endWriteStream(indexStream, callback);
                 },
                 callback => {
                     //  000.NDX of private mails
@@ -1593,11 +1574,7 @@ class QWKPacketWriter extends EventEmitter {
                         appendIndexData(indexStream, offset)
                     );
 
-                    indexStream.on('close', err => {
-                        return callback(err);
-                    });
-
-                    indexStream.end();
+                    return endWriteStream(indexStream, callback);
                 },
                 callback => {
                     //  ####.NDX
@@ -1617,11 +1594,7 @@ class QWKPacketWriter extends EventEmitter {
                                 appendIndexData(indexStream, offset)
                             );
 
-                            indexStream.on('close', err => {
-                                return nextArea(err);
-                            });
-
-                            indexStream.end();
+                            return endWriteStream(indexStream, nextArea);
                         },
                         err => {
                             return callback(err);

--- a/test/packet_stream_end.test.js
+++ b/test/packet_stream_end.test.js
@@ -1,0 +1,119 @@
+'use strict';
+
+const { strict: assert } = require('assert');
+const fs = require('fs');
+const os = require('os');
+const paths = require('path');
+
+const { endWriteStream } = require('../core/file_util.js');
+const StatLog = require('../core/stat_log.js');
+const { BlueWavePacketWriter } = require('../core/bluewave_mail_packet.js');
+
+function tempFile(name) {
+    return paths.join(fs.mkdtempSync(paths.join(os.tmpdir(), 'enigstream-')), name);
+}
+
+describe('ending a packet write stream', () => {
+    it('answers once the stream has closed', done => {
+        const ws = fs.createWriteStream(tempFile('ok.dat'));
+        ws.write('some packet bytes');
+        endWriteStream(ws, err => {
+            assert.equal(err, null);
+            assert.ok(ws.destroyed, 'the stream was ended');
+            done();
+        });
+    });
+
+    //
+    //  The regression. A stream that failed earlier has already emitted its
+    //  'close', so a listener attached now would never hear one -- and the
+    //  export it belongs to would wait on the callback until the carrier
+    //  dropped, with the idle monitor already stopped.
+    //
+    it('refuses a stream that has already gone, rather than waiting on it', done => {
+        const ws = fs.createWriteStream(tempFile('gone.dat'));
+        ws.once('close', () => {
+            assert.ok(ws.destroyed, 'precondition: the stream is already gone');
+            endWriteStream(ws, err => {
+                assert.ok(err, 'expected an error rather than silence');
+                assert.match(err.message, /closed before it could be finished/);
+                done();
+            });
+        });
+        ws.destroy();
+    });
+
+    it('hands back the failure when the stream dies while ending', done => {
+        const ws = fs.createWriteStream(tempFile('dies.dat'));
+        endWriteStream(ws, err => {
+            assert.ok(err, 'expected an error');
+            assert.equal(err.message, 'the disk went away');
+            done();
+        });
+        ws.destroy(new Error('the disk went away'));
+    });
+
+    it('answers only once, however many events arrive', done => {
+        const ws = fs.createWriteStream(tempFile('once.dat'));
+        let calls = 0;
+
+        endWriteStream(ws, () => {
+            calls += 1;
+        });
+
+        setTimeout(() => {
+            ws.emit('error', new Error('and then it failed too'));
+            ws.emit('close');
+            assert.equal(calls, 1);
+            done();
+        }, 20);
+    });
+});
+
+//
+//  The same failure seen from the caller's side: a writer whose packet stream
+//  died must end the export, not leave it waiting on a 'finished' that the
+//  series can no longer reach.
+//
+describe('an offline packet writer whose stream died', () => {
+    const realInit = StatLog.init;
+    const realGetSystemStat = StatLog.getSystemStat;
+
+    beforeEach(() => {
+        StatLog.init = cb => cb(null);
+        StatLog.getSystemStat = () => 'SysOp Name';
+    });
+
+    afterEach(() => {
+        StatLog.init = realInit;
+        StatLog.getSystemStat = realGetSystemStat;
+    });
+
+    it('emits error instead of hanging', done => {
+        const writer = new BlueWavePacketWriter({
+            bbsID: 'ENIGMA',
+            user: null,
+            systemName: 'Test Board',
+            sysOpName: 'SysOp Name',
+        });
+
+        writer.once('ready', () => {
+            //  the .DAT stream dies mid-export, before finish() is reached
+            writer.datStream.once('close', () => {
+                writer.once('finished', () =>
+                    done(new Error('reported success over a dead stream'))
+                );
+                writer.once('error', err => {
+                    assert.match(err.message, /closed before it could be finished/);
+                    writer.temptmp.cleanup();
+                    done();
+                });
+
+                writer.finish(writer.workDir);
+            });
+            writer.datStream.destroy();
+        });
+
+        writer.init();
+    });
+});


### PR DESCRIPTION
Fixes #809.

Both offline mail packet writers ended a stream by waiting only on `'close'`, and five of the seven sites had no `'error'` listener at all. A write failure — a full disk, a quota, a temp directory that went away — left the step unanswered: the stream had already emitted its `'close'` and destroyed itself, so the listener attached afterwards never heard one.

The caller is then wedged the way #799 fixed for the writer's own `'error'` event. `_finishPacket()` never calls back, `startIdleMonitor()` never runs, and since `stopIdleMonitor()` cleared the interval there is no idle timeout left to rescue the node — it stays until the carrier drops. `bbs.js` keeps the process alive through the unhandled error, so this costs a session rather than the board.

### What changed

`endWriteStream()` in `core/file_util.js` answers exactly once on either event and refuses a stream that is already gone. It now ends all seven:

| file | stream | before |
|---|---|---|
| `bluewave_mail_packet.js` | `.DAT` | `'close'` only; error listener set in `init()` |
| `qwk_mail_packet.js` | messages | `'close'` only, no error listener |
| | headers | same |
| | control | `'close'` **and** `'error'`, both calling `cb` |
| | index ×3 | `on('close', err => callback(err))`, no error listener |

Two latent bugs go with it. The control stream's pair of handlers could both fire, which `async` reports as *Callback was already called*. The three index streams read `err` off `'close'`, which emits no arguments, so they reported success whatever happened.

Net on the QWK writer is -41/+9.

### Verifying it

I stashed the fix and ran the new tests against the unfixed code. The integration case — *emits error instead of hanging* — times out at 2500ms, which is the bug reproducing. The four helper tests fail trivially there, so that timeout is the one doing the work.

Full suite 2483 passing; prettier and eslint clean.

### Notes

Pre-existing in the QWK writer; found while reviewing #798, which mirrored the pattern for its own `.DAT` stream. Not a regression from that PR, which is why it wasn't held for it. Only reachable on a packet write failure.

`endWriteStream` sits in `file_util.js` beside `_streamCopy`, which already uses the same done-guard shape. Happy to move it to a module of its own if you'd rather it not widen that file's role.
