### PR TITLE
ci(docker): build the image on pull requests, without publishing

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,13 +4,25 @@ on:
   push:
     branches: [ master ]
 
+  pull_request:
+    #  The inputs that decide whether the image builds. Application source is
+    #  copied in after npm ci and cannot fail it, so it is left out rather
+    #  than spending eleven minutes under QEMU on every pull request.
+    paths:
+      - 'docker/**'
+      - '.dockerignore'
+      - 'package.json'
+      - 'package-lock.json'
+      - '.github/workflows/docker.yml'
+
   workflow_dispatch:
 
 concurrency:
-  #  One mutable tag, so runs collapse rather than racing: a build that has
-  #  been superseded can only publish a :latest older than the one that
-  #  superseded it.
-  group: ${{ github.workflow }}
+  #  Master collapses onto one group: there is a single mutable tag, so a run
+  #  that has been superseded can only publish a :latest older than the one
+  #  that superseded it. Pull requests get a lane each, so they cancel neither
+  #  a publish nor one another.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -28,6 +40,9 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Login to DockerHub
+        #  A pull request from a fork is given no secrets, so this would fail
+        #  -- and it has nothing to log in for, since it does not publish.
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v2
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -42,5 +57,10 @@ jobs:
           #  is already ARMv8 -- and asking for it now fails the build rather
           #  than silently resolving to amd64 as it used to.
           platforms: linux/amd64,linux/arm64,linux/arm/v7
-          push: true
+          #  A pull request builds every platform and publishes nothing. The
+          #  arm legs are where an image change usually breaks -- a lockfile
+          #  that resolves differently under QEMU, a native module that will
+          #  not compile -- so building only amd64 would check the half that
+          #  rarely fails.
+          push: ${{ github.event_name != 'pull_request' }}
 


### PR DESCRIPTION
Fixes #811.

The Docker workflow only ran on a push to master, so nothing about the image was checked before it merged — the green ticks on a Docker pull request come from `lint`, `test` and CodeQL, none of which read `docker/`, `.dockerignore` or the workflow itself. A mistake first ran in the job that publishes `:latest`. #800 and #801 were both live examples.

### What changed

Pull requests now build the same three platforms and publish nothing, behind a `paths` filter.

**All three platforms, not just amd64.** Building one architecture would be quicker, but the arm legs are where an image change usually breaks — a lockfile that resolves differently under QEMU, a native module that will not compile. #801 was exactly that shape: `npm ci` installing strictly from a lockfile, where the risk lived entirely in the arm optional dependencies. An amd64-only check would have validated the half that was never in danger. The `paths` filter is the cost control instead, keeping the job off pull requests that cannot affect the image.

**Fork pull requests are given no secrets**, so the DockerHub login is skipped there rather than left to fail.

**The concurrency group was workflow-wide.** That is deliberate for master — one mutable tag, so a superseded run can only publish a `:latest` older than the one that superseded it — but with pull requests in the mix it would have let a PR build cancel a publish. Keying on the pull request number and falling back to `github.ref` keeps every master push in one collapsing group while giving each pull request a lane of its own.

### It tests itself

`pull_request` workflows run from the merge commit, and `.github/workflows/docker.yml` is in its own paths filter — so the Docker job on this PR *is* the new configuration running against itself. If it goes green here, the change works.

### Notes

The filter is not quite exhaustive: `art/`, `mods/` and `config/` are copied in by the Dockerfile and an emptied one would fail its `cp -rp`. That seemed too remote to be worth eleven minutes of QEMU on every art change, but it is a deliberate gap rather than an oversight.

This collides with #800, which appends to the same `with:` block and whose comment assumes nothing runs on a pull request. Noted over there — happy to reorder if that one would rather land first.

The stale `build-push-action@v3` / `login-action@v2` pinning is left alone on purpose; raised on #800 and better as its own change.
