### PR TITLE
feat(ftn): relay imported EchoMail to secondary uplinks (#748)

### DIFF
--- a/core/ftn_mail_packet.js
+++ b/core/ftn_mail_packet.js
@@ -771,6 +771,24 @@ function Packet(options) {
             ftn_msg_dest_net: msgData.ftn_msg_dest_net,
         };
 
+        //
+        //  Record the origin point when the packet is a type that actually has
+        //  one. Without this, mail from our own point reads as coming from our
+        //  own address, and anything reasoning about where a message came from
+        //  -- EchoMail relay, for one -- cannot tell the two apart.
+        //
+        //  Gated on version rather than written unconditionally: origPoint is
+        //  a fill field in a plain type-2 packet, so a stray non-zero value
+        //  there would make a message look like it came from a point that does
+        //  not exist, and the origin would stop being recognised at all.
+        //
+        if (
+            ('2+' === header.version || '2.2' === header.version) &&
+            header.origPoint > 0
+        ) {
+            msg.meta.FtnProperty.ftn_orig_point = header.origPoint;
+        }
+
         self.processMessageBody(msgData.message, messageBodyData => {
             msg.message = messageBodyData.message;
             msg.meta.FtnKludge = messageBodyData.kludgeLines;

--- a/core/message.js
+++ b/core/message.js
@@ -766,6 +766,59 @@ module.exports = class Message {
         }
     }
 
+    //
+    //  OR |bit| into this message's state_flags0, as one row.
+    //
+    //  updateMetaValue() cannot do this. message_meta's UNIQUE key includes
+    //  meta_value (see database.js), so REPLACE INTO with a value that differs
+    //  from what is stored has nothing to collide with and inserts a *second*
+    //  row -- leaving a bitmask field holding '1' and '2' rather than '3', and
+    //  reloading as an array rather than a value.
+    //
+    //  That was unreachable while nothing ever exported a message it had
+    //  imported. EchoMail relay does exactly that.
+    //
+    setStateFlags0Bit(bit, cb) {
+        const name = MessageConst.SystemMetaNames.StateFlags0;
+        try {
+            msgDb.transaction(() => {
+                const rows = msgDb
+                    .prepare(
+                        `SELECT meta_value FROM message_meta
+                        WHERE message_id = ? AND meta_category = 'System'
+                          AND meta_name = ?;`
+                    )
+                    .all(this.messageId, name);
+
+                const flags = rows.reduce(
+                    (acc, row) => acc | (parseInt(row.meta_value, 10) || 0),
+                    bit
+                );
+
+                msgDb
+                    .prepare(
+                        `DELETE FROM message_meta
+                    WHERE message_id = ? AND meta_category = 'System'
+                      AND meta_name = ?;`
+                    )
+                    .run(this.messageId, name);
+
+                msgDb
+                    .prepare(
+                        `INSERT INTO message_meta (message_id, meta_category, meta_name, meta_value)
+                    VALUES (?, 'System', ?, ?);`
+                    )
+                    .run(this.messageId, name, flags.toString());
+
+                this.meta.System = this.meta.System || {};
+                this.meta.System[name] = flags.toString();
+            })();
+            return cb(null);
+        } catch (err) {
+            return cb(err);
+        }
+    }
+
     updateMetaValue(category, name, value, cb) {
         try {
             if (!Array.isArray(value)) {

--- a/core/scanner_tossers/ftn_bso.js
+++ b/core/scanner_tossers/ftn_bso.js
@@ -822,7 +822,7 @@ function FTNMessageScanTossModule() {
     //  Mail imported from here on is relayed; anything already in the base is
     //  treated as history.
     //
-    this.seedRelayScanId = function (areaTag, cb) {
+    this.seedRelayScanId = function (areaTag, scanToss, cb) {
         let maxId = 0;
         try {
             const row = msgDb
@@ -836,12 +836,10 @@ function FTNMessageScanTossModule() {
         }
 
         Log.info(
-            { areaTag, lastScanId: maxId },
-            'EchoMail relay: first scan of this area; starting from current mail'
+            { areaTag, scanToss, lastScanId: maxId },
+            'EchoMail relay: first scan of this area for this uplink; starting from current mail'
         );
-        return this.setAreaLastScanId(areaTag, ScanToss.Relay, maxId, err =>
-            cb(err, maxId)
-        );
+        return this.setAreaLastScanId(areaTag, scanToss, maxId, err => cb(err, maxId));
     };
 
     //
@@ -1049,10 +1047,13 @@ function FTNMessageScanTossModule() {
                             );
                         },
                         function storeStateFlags0Meta(callback) {
-                            message.updateMetaValue(
-                                'System',
-                                'state_flags0',
-                                Message.StateFlags0.Exported.toString(),
+                            //  OR the bit in rather than writing the value:
+                            //  a relayed message already carries Imported, and
+                            //  message_meta's UNIQUE key includes meta_value,
+                            //  so a plain write leaves two rows instead of a
+                            //  combined one.
+                            message.setStateFlags0Bit(
+                                Message.StateFlags0.Exported,
                                 err => {
                                     callback(err);
                                 }
@@ -1414,10 +1415,11 @@ function FTNMessageScanTossModule() {
                             );
                         },
                         function storeStateFlags0Meta(callback) {
-                            return message.updateMetaValue(
-                                'System',
-                                'state_flags0',
-                                Message.StateFlags0.Exported.toString(),
+                            //  See the EchoMail export path: OR the bit in so a
+                            //  message that already carries another flag ends up
+                            //  with one combined value rather than two rows.
+                            return message.setStateFlags0Bit(
+                                Message.StateFlags0.Exported,
                                 callback
                             );
                         },
@@ -1679,7 +1681,15 @@ function FTNMessageScanTossModule() {
 
                                     fse.move(oldPath, newPath, err => {
                                         if (err) {
-                                            Log.warn(
+                                            //  The packet is still in the temp
+                                            //  area, so this export did not
+                                            //  happen. Report it: the caller
+                                            //  advances the area's last scan ID
+                                            //  on a clean return, and doing that
+                                            //  here is how a disk-full or
+                                            //  permission error turns into mail
+                                            //  nobody ever sees again. See #818.
+                                            Log.error(
                                                 {
                                                     oldPath: oldPath,
                                                     newPath: newPath,
@@ -1688,7 +1698,7 @@ function FTNMessageScanTossModule() {
                                                 'Failed moving temporary outbound file!'
                                             );
 
-                                            return nextFile();
+                                            return nextFile(err);
                                         }
 
                                         const flowFilePath = self.getOutgoingFlowFileName(
@@ -1707,10 +1717,39 @@ function FTNMessageScanTossModule() {
                                             exportOpts.destAddress,
                                             err => {
                                                 if (err) {
-                                                    Log.warn(
-                                                        { path: flowFilePath },
+                                                    //  Also fatal to this
+                                                    //  export, and less obvious
+                                                    //  than the move: the packet
+                                                    //  sits in outbound with no
+                                                    //  flow file referencing it,
+                                                    //  so the mailer never offers
+                                                    //  it and nothing cleans it
+                                                    //  up.
+                                                    //
+                                                    //  This includes a busy flow
+                                                    //  file, which is an ordinary
+                                                    //  outcome under concurrent
+                                                    //  sessions -- and swallowing
+                                                    //  it meant a node that was
+                                                    //  merely busy lost the mail
+                                                    //  permanently, because the
+                                                    //  scan ID moved on anyway.
+                                                    //
+                                                    //  Retrying re-packetises
+                                                    //  under a fresh name rather
+                                                    //  than re-referencing this
+                                                    //  one, so the cost of the
+                                                    //  failed attempt is an
+                                                    //  orphaned packet, not a
+                                                    //  duplicate send.
+                                                    Log.error(
+                                                        {
+                                                            path: flowFilePath,
+                                                            error: err.toString(),
+                                                        },
                                                         'Failed appending flow reference record!'
                                                     );
+                                                    return nextFile(err);
                                                 }
                                                 nextFile();
                                             }
@@ -4135,6 +4174,12 @@ function FTNMessageScanTossModule() {
         //  imported. Messages this system composed locally are the export
         //  scan's business, not ours.
         //
+        //  Test the *bit*, not the value. Once a message has been through an
+        //  export its flags read 3 (Imported|Exported), not 1, and an equality
+        //  test stops matching it -- which matters on the retry after a failed
+        //  pass, where the flag was written before the failure and the message
+        //  still has to come round again.
+        //
         const getCandidatesSql = `SELECT message_id, message_uuid
             FROM message m
             WHERE area_tag = ? AND message_id > ?
@@ -4143,11 +4188,11 @@ function FTNMessageScanTossModule() {
                 WHERE message_id = m.message_id
                   AND meta_category = 'System'
                   AND meta_name = 'state_flags0'
-                  AND meta_value = ?
+                  AND (CAST(meta_value AS INTEGER) & ?) = ?
               )
             ORDER BY message_id;`;
 
-        const importedFlag = Message.StateFlags0.Imported.toString();
+        const importedFlag = Message.StateFlags0.Imported;
 
         //
         //  Grouped by (network, uplink) rather than per area or per message.
@@ -4161,9 +4206,6 @@ function FTNMessageScanTossModule() {
         //  what supplies our local address.
         //
         const groups = new Map();
-        //  areaTag -> { maxId, failed } so a group that fails holds back the
-        //  watermark of every area that contributed to it.
-        const areaState = new Map();
 
         async.eachSeries(
             areaTags,
@@ -4183,28 +4225,57 @@ function FTNMessageScanTossModule() {
                 }
                 const localAddress = new Address(networkConfig.localAddress);
 
-                try {
-                    if (self.isAreaScanUnset(areaTag, ScanToss.Relay)) {
-                        return self.seedRelayScanId(areaTag, err => nextArea(err));
-                    }
-                } catch (err) {
-                    return nextArea(err);
-                }
-
-                return self.getAreaLastScanId(
-                    areaTag,
-                    ScanToss.Relay,
-                    (err, lastScanId) => {
+                //
+                //  Watermark per destination. An uplink seen for the first time
+                //  is seeded to where the area is now and considered no further
+                //  this pass, exactly as a new area is -- which is also what
+                //  makes adding an uplink to a live area safe.
+                //
+                const marks = new Map();
+                return async.eachSeries(
+                    areaConfig.uplinks,
+                    (uplink, nextUplink) => {
+                        const scanToss = relayScanToss(uplink);
+                        try {
+                            if (self.isAreaScanUnset(areaTag, scanToss)) {
+                                return self.seedRelayScanId(areaTag, scanToss, err =>
+                                    nextUplink(err)
+                                );
+                            }
+                        } catch (err) {
+                            return nextUplink(err);
+                        }
+                        return self.getAreaLastScanId(
+                            areaTag,
+                            scanToss,
+                            (err, lastScanId) => {
+                                if (err) {
+                                    return nextUplink(err);
+                                }
+                                marks.set(uplink, lastScanId);
+                                return nextUplink(null);
+                            }
+                        );
+                    },
+                    err => {
                         if (err) {
                             return nextArea(err);
                         }
+                        if (0 === marks.size) {
+                            return nextArea(); //  every uplink was just seeded
+                        }
+
+                        //  One query for the area, from the furthest-behind
+                        //  destination; each uplink then takes the slice above
+                        //  its own watermark.
+                        const lowWater = Math.min(...marks.values());
 
                         let rows;
                         let metaByMessageId;
                         try {
                             rows = msgDb
                                 .prepare(getCandidatesSql)
-                                .all(areaTag, lastScanId, importedFlag);
+                                .all(areaTag, lowWater, importedFlag, importedFlag);
                             if (0 === rows.length) {
                                 return nextArea();
                             }
@@ -4215,11 +4286,6 @@ function FTNMessageScanTossModule() {
                             return nextArea(err);
                         }
 
-                        areaState.set(areaTag, {
-                            maxId: rows[rows.length - 1].message_id,
-                            failed: false,
-                        });
-
                         rows.forEach(row => {
                             const meta = metaByMessageId.get(row.message_id) || {};
                             const targets = self.relayTargetsForMessage(
@@ -4229,7 +4295,11 @@ function FTNMessageScanTossModule() {
                                 localAddress
                             );
 
-                            targets.forEach(uplink => {
+                            marks.forEach((watermark, uplink) => {
+                                if (row.message_id <= watermark) {
+                                    return; //  this destination has passed it
+                                }
+
                                 const key = `${areaConfig.network} ${uplink}`;
                                 let group = groups.get(key);
                                 if (!group) {
@@ -4237,12 +4307,27 @@ function FTNMessageScanTossModule() {
                                         network: areaConfig.network,
                                         uplink,
                                         uuids: [],
-                                        areaTags: new Set(),
+                                        //  areaTag -> { maxId, contributed }
+                                        areas: new Map(),
                                     };
                                     groups.set(key, group);
                                 }
-                                group.uuids.push(row.message_uuid);
-                                group.areaTags.add(areaTag);
+
+                                let areaMark = group.areas.get(areaTag);
+                                if (!areaMark) {
+                                    areaMark = { maxId: 0, contributed: false };
+                                    group.areas.set(areaTag, areaMark);
+                                }
+                                //  Considered, so the watermark moves past it
+                                //  whether or not it is sent -- otherwise a
+                                //  message every uplink has already seen is
+                                //  re-judged on every pass, forever.
+                                areaMark.maxId = Math.max(areaMark.maxId, row.message_id);
+
+                                if (targets.includes(uplink)) {
+                                    group.uuids.push(row.message_uuid);
+                                    areaMark.contributed = true;
+                                }
                             });
                         });
 
@@ -4258,13 +4343,22 @@ function FTNMessageScanTossModule() {
                 async.eachSeries(
                     Array.from(groups.values()),
                     (group, nextGroup) => {
+                        const areaTagList = Array.from(group.areas.keys());
+
+                        //  Nothing qualified for this destination, so there is
+                        //  nothing to send and nothing that can fail. Record
+                        //  the progress and move on.
+                        if (0 === group.uuids.length) {
+                            return self.advanceRelayScanIds(group, true, nextGroup);
+                        }
+
                         //  A stand-in area config: exportEchoMailMessagesToUplinks
                         //  uses it for the network (which supplies our local
                         //  address) and for log context. Each message still
                         //  carries its own area_tag through to the AREA kludge.
                         const groupAreaConfig = {
                             network: group.network,
-                            tag: `(relay: ${Array.from(group.areaTags).join(', ')})`,
+                            tag: `(relay: ${areaTagList.join(', ')})`,
                             uplinks: [group.uplink],
                         };
 
@@ -4274,12 +4368,6 @@ function FTNMessageScanTossModule() {
                             [group.uplink],
                             err => {
                                 if (err) {
-                                    group.areaTags.forEach(areaTag => {
-                                        const state = areaState.get(areaTag);
-                                        if (state) {
-                                            state.failed = true;
-                                        }
-                                    });
                                     Log.warn(
                                         {
                                             uplink: group.uplink,
@@ -4294,21 +4382,23 @@ function FTNMessageScanTossModule() {
                                             uplink: group.uplink,
                                             network: group.network,
                                             messagesRelayed: group.uuids.length,
-                                            areas: Array.from(group.areaTags),
+                                            areas: areaTagList,
                                         },
                                         'EchoMail relay complete'
                                     );
                                 }
-                                return nextGroup(null); //  others still get theirs
+                                //  On failure only the areas that actually had
+                                //  mail in this batch are held back. An area
+                                //  that contributed nothing to it learned
+                                //  nothing from the failure and would otherwise
+                                //  re-judge the same messages every pass.
+                                return self.advanceRelayScanIds(group, !err, () =>
+                                    nextGroup(null)
+                                );
                             }
                         );
                     },
-                    () => {
-                        //  Areas whose candidates were all filtered away have no
-                        //  group at all, and still advance: the decision has
-                        //  been made for those messages.
-                        return self.advanceRelayScanIds(areaState, cb);
-                    }
+                    cb
                 );
             }
         );
@@ -4377,18 +4467,23 @@ function FTNMessageScanTossModule() {
     };
 
     //
-    //  Move each area's relay watermark up, skipping any area whose mail did
-    //  not all get out.
+    //  Move this destination's watermark up for each area that fed it.
     //
-    this.advanceRelayScanIds = function (areaState, cb) {
+    //  |delivered| says whether the batch got out. When it did not, only the
+    //  areas that contributed to the batch are held back -- an area that had
+    //  nothing for this uplink learned nothing from the failure, and holding it
+    //  back would have it re-judge the same messages on every pass.
+    //
+    this.advanceRelayScanIds = function (group, delivered, cb) {
+        const scanToss = relayScanToss(group.uplink);
         async.eachSeries(
-            Array.from(areaState.entries()),
+            Array.from(group.areas.entries()),
             (entry, nextArea) => {
-                const [areaTag, state] = entry;
-                if (state.failed) {
+                const [areaTag, mark] = entry;
+                if (!delivered && mark.contributed) {
                     return nextArea();
                 }
-                self.setAreaLastScanId(areaTag, ScanToss.Relay, state.maxId, nextArea);
+                self.setAreaLastScanId(areaTag, scanToss, mark.maxId, nextArea);
             },
             cb
         );
@@ -5423,6 +5518,19 @@ const ScanToss = {
     Export: 'ftn_bso',
     Relay: 'ftn_bso_relay',
 };
+
+//
+//  The relay watermark is per (area, destination), not per area.
+//
+//  A single watermark for the whole area means one unreachable uplink holds it
+//  back for all of them: every pass then re-selects a set that only grows, and
+//  re-sends all of it to the uplinks that are working. A dead point would
+//  quietly turn into an ever-larger duplicate feed for everyone else. Each
+//  destination tracks its own progress instead.
+//
+function relayScanToss(uplink) {
+    return `${ScanToss.Relay}:${uplink}`;
+}
 
 const EXPORT_WATCHDOG_MS = 10 * 60 * 1000;
 

--- a/core/scanner_tossers/ftn_bso.js
+++ b/core/scanner_tossers/ftn_bso.js
@@ -761,30 +761,87 @@ function FTNMessageScanTossModule() {
         }
     };
 
-    this.getAreaLastScanId = function (areaTag, cb) {
+    //
+    //  Watermarks are keyed by (scan_toss, area_tag). The export scan uses
+    //  ScanToss.Export; the relay scan (performEchoMailRelayExport) keeps its
+    //  own under ScanToss.Relay so the two never move each other.
+    //
+    this.getAreaLastScanId = function (areaTag, scanToss, cb) {
         const sql = `SELECT message_id
             FROM message_area_last_scan
-            WHERE scan_toss = 'ftn_bso' AND area_tag = ?
+            WHERE scan_toss = ? AND area_tag = ?
             LIMIT 1;`;
 
         try {
-            const row = msgDb.prepare(sql).get(areaTag);
+            const row = msgDb.prepare(sql).get(scanToss, areaTag);
             return cb(null, row ? row.message_id : 0);
         } catch (err) {
             return cb(err);
         }
     };
 
-    this.setAreaLastScanId = function (areaTag, lastScanId, cb) {
+    this.setAreaLastScanId = function (areaTag, scanToss, lastScanId, cb) {
         const sql = `REPLACE INTO message_area_last_scan (scan_toss, area_tag, message_id)
-            VALUES ('ftn_bso', ?, ?);`;
+            VALUES (?, ?, ?);`;
 
         try {
-            msgDb.prepare(sql).run(areaTag, lastScanId);
+            msgDb.prepare(sql).run(scanToss, areaTag, lastScanId);
             return cb(null);
         } catch (err) {
             return cb(err);
         }
+    };
+
+    //
+    //  True when |areaTag| has never been scanned under |scanToss|.
+    //
+    //  getAreaLastScanId() cannot answer this: it reports 0 both for "never
+    //  scanned" and for "scanned, nothing seen yet", and the relay scan has to
+    //  tell them apart. A relay watermark that starts at 0 selects every
+    //  message ever imported into the area -- see seedRelayScanId().
+    //
+    this.isAreaScanUnset = function (areaTag, scanToss) {
+        const sql = `SELECT 1 AS present
+            FROM message_area_last_scan
+            WHERE scan_toss = ? AND area_tag = ?
+            LIMIT 1;`;
+        return !msgDb.prepare(sql).get(scanToss, areaTag);
+    };
+
+    //
+    //  Start relaying from *now* rather than from the beginning of time.
+    //
+    //  The relay scan selects imported messages above its watermark. On an
+    //  established board the entire message base is imported messages, so a
+    //  watermark starting at 0 would offer years of history to a link that has
+    //  never asked for it -- and, since a destination has only 36 bundle names
+    //  per day (getOutgoingBundleFileName), would likely stall part way through
+    //  and retry the same pile every scan.
+    //
+    //  So on first sight of an area, record where it is and export nothing.
+    //  Mail imported from here on is relayed; anything already in the base is
+    //  treated as history.
+    //
+    this.seedRelayScanId = function (areaTag, cb) {
+        let maxId = 0;
+        try {
+            const row = msgDb
+                .prepare(
+                    `SELECT MAX(message_id) AS max_id FROM message WHERE area_tag = ?;`
+                )
+                .get(areaTag);
+            maxId = (row && row.max_id) || 0;
+        } catch (err) {
+            return cb(err);
+        }
+
+        Log.info(
+            { areaTag, lastScanId: maxId },
+            'EchoMail relay: first scan of this area; starting from current mail'
+        );
+        return this.setAreaLastScanId(areaTag, ScanToss.Relay, maxId, err =>
+            cb(err, maxId)
+        );
     };
 
     //
@@ -1473,7 +1530,20 @@ function FTNMessageScanTossModule() {
         );
     };
 
-    this.exportEchoMailMessagesToUplinks = function (messageUuids, areaConfig, cb) {
+    //
+    //  |uplinks| is passed rather than read from |areaConfig| because the relay
+    //  scan sends a given message to a *subset* of the area's uplinks -- the
+    //  ones that have not already seen it. Note that the SEEN-BY line still
+    //  names every configured uplink: prepareMessage() builds it from config,
+    //  not from this list, which is correct FTN practice (you declare the whole
+    //  distribution) and helps a downlink we skipped avoid sending it back.
+    //
+    this.exportEchoMailMessagesToUplinks = function (
+        messageUuids,
+        areaConfig,
+        uplinks,
+        cb
+    ) {
         //  One uplink failing must not abandon the rest, but it must not pass
         //  for success either: the caller advances the area's last scan ID on
         //  a clean return, and doing that after a failed uplink is what turns
@@ -1488,7 +1558,7 @@ function FTNMessageScanTossModule() {
         //  uplinks landing in one millisecond therefore choose the same file
         //  name, and one silently overwrites or loses the other's mail.
         async.eachSeries(
-            areaConfig.uplinks,
+            uplinks,
             (uplink, nextUplink) => {
                 const nodeConfig = self.getNodeConfigByAddress(uplink);
                 if (!nodeConfig) {
@@ -3889,7 +3959,7 @@ function FTNMessageScanTossModule() {
                 async.waterfall(
                     [
                         function getLastScanId(callback) {
-                            self.getAreaLastScanId(areaTag, callback);
+                            self.getAreaLastScanId(areaTag, ScanToss.Export, callback);
                         },
                         function getNewUuids(lastScanId, callback) {
                             let rows;
@@ -3912,6 +3982,7 @@ function FTNMessageScanTossModule() {
                             self.exportEchoMailMessagesToUplinks(
                                 uuidsOnly,
                                 areaConfig,
+                                areaConfig.uplinks,
                                 err => {
                                     const newLastScanId =
                                         msgRows[msgRows.length - 1].message_id;
@@ -3946,7 +4017,12 @@ function FTNMessageScanTossModule() {
                             );
                         },
                         function updateLastScanId(newLastScanId, callback) {
-                            self.setAreaLastScanId(areaTag, newLastScanId, callback);
+                            self.setAreaLastScanId(
+                                areaTag,
+                                ScanToss.Export,
+                                newLastScanId,
+                                callback
+                            );
                         },
                     ],
                     () => {
@@ -3957,6 +4033,364 @@ function FTNMessageScanTossModule() {
             err => {
                 return cb(err);
             }
+        );
+    };
+
+    //
+    //  Does |addr| name the same system as |other|? Point defaults to 0 on both
+    //  sides, and a missing zone is treated as "unknown, do not let it decide",
+    //  because a type-2 packet header carries no zone at all.
+    //
+    this.isSameFtnSystem = function (addr, other) {
+        if (!addr || !other) {
+            return false;
+        }
+        if (addr.net !== other.net || addr.node !== other.node) {
+            return false;
+        }
+        if ((addr.point || 0) !== (other.point || 0)) {
+            return false;
+        }
+        if (_.isNumber(addr.zone) && _.isNumber(other.zone)) {
+            return addr.zone === other.zone;
+        }
+        return true;
+    };
+
+    //
+    //  Which of |uplinks| should be offered a message we imported?
+    //
+    //  Three rules, in order:
+    //
+    //  1. Never back to the system that handed it to us. The packet header
+    //     origin is recorded at import (ftn_orig_*) and export does not
+    //     overwrite it in the database, so this is exact and does not depend on
+    //     SEEN-BY being well formed.
+    //
+    //  2. Always to our own points. SEEN-BY has no point component (FTS-1027):
+    //     a point's net/node are its boss's, and an upstream sender routinely
+    //     adds the boss to SEEN-BY before the message ever arrives. A plain
+    //     SEEN-BY test therefore reads "I have seen this", which is true by
+    //     definition once imported, so a point would never be relayed to.
+    //
+    //  3. Otherwise, only to uplinks not already in SEEN-BY -- the ordinary
+    //     loop guard for a genuine peer relationship.
+    //
+    this.relayTargetsForMessage = function (
+        uplinks,
+        seenByAddrs,
+        originAddress,
+        localAddress
+    ) {
+        return uplinks.filter(uplink => {
+            const addr = _.isString(uplink) ? Address.fromString(uplink) : uplink;
+            if (!addr || !addr.isValid()) {
+                Log.warn({ uplink }, 'EchoMail relay: unparsable uplink address');
+                return false;
+            }
+
+            if (self.isSameFtnSystem(addr, originAddress)) {
+                return false;
+            }
+
+            const isOurPoint =
+                (addr.point || 0) > 0 &&
+                localAddress &&
+                addr.net === localAddress.net &&
+                addr.node === localAddress.node &&
+                (!_.isNumber(addr.zone) ||
+                    !_.isNumber(localAddress.zone) ||
+                    addr.zone === localAddress.zone);
+            if (isOurPoint) {
+                return true;
+            }
+
+            return !seenByAddrs.some(
+                seen => seen.net === addr.net && seen.node === addr.node
+            );
+        });
+    };
+
+    //
+    //  EchoMail we imported, offered on to the area's other uplinks.
+    //
+    //  performEchoMailExport() cannot do this: it excludes any message carrying
+    //  a System/state_flags0 row, and import always writes one. So a second
+    //  uplink on an area -- a downstream point, or a sub-hub -- has until now
+    //  only ever received messages composed by a user at a terminal on this
+    //  system, never the echomail that flowed in from the area's own source.
+    //
+    //  Opt-in per area via `relay: true`, because relaying is outwardly visible
+    //  on the network: a board that configured a second uplink for some other
+    //  reason should not silently start feeding it.
+    //
+    this.performEchoMailRelayExport = function (cb) {
+        const config = Config();
+        const areaTags = Object.keys(
+            _.get(config, 'messageNetworks.ftn.areas', {})
+        ).filter(areaTag => Message.WellKnownAreaTags.Private !== areaTag);
+
+        //
+        //  Candidates are messages above the relay watermark that were
+        //  imported. Messages this system composed locally are the export
+        //  scan's business, not ours.
+        //
+        const getCandidatesSql = `SELECT message_id, message_uuid
+            FROM message m
+            WHERE area_tag = ? AND message_id > ?
+              AND EXISTS (
+                SELECT 1 FROM message_meta
+                WHERE message_id = m.message_id
+                  AND meta_category = 'System'
+                  AND meta_name = 'state_flags0'
+                  AND meta_value = ?
+              )
+            ORDER BY message_id;`;
+
+        const importedFlag = Message.StateFlags0.Imported.toString();
+
+        //
+        //  Grouped by (network, uplink) rather than per area or per message.
+        //  A destination has only 36 bundle names per day
+        //  (getOutgoingBundleFileName), and once they are gone exports to that
+        //  node fail until the day rolls over. One call per destination per run
+        //  keeps a hub with many areas well clear of that. Batching across
+        //  areas is safe because exportMessagesByUuid loads each message
+        //  individually and prepareMessage takes the AREA kludge from the
+        //  message's own area_tag; only the network has to match, since that is
+        //  what supplies our local address.
+        //
+        const groups = new Map();
+        //  areaTag -> { maxId, failed } so a group that fails holds back the
+        //  watermark of every area that contributed to it.
+        const areaState = new Map();
+
+        async.eachSeries(
+            areaTags,
+            (areaTag, nextArea) => {
+                const areaConfig = config.messageNetworks.ftn.areas[areaTag];
+                if (!self.isAreaConfigValid(areaConfig) || true !== areaConfig.relay) {
+                    return nextArea();
+                }
+
+                const networkConfig = self.getNetworkConfig(areaConfig.network);
+                if (!networkConfig || !networkConfig.localAddress) {
+                    Log.warn(
+                        { areaTag, network: areaConfig.network },
+                        'EchoMail relay: no local address for network; skipping area'
+                    );
+                    return nextArea();
+                }
+                const localAddress = new Address(networkConfig.localAddress);
+
+                try {
+                    if (self.isAreaScanUnset(areaTag, ScanToss.Relay)) {
+                        return self.seedRelayScanId(areaTag, err => nextArea(err));
+                    }
+                } catch (err) {
+                    return nextArea(err);
+                }
+
+                return self.getAreaLastScanId(
+                    areaTag,
+                    ScanToss.Relay,
+                    (err, lastScanId) => {
+                        if (err) {
+                            return nextArea(err);
+                        }
+
+                        let rows;
+                        let metaByMessageId;
+                        try {
+                            rows = msgDb
+                                .prepare(getCandidatesSql)
+                                .all(areaTag, lastScanId, importedFlag);
+                            if (0 === rows.length) {
+                                return nextArea();
+                            }
+                            metaByMessageId = self.getRelayDecisionMeta(
+                                rows.map(r => r.message_id)
+                            );
+                        } catch (err) {
+                            return nextArea(err);
+                        }
+
+                        areaState.set(areaTag, {
+                            maxId: rows[rows.length - 1].message_id,
+                            failed: false,
+                        });
+
+                        rows.forEach(row => {
+                            const meta = metaByMessageId.get(row.message_id) || {};
+                            const targets = self.relayTargetsForMessage(
+                                areaConfig.uplinks,
+                                meta.seenBy || [],
+                                meta.origin,
+                                localAddress
+                            );
+
+                            targets.forEach(uplink => {
+                                const key = `${areaConfig.network} ${uplink}`;
+                                let group = groups.get(key);
+                                if (!group) {
+                                    group = {
+                                        network: areaConfig.network,
+                                        uplink,
+                                        uuids: [],
+                                        areaTags: new Set(),
+                                    };
+                                    groups.set(key, group);
+                                }
+                                group.uuids.push(row.message_uuid);
+                                group.areaTags.add(areaTag);
+                            });
+                        });
+
+                        return nextArea();
+                    }
+                );
+            },
+            err => {
+                if (err) {
+                    return cb(err);
+                }
+
+                async.eachSeries(
+                    Array.from(groups.values()),
+                    (group, nextGroup) => {
+                        //  A stand-in area config: exportEchoMailMessagesToUplinks
+                        //  uses it for the network (which supplies our local
+                        //  address) and for log context. Each message still
+                        //  carries its own area_tag through to the AREA kludge.
+                        const groupAreaConfig = {
+                            network: group.network,
+                            tag: `(relay: ${Array.from(group.areaTags).join(', ')})`,
+                            uplinks: [group.uplink],
+                        };
+
+                        self.exportEchoMailMessagesToUplinks(
+                            group.uuids,
+                            groupAreaConfig,
+                            [group.uplink],
+                            err => {
+                                if (err) {
+                                    group.areaTags.forEach(areaTag => {
+                                        const state = areaState.get(areaTag);
+                                        if (state) {
+                                            state.failed = true;
+                                        }
+                                    });
+                                    Log.warn(
+                                        {
+                                            uplink: group.uplink,
+                                            messages: group.uuids.length,
+                                            error: err.message,
+                                        },
+                                        'EchoMail relay incomplete; will retry'
+                                    );
+                                } else {
+                                    Log.info(
+                                        {
+                                            uplink: group.uplink,
+                                            network: group.network,
+                                            messagesRelayed: group.uuids.length,
+                                            areas: Array.from(group.areaTags),
+                                        },
+                                        'EchoMail relay complete'
+                                    );
+                                }
+                                return nextGroup(null); //  others still get theirs
+                            }
+                        );
+                    },
+                    () => {
+                        //  Areas whose candidates were all filtered away have no
+                        //  group at all, and still advance: the decision has
+                        //  been made for those messages.
+                        return self.advanceRelayScanIds(areaState, cb);
+                    }
+                );
+            }
+        );
+    };
+
+    //
+    //  Meta needed to decide where a candidate may be relayed, for a batch of
+    //  message IDs: the SEEN-BY entries and the packet header origin.
+    //
+    this.getRelayDecisionMeta = function (messageIds) {
+        const byId = new Map();
+        if (0 === messageIds.length) {
+            return byId;
+        }
+
+        //  SQLite has a hard limit on host parameters, so read in chunks rather
+        //  than building one enormous IN list.
+        const CHUNK = 500;
+        for (let i = 0; i < messageIds.length; i += CHUNK) {
+            const chunk = messageIds.slice(i, i + CHUNK);
+            const placeholders = chunk.map(() => '?').join(',');
+            const rows = msgDb
+                .prepare(
+                    `SELECT message_id, meta_name, meta_value
+                    FROM message_meta
+                    WHERE message_id IN (${placeholders})
+                      AND meta_category = 'FtnProperty'
+                      AND meta_name IN (
+                        'ftn_seen_by', 'ftn_orig_node', 'ftn_orig_network',
+                        'ftn_orig_zone', 'ftn_orig_point'
+                      );`
+                )
+                .all(...chunk);
+
+            rows.forEach(row => {
+                let entry = byId.get(row.message_id);
+                if (!entry) {
+                    entry = { seenByRaw: [], orig: {} };
+                    byId.set(row.message_id, entry);
+                }
+                if ('ftn_seen_by' === row.meta_name) {
+                    //  One row per line when it arrived as an array.
+                    entry.seenByRaw.push(row.meta_value);
+                } else {
+                    entry.orig[row.meta_name] = parseInt(row.meta_value, 10);
+                }
+            });
+        }
+
+        byId.forEach(entry => {
+            entry.seenBy = entry.seenByRaw.flatMap(raw =>
+                ftnUtil.parseAbbreviatedNetNodeList(raw)
+            );
+            const o = entry.orig;
+            if (_.isFinite(o.ftn_orig_node) && _.isFinite(o.ftn_orig_network)) {
+                entry.origin = new Address({
+                    node: o.ftn_orig_node,
+                    net: o.ftn_orig_network,
+                    zone: _.isFinite(o.ftn_orig_zone) ? o.ftn_orig_zone : undefined,
+                    point: _.isFinite(o.ftn_orig_point) ? o.ftn_orig_point : 0,
+                });
+            }
+        });
+
+        return byId;
+    };
+
+    //
+    //  Move each area's relay watermark up, skipping any area whose mail did
+    //  not all get out.
+    //
+    this.advanceRelayScanIds = function (areaState, cb) {
+        async.eachSeries(
+            Array.from(areaState.entries()),
+            (entry, nextArea) => {
+                const [areaTag, state] = entry;
+                if (state.failed) {
+                    return nextArea();
+                }
+                self.setAreaLastScanId(areaTag, ScanToss.Relay, state.maxId, nextArea);
+            },
+            cb
         );
     };
 
@@ -3995,6 +4429,7 @@ function FTNMessageScanTossModule() {
                 function getLastScanId(callback) {
                     return self.getAreaLastScanId(
                         Message.WellKnownAreaTags.Private,
+                        ScanToss.Export,
                         callback
                     );
                 },
@@ -4978,6 +5413,17 @@ function sweepOrphanBsyFiles(dirs) {
 }
 
 const IMPORT_WATCHDOG_MS = 5 * 60 * 1000;
+//
+//  scan_toss keys in message_area_last_scan. Export tracks what this system
+//  has written and offered upstream; Relay tracks what it has imported and
+//  passed on. Two scans over the same areas with different criteria, so they
+//  need separate watermarks.
+//
+const ScanToss = {
+    Export: 'ftn_bso',
+    Relay: 'ftn_bso_relay',
+};
+
 const EXPORT_WATCHDOG_MS = 10 * 60 * 1000;
 
 //
@@ -5575,7 +6021,10 @@ FTNMessageScanTossModule.prototype.performExport = function (cb) {
                 'FTN export',
                 innerDone => {
                     async.eachSeries(
-                        ['EchoMail', 'NetMail'],
+                        //  EchoMailRelay runs after EchoMail: both can target
+                        //  the same node, and the export scan's packets should
+                        //  claim their bundle names first.
+                        ['EchoMail', 'EchoMailRelay', 'NetMail'],
                         (type, nextType) => {
                             self[`perform${type}Export`](err => {
                                 if (err) {
@@ -5646,6 +6095,7 @@ FTNMessageScanTossModule.prototype.record = function (message) {
             this.exportEchoMailMessagesToUplinks(
                 [message.messageUuid],
                 areaConfig,
+                areaConfig.uplinks,
                 err => {
                     this.exportingEnd(() => exportLog(err));
                 }

--- a/test/binkp_ftn_bso_integration.test.js
+++ b/test/binkp_ftn_bso_integration.test.js
@@ -789,10 +789,15 @@ describe('ftn_bso ↔ BinkP integration', function () {
 
             const outDir = mod.getOutgoingEchoMailPacketDir('testnet', DEST);
 
-            mod.exportEchoMailMessagesToUplinks(['uuid-1'], AREA_CONFIG, err => {
-                configModule._popTestConfig(prev);
-                cb(err, { outDir, root });
-            });
+            mod.exportEchoMailMessagesToUplinks(
+                ['uuid-1'],
+                AREA_CONFIG,
+                AREA_CONFIG.uplinks,
+                err => {
+                    configModule._popTestConfig(prev);
+                    cb(err, { outDir, root });
+                }
+            );
         }
 
         function spoolFor(root) {

--- a/test/ftn_echomail_relay.test.js
+++ b/test/ftn_echomail_relay.test.js
@@ -84,6 +84,7 @@ describe('ftn_bso — EchoMail relay to secondary uplinks (issue #748)', functio
     const HUB = '1:218/701'; //  where our mail comes from
     const PEER = '1:218/702'; //  a genuine second peer
     const POINT = '1:218/700.1'; //  our own point -- same net/node as LOCAL
+    const POINT2 = '1:218/700.2'; //  a sibling point, same net/node again
 
     let tmpDir;
     let testDb;
@@ -108,7 +109,7 @@ describe('ftn_bso — EchoMail relay to secondary uplinks (issue #748)', functio
                     },
                     packetTargetByteSize: 256000,
                     nodes: Object.fromEntries(
-                        [HUB, PEER, POINT].map(u => [u, { packetType: '2+' }])
+                        [HUB, PEER, POINT, POINT2].map(u => [u, { packetType: '2+' }])
                     ),
                 },
             },
@@ -127,7 +128,7 @@ describe('ftn_bso — EchoMail relay to secondary uplinks (issue #748)', functio
     const RELAY_AREA = {
         network: 'testnet',
         tag: 'TEST',
-        uplinks: [HUB, PEER, POINT],
+        uplinks: [HUB, PEER, POINT, POINT2],
         relay: true,
     };
     const QUIET_AREA = {
@@ -245,6 +246,9 @@ describe('ftn_bso — EchoMail relay to secondary uplinks (issue #748)', functio
         seenBy,
         withZone = false,
     }) {
+        //  `origin` may carry a point (1:218/700.1). A type 2+ or 2.2 packet
+        //  header carries origPoint and the importer now records it; a plain
+        //  type-2 does not, which is why it is conditional here too.
         const seq = ++fixtureSeq;
         const message = new Message({
             areaTag,
@@ -257,7 +261,7 @@ describe('ftn_bso — EchoMail relay to secondary uplinks (issue #748)', functio
             message.persist(err => (err ? reject(err) : resolve()))
         );
 
-        const [, zone, net, node] = /^(\d+):(\d+)\/(\d+)/.exec(origin);
+        const [, zone, net, node, point] = /^(\d+):(\d+)\/(\d+)(?:\.(\d+))?/.exec(origin);
         const meta = [
             ['System', 'state_flags0', Message.StateFlags0.Imported.toString()],
             ['FtnProperty', 'ftn_orig_network', net],
@@ -265,6 +269,9 @@ describe('ftn_bso — EchoMail relay to secondary uplinks (issue #748)', functio
         ];
         if (withZone) {
             meta.push(['FtnProperty', 'ftn_orig_zone', zone]);
+        }
+        if (point && Number(point) > 0) {
+            meta.push(['FtnProperty', 'ftn_orig_point', point]);
         }
         if (undefined !== seenBy) {
             meta.push(['FtnProperty', 'ftn_seen_by', seenBy]);
@@ -295,13 +302,16 @@ describe('ftn_bso — EchoMail relay to secondary uplinks (issue #748)', functio
         return message;
     }
 
-    function relayScanId(areaTag) {
+    //  Watermarks are per (area, destination), so a test that cares about one
+    //  destination has to name it. Default to the hub, which every relay area
+    //  here has.
+    function relayScanId(areaTag, uplink = HUB) {
         const row = testDb
             .prepare(
                 `SELECT message_id FROM message_area_last_scan
-                 WHERE scan_toss = 'ftn_bso_relay' AND area_tag = ?;`
+                 WHERE scan_toss = ? AND area_tag = ?;`
             )
-            .get(areaTag);
+            .get(`ftn_bso_relay:${uplink}`, areaTag);
         return row ? row.message_id : undefined;
     }
 
@@ -441,16 +451,12 @@ describe('ftn_bso — EchoMail relay to secondary uplinks (issue #748)', functio
         assert.ok(files.includes(flowName(PEER)), 'the other peer should still get it');
     });
 
-    it('does send our own point back the mail it sent us (known gap)', async () => {
-        //  A point's packet header carries origPoint, but the importer does not
-        //  record it -- so a message from OUR point reads as coming from
-        //  1:218/700, which is us, point 0. The origin rule therefore cannot
-        //  see that the point sent it, and the point carve-out relays
-        //  unconditionally.
-        //
-        //  The receiving tosser drops it on MSGID, so this is wasted traffic
-        //  rather than a loop, but it is worth knowing about and worth a test
-        //  that will notice if the importer ever starts recording the point.
+    it('does not send our own point back the mail it sent us', async () => {
+        //  A point shares its boss's net/node, so without the point component
+        //  a message from OUR point reads as coming from us. The importer now
+        //  records ftn_orig_point for packet types that carry one, which is
+        //  what lets the origin rule tell the two apart -- otherwise the point
+        //  carve-out would relay it straight back.
         const root = await freshRoot('point-origin');
         await addImported({});
         await runRelay(root); //  seed
@@ -459,15 +465,32 @@ describe('ftn_bso — EchoMail relay to secondary uplinks (issue #748)', functio
         await runRelay(root);
 
         const files = await flowFilesIn(root);
-        const wentToPoint = files.some(
-            f => f.includes('.pnt/') && f.endsWith('00000001.clo')
+        assert.ok(
+            !files.some(f => f.endsWith('00000001.clo')),
+            `our point should not get its own message back; got ${files.join(', ')}`
         );
-        assert.equal(
-            wentToPoint,
-            true,
-            'documents current behaviour: see the comment above -- if this ' +
-                'starts failing, the importer began recording ftn_orig_point ' +
-                'and the origin rule can now catch this case'
+        assert.ok(
+            files.includes(flowName(HUB)) || files.includes(flowName(PEER)),
+            'the node uplinks should still have been relayed to'
+        );
+    });
+
+    it("still relays a point's message to its sibling points", async () => {
+        //  Two points of the same boss share net and node and differ only in
+        //  the point number, so "same system" has to compare it. Without that
+        //  comparison one point's mail is treated as having come from the
+        //  other, and the sibling silently never receives it.
+        const root = await freshRoot('sibling-point');
+        await addImported({});
+        await runRelay(root); //  seed
+
+        await addImported({ origin: POINT });
+        await runRelay(root);
+
+        const files = await flowFilesIn(root);
+        assert.ok(
+            files.some(f => f.endsWith('00000002.clo')),
+            `the sibling point should have been relayed to; got ${files.join(', ')}`
         );
     });
 
@@ -583,6 +606,208 @@ describe('ftn_bso — EchoMail relay to secondary uplinks (issue #748)', functio
         );
     });
 
+    it('combines the exported flag into the imported one, as one row', async () => {
+        //  state_flags0 is a bitmask, but message_meta's UNIQUE key includes
+        //  meta_value, so REPLACE INTO with a different value inserts a second
+        //  row instead of replacing the first. Nothing hit that before relay,
+        //  because nothing ever exported a message it had imported: the result
+        //  was '1' and '2' side by side instead of '3', and the field reloading
+        //  as an array rather than a value.
+        const root = await freshRoot('flag-combine');
+        await addImported({});
+        await runRelay(root); //  seed
+
+        const relayed = await addImported({ origin: HUB, seenBy: '218/701' });
+        const err = await runRelay(root);
+        assert.ok(!err, err && err.message);
+
+        const rows = testDb
+            .prepare(
+                `SELECT meta_value FROM message_meta
+                 WHERE message_id = ? AND meta_category = 'System'
+                   AND meta_name = 'state_flags0';`
+            )
+            .all(relayed.messageId)
+            .map(r => r.meta_value);
+
+        assert.deepEqual(
+            rows,
+            [String(Message.StateFlags0.Imported | Message.StateFlags0.Exported)],
+            'one row holding both bits, not one row per bit'
+        );
+    });
+
+    it('does not re-feed healthy uplinks because another one is broken', async () => {
+        //  The reason watermarks are per destination rather than per area.
+        //
+        //  With one watermark for the whole area, an uplink that never succeeds
+        //  holds it back forever: every pass re-selects a set that only grows,
+        //  and hands all of it to the uplinks that are working. A dead point
+        //  quietly becomes an ever-larger duplicate feed for everyone else.
+        //
+        //  Counted as messages delivered, not flow references: a pass bundles
+        //  everything it has for a destination into one packet, so counting
+        //  references counts passes and would be the same either way.
+        const root = await freshRoot('dead-uplink');
+        await addImported({});
+        await runRelay(root); //  seed
+
+        const outboundDir = path.join(root, 'outbound', 'outbound');
+        await fsp.mkdir(outboundDir, { recursive: true });
+
+        //  Break PEER by making its flow file unwritable; the hub and the
+        //  points carry on normally.
+        const peerFlow = path.join(outboundDir, flowName(PEER));
+        await fsp.writeFile(peerFlow, '');
+        await fsp.chmod(peerFlow, 0o400);
+
+        const subjects = [];
+        try {
+            for (let i = 0; i < 3; i++) {
+                const msg = await addImported({ origin: HUB });
+                subjects.push(msg.subject);
+                await runRelay(root);
+            }
+        } finally {
+            await fsp.chmod(peerFlow, 0o600);
+        }
+
+        //  Everything the healthy point was actually given: its flow file names
+        //  the packets, and each packet carries the subjects in plain CP437.
+        const pointFlowRel = (await flowFilesIn(root)).find(f =>
+            f.endsWith('00000001.clo')
+        );
+        assert.ok(pointFlowRel, 'our point should have received mail');
+
+        const refs = (await fsp.readFile(path.join(outboundDir, pointFlowRel), 'utf8'))
+            .split('\n')
+            .filter(Boolean)
+            .map(line => line.replace(/^[\^#~!@-]/, ''));
+
+        let delivered = '';
+        for (const ref of refs) {
+            delivered += await fsp.readFile(ref, 'latin1');
+        }
+
+        const counts = subjects.map(subject => delivered.split(subject).length - 1);
+        assert.deepEqual(
+            counts,
+            [1, 1, 1],
+            `each message should reach the point once; got ${JSON.stringify(counts)}`
+        );
+    });
+
+    it('holds the watermark back when the flow file cannot be written', async () => {
+        //  The other half of #818, and the one that happens most: the packet
+        //  moves into outbound fine, then the flow reference cannot be
+        //  appended -- a full disk, a permission problem, or simply the node
+        //  being busy, which is an ordinary outcome under concurrent sessions.
+        //
+        //  Swallowed, it left the packet in outbound with nothing referencing
+        //  it, so the mailer never offered it and nothing ever cleaned it up --
+        //  while the watermark moved on regardless.
+        const root = await freshRoot('flow-fail-hold');
+        await addImported({});
+        await runRelay(root); //  seed
+
+        const pending = await addImported({ origin: HUB, seenBy: '218/701' });
+
+        const outboundDir = path.join(root, 'outbound', 'outbound');
+        await fsp.mkdir(outboundDir, { recursive: true });
+        const peerFlow = path.join(outboundDir, flowName(PEER));
+        await fsp.writeFile(peerFlow, '');
+        await fsp.chmod(peerFlow, 0o400);
+
+        let err;
+        try {
+            err = await runRelay(root);
+        } finally {
+            await fsp.chmod(peerFlow, 0o600);
+        }
+
+        assert.ok(!err, 'the pass itself should not throw');
+        assert.notEqual(
+            relayScanId('relay_area', PEER),
+            pending.messageId,
+            'a packet nothing references has not been delivered'
+        );
+        assert.ok(
+            logged.some(entry =>
+                JSON.stringify(entry).includes('Failed appending flow reference record')
+            ),
+            'the append failure should be reported'
+        );
+
+        //  ...and the retry delivers once the problem is gone.
+        const retryErr = await runRelay(root);
+        assert.ok(!retryErr, retryErr && retryErr.message);
+        assert.equal(
+            relayScanId('relay_area', PEER),
+            pending.messageId,
+            'and only then should that destination move on'
+        );
+    });
+
+    it('holds the watermark back when the move into outbound fails', async () => {
+        //  The failure mode the other test does NOT cover, and the one that
+        //  actually happens: the outbound directory already exists, so
+        //  fse.mkdirs is a silent no-op and the export gets all the way to
+        //  moving the packet in before it fails. That branch used to log a
+        //  warning and then report success, so the scan ID advanced past a
+        //  packet left orphaned in the temp area and the mail was never
+        //  offered again. See #818.
+        const root = await freshRoot('move-fail-hold');
+        await addImported({});
+        await runRelay(root); //  seed
+
+        const pending = await addImported({ origin: HUB, seenBy: '218/701' });
+
+        //  Create the destination directory first, then take write permission
+        //  away: mkdirs succeeds, the move does not.
+        const outboundDir = path.join(root, 'outbound', 'outbound');
+        await fsp.mkdir(outboundDir, { recursive: true });
+        await fsp.chmod(outboundDir, 0o500);
+
+        let err;
+        try {
+            err = await runRelay(root);
+        } finally {
+            await fsp.chmod(outboundDir, 0o700);
+        }
+
+        assert.ok(!err, 'the pass itself should not throw');
+        assert.notEqual(
+            relayScanId('relay_area', PEER),
+            pending.messageId,
+            'a packet that never left the temp area must come round again'
+        );
+        assert.equal(
+            relayScanId('relay_area', HUB),
+            pending.messageId,
+            'the hub was the origin, had nothing to send, and is not held back by ' +
+                "another destination's failure"
+        );
+        assert.ok(
+            logged.some(entry =>
+                JSON.stringify(entry).includes('Failed moving temporary outbound file')
+            ),
+            'the move failure should be reported'
+        );
+
+        //  ...and the retry actually delivers once the problem is fixed.
+        const retryErr = await runRelay(root);
+        assert.ok(!retryErr, retryErr && retryErr.message);
+        assert.ok(
+            (await flowFilesIn(root)).includes(flowName(PEER)),
+            'the next pass should deliver what the failed one did not'
+        );
+        assert.equal(
+            relayScanId('relay_area', PEER),
+            pending.messageId,
+            'and only then should that destination move on'
+        );
+    });
+
     it('holds the watermark back when an uplink fails', async () => {
         //  A destination with no node configuration is skipped by
         //  exportEchoMailMessagesToUplinks rather than failing, so provoke a
@@ -605,7 +830,7 @@ describe('ftn_bso — EchoMail relay to secondary uplinks (issue #748)', functio
 
         assert.ok(!err, 'the pass itself should not throw');
         assert.notEqual(
-            relayScanId('relay_area'),
+            relayScanId('relay_area', PEER),
             pending.messageId,
             'mail that did not get out must come round again'
         );

--- a/test/ftn_echomail_relay.test.js
+++ b/test/ftn_echomail_relay.test.js
@@ -135,6 +135,15 @@ describe('ftn_bso — EchoMail relay to secondary uplinks (issue #748)', functio
         tag: 'QUIET',
         uplinks: [HUB, PEER],
     };
+    //  Relay-enabled but with no point among its uplinks, so a message every
+    //  uplink has seen really does leave nothing to send. RELAY_AREA cannot
+    //  express that: its point is relayed to unconditionally, by design.
+    const PEERS_AREA = {
+        network: 'testnet',
+        tag: 'PEERS',
+        uplinks: [HUB, PEER],
+        relay: true,
+    };
 
     before(async () => {
         tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'enigma_ftnrelay_'));
@@ -143,7 +152,11 @@ describe('ftn_bso — EchoMail relay to secondary uplinks (issue #748)', functio
         }
 
         prevConfig = configModule._pushTestConfig(
-            makeConfig(tmpDir, { relay_area: RELAY_AREA, quiet_area: QUIET_AREA })
+            makeConfig(tmpDir, {
+                relay_area: RELAY_AREA,
+                quiet_area: QUIET_AREA,
+                peers_area: PEERS_AREA,
+            })
         );
 
         //  Same load-order dance as ftn_export_multi_uplink.test.js: message.js
@@ -215,7 +228,23 @@ describe('ftn_bso — EchoMail relay to secondary uplinks (issue #748)', functio
     //  An imported message: persisted, then given the meta the tosser writes on
     //  import -- the Imported state flag, the packet header origin, and SEEN-BY.
     //
-    async function addImported({ areaTag = 'relay_area', origin = HUB, seenBy }) {
+    //  `ftn_mail_packet.js` writes ftn_orig_node and ftn_orig_network from the
+    //  packet header and *nothing else about the origin*: no ftn_orig_zone and
+    //  no ftn_orig_point, even for a type 2+ packet that carried them. So that
+    //  is what this fixture writes by default. An earlier version supplied a
+    //  zone, which no real import ever does, and the effect was that every test
+    //  exercised isSameFtnSystem's strict-zone branch and none of them
+    //  exercised the branch production actually takes.
+    //
+    //  Pass `withZone: true` for the rarer case of an origin that does carry
+    //  one.
+    //
+    async function addImported({
+        areaTag = 'relay_area',
+        origin = HUB,
+        seenBy,
+        withZone = false,
+    }) {
         const seq = ++fixtureSeq;
         const message = new Message({
             areaTag,
@@ -231,10 +260,12 @@ describe('ftn_bso — EchoMail relay to secondary uplinks (issue #748)', functio
         const [, zone, net, node] = /^(\d+):(\d+)\/(\d+)/.exec(origin);
         const meta = [
             ['System', 'state_flags0', Message.StateFlags0.Imported.toString()],
-            ['FtnProperty', 'ftn_orig_zone', zone],
             ['FtnProperty', 'ftn_orig_network', net],
             ['FtnProperty', 'ftn_orig_node', node],
         ];
+        if (withZone) {
+            meta.push(['FtnProperty', 'ftn_orig_zone', zone]);
+        }
         if (undefined !== seenBy) {
             meta.push(['FtnProperty', 'ftn_seen_by', seenBy]);
         }
@@ -391,6 +422,55 @@ describe('ftn_bso — EchoMail relay to secondary uplinks (issue #748)', functio
         );
     });
 
+    it('keeps the origin rule when the packet header carried no zone', async () => {
+        //  The production shape: ftn_orig_network and ftn_orig_node only. This
+        //  is the branch of isSameFtnSystem that every real message takes, and
+        //  until this test existed none of them covered it.
+        const root = await freshRoot('no-zone-origin');
+        await addImported({});
+        await runRelay(root); //  seed
+
+        await addImported({ origin: HUB, withZone: false });
+        await runRelay(root);
+
+        const files = await flowFilesIn(root);
+        assert.ok(
+            !files.includes(flowName(HUB)),
+            `a zoneless origin must still be recognised; got ${files.join(', ')}`
+        );
+        assert.ok(files.includes(flowName(PEER)), 'the other peer should still get it');
+    });
+
+    it('does send our own point back the mail it sent us (known gap)', async () => {
+        //  A point's packet header carries origPoint, but the importer does not
+        //  record it -- so a message from OUR point reads as coming from
+        //  1:218/700, which is us, point 0. The origin rule therefore cannot
+        //  see that the point sent it, and the point carve-out relays
+        //  unconditionally.
+        //
+        //  The receiving tosser drops it on MSGID, so this is wasted traffic
+        //  rather than a loop, but it is worth knowing about and worth a test
+        //  that will notice if the importer ever starts recording the point.
+        const root = await freshRoot('point-origin');
+        await addImported({});
+        await runRelay(root); //  seed
+
+        await addImported({ origin: POINT });
+        await runRelay(root);
+
+        const files = await flowFilesIn(root);
+        const wentToPoint = files.some(
+            f => f.includes('.pnt/') && f.endsWith('00000001.clo')
+        );
+        assert.equal(
+            wentToPoint,
+            true,
+            'documents current behaviour: see the comment above -- if this ' +
+                'starts failing, the importer began recording ftn_orig_point ' +
+                'and the origin rule can now catch this case'
+        );
+    });
+
     it('skips a peer already in SEEN-BY, and relays to one that is not', async () => {
         const root = await freshRoot('seen-by');
         await addImported({});
@@ -474,20 +554,30 @@ describe('ftn_bso — EchoMail relay to secondary uplinks (issue #748)', functio
 
     it('advances past messages every uplink had already seen', async () => {
         //  Otherwise they are re-read and re-judged on every scan forever.
+        //
+        //  This has to run against an area with no point in it. An earlier
+        //  version used relay_area, whose point is relayed to unconditionally,
+        //  so mail was always going out and the assertion never saw the
+        //  "filtered away entirely" case it names -- it passed with the SEEN-BY
+        //  filter disabled outright.
         const root = await freshRoot('filtered-advance');
-        await addImported({});
+        await addImported({ areaTag: 'peers_area' });
         await runRelay(root); //  seed
 
         const filtered = await addImported({
+            areaTag: 'peers_area',
             origin: HUB,
-            seenBy: '218/700 701 702',
+            seenBy: '218/701 702',
         });
-        //  ...but the point still gets it, so use an area whose only uplinks
-        //  are ordinary peers to make "nothing to send" the real case.
         await runRelay(root);
 
+        assert.deepEqual(
+            await flowFilesIn(root),
+            [],
+            'origin plus SEEN-BY should account for every uplink of this area'
+        );
         assert.equal(
-            relayScanId('relay_area'),
+            relayScanId('peers_area'),
             filtered.messageId,
             'the decision has been made for that message; do not weigh it again'
         );

--- a/test/ftn_echomail_relay.test.js
+++ b/test/ftn_echomail_relay.test.js
@@ -1,0 +1,538 @@
+'use strict';
+
+//
+//  EchoMail relay to secondary uplinks -- issue #748.
+//
+//  performEchoMailExport() selects only messages with no System/state_flags0
+//  row, and import always writes one. So a second uplink on an area -- a
+//  downstream point, or a sub-hub -- only ever saw messages composed by a user
+//  at a terminal on this system, never the echomail that flowed in from the
+//  area's own source.
+//
+//  performEchoMailRelayExport() is the second pass that closes that. What is
+//  worth testing is not that it moves bytes -- exportEchoMailMessagesToUplinks
+//  is covered by ftn_export_multi_uplink.test.js -- but the three decisions
+//  around it:
+//
+//    * where it starts from on an area it has never scanned (not the beginning
+//      of time);
+//    * which uplinks a given message is offered to;
+//    * whether the watermark advances when an uplink fails.
+//
+
+const { strict: assert } = require('assert');
+const fsp = require('fs/promises');
+const path = require('path');
+const os = require('os');
+const Database = require('better-sqlite3');
+
+const configModule = require('../core/config.js');
+const loggerModule = require('../core/logger.js');
+
+// ─── schema ──────────────────────────────────────────────────────────────────
+
+//  Only what the relay path touches; see ftn_export_multi_uplink.test.js,
+//  which carries the same subset for the same reason.
+function applySchema(db) {
+    db.exec(`
+        CREATE TABLE IF NOT EXISTS message (
+            message_id              INTEGER PRIMARY KEY,
+            area_tag                VARCHAR NOT NULL,
+            message_uuid            VARCHAR(36) NOT NULL,
+            reply_to_message_id     INTEGER,
+            to_user_name            VARCHAR NOT NULL,
+            from_user_name          VARCHAR NOT NULL,
+            subject,
+            message,
+            modified_timestamp      DATETIME NOT NULL,
+            view_count              INTEGER NOT NULL DEFAULT 0,
+            UNIQUE(message_uuid)
+        );
+
+        CREATE VIRTUAL TABLE IF NOT EXISTS message_fts USING fts4 (
+            content="message",
+            subject,
+            message
+        );
+
+        CREATE TRIGGER IF NOT EXISTS message_after_insert AFTER INSERT ON message BEGIN
+            INSERT INTO message_fts(docid, subject, message) VALUES(new.rowid, new.subject, new.message);
+        END;
+
+        CREATE TABLE IF NOT EXISTS message_meta (
+            message_id      INTEGER NOT NULL,
+            meta_category   INTEGER NOT NULL,
+            meta_name       VARCHAR NOT NULL,
+            meta_value      VARCHAR NOT NULL,
+            UNIQUE(message_id, meta_category, meta_name, meta_value),
+            FOREIGN KEY(message_id) REFERENCES message(message_id) ON DELETE CASCADE
+        );
+
+        CREATE TABLE IF NOT EXISTS message_area_last_scan (
+            scan_toss       VARCHAR NOT NULL,
+            area_tag        VARCHAR NOT NULL,
+            message_id      INTEGER NOT NULL,
+            UNIQUE(scan_toss, area_tag)
+        );
+    `);
+}
+
+describe('ftn_bso — EchoMail relay to secondary uplinks (issue #748)', function () {
+    this.timeout(15000);
+
+    const LOCAL = '1:218/700';
+    const HUB = '1:218/701'; //  where our mail comes from
+    const PEER = '1:218/702'; //  a genuine second peer
+    const POINT = '1:218/700.1'; //  our own point -- same net/node as LOCAL
+
+    let tmpDir;
+    let testDb;
+    let prevConfig;
+    let prevMessageDb;
+    let Message;
+    let getModule;
+    let logged;
+    let prevLog;
+
+    function makeConfig(root, areas) {
+        return {
+            debug: { assertsEnabled: false },
+            menus: { cls: false },
+            general: { boardName: 'Test BBS' },
+            scannerTossers: {
+                ftn_bso: {
+                    paths: {
+                        outbound: path.join(root, 'outbound'),
+                        inbound: path.join(root, 'ftn_in'),
+                        secInbound: path.join(root, 'ftn_secin'),
+                    },
+                    packetTargetByteSize: 256000,
+                    nodes: Object.fromEntries(
+                        [HUB, PEER, POINT].map(u => [u, { packetType: '2+' }])
+                    ),
+                },
+            },
+            messageNetworks: {
+                ftn: {
+                    networks: {
+                        testnet: { localAddress: LOCAL, defaultZone: 1 },
+                    },
+                    areas,
+                },
+            },
+        };
+    }
+
+    //  Relay is opt-in; an area without `relay: true` is skipped entirely.
+    const RELAY_AREA = {
+        network: 'testnet',
+        tag: 'TEST',
+        uplinks: [HUB, PEER, POINT],
+        relay: true,
+    };
+    const QUIET_AREA = {
+        network: 'testnet',
+        tag: 'QUIET',
+        uplinks: [HUB, PEER],
+    };
+
+    before(async () => {
+        tmpDir = await fsp.mkdtemp(path.join(os.tmpdir(), 'enigma_ftnrelay_'));
+        for (const d of ['outbound', 'ftn_in', 'ftn_secin', 'temp']) {
+            await fsp.mkdir(path.join(tmpDir, d), { recursive: true });
+        }
+
+        prevConfig = configModule._pushTestConfig(
+            makeConfig(tmpDir, { relay_area: RELAY_AREA, quiet_area: QUIET_AREA })
+        );
+
+        //  Same load-order dance as ftn_export_multi_uplink.test.js: message.js
+        //  captures dbs.message at load and ftn_bso.js captures the Message
+        //  class at load, so the database has to be in place before either is
+        //  reloaded, and in that order.
+        const dbModule = require('../core/database.js');
+        prevMessageDb = dbModule.dbs.message;
+        testDb = new Database(':memory:');
+        testDb.pragma('foreign_keys = ON');
+        applySchema(testDb);
+        dbModule.dbs.message = testDb;
+
+        //  Object.assign copies own enumerable properties, and bunyan's
+        //  methods live on the prototype -- so the stub has to supply every
+        //  level the code under test calls, not just the ones asserted on.
+        logged = [];
+        prevLog = loggerModule.log;
+        loggerModule.log = Object.assign({}, prevLog, {
+            trace: () => {},
+            debug: () => {},
+            info: () => {},
+            warn: (...a) => logged.push(a),
+            error: (...a) => logged.push(a),
+            child: () => loggerModule.log,
+        });
+
+        delete require.cache[require.resolve('../core/message.js')];
+        delete require.cache[require.resolve('../core/scanner_tossers/ftn_bso.js')];
+        Message = require('../core/message.js');
+        ({ getModule } = require('../core/scanner_tossers/ftn_bso.js'));
+    });
+
+    after(async () => {
+        configModule._popTestConfig(prevConfig);
+        loggerModule.log = prevLog;
+        delete require.cache[require.resolve('../core/message.js')];
+        delete require.cache[require.resolve('../core/scanner_tossers/ftn_bso.js')];
+        require('../core/database.js').dbs.message = prevMessageDb;
+        if (testDb) {
+            testDb.close();
+        }
+        await fsp.rm(tmpDir, { recursive: true, force: true });
+    });
+
+    beforeEach(() => {
+        logged.length = 0;
+        testDb.exec('DELETE FROM message_area_last_scan;');
+        testDb.exec('DELETE FROM message_meta;');
+        testDb.exec('DELETE FROM message;');
+        testDb.exec('DELETE FROM message_fts;');
+    });
+
+    function makeModule(root) {
+        const mod = new getModule();
+        mod.moduleConfig = makeConfig(root, {}).scannerTossers.ftn_bso;
+        mod.exportTempDir = path.join(root, 'temp');
+        return mod;
+    }
+
+    //
+    //  Message UUIDs are derived from areaTag + modTimestamp (to the second) +
+    //  subject + body, so fixtures written in the same second collide unless
+    //  something in them differs. Hence the counter.
+    //
+    let fixtureSeq = 0;
+
+    //
+    //  An imported message: persisted, then given the meta the tosser writes on
+    //  import -- the Imported state flag, the packet header origin, and SEEN-BY.
+    //
+    async function addImported({ areaTag = 'relay_area', origin = HUB, seenBy }) {
+        const seq = ++fixtureSeq;
+        const message = new Message({
+            areaTag,
+            toUserName: 'All',
+            fromUserName: 'Upstream',
+            subject: `relayed ${seq}`,
+            message: `body ${seq}`,
+        });
+        await new Promise((resolve, reject) =>
+            message.persist(err => (err ? reject(err) : resolve()))
+        );
+
+        const [, zone, net, node] = /^(\d+):(\d+)\/(\d+)/.exec(origin);
+        const meta = [
+            ['System', 'state_flags0', Message.StateFlags0.Imported.toString()],
+            ['FtnProperty', 'ftn_orig_zone', zone],
+            ['FtnProperty', 'ftn_orig_network', net],
+            ['FtnProperty', 'ftn_orig_node', node],
+        ];
+        if (undefined !== seenBy) {
+            meta.push(['FtnProperty', 'ftn_seen_by', seenBy]);
+        }
+        const stmt = testDb.prepare(
+            `INSERT INTO message_meta (message_id, meta_category, meta_name, meta_value)
+             VALUES (?, ?, ?, ?);`
+        );
+        for (const [cat, name, value] of meta) {
+            stmt.run(message.messageId, cat, name, String(value));
+        }
+        return message;
+    }
+
+    //  A locally composed message: no state_flags0 at all.
+    async function addLocal(areaTag = 'relay_area') {
+        const seq = ++fixtureSeq;
+        const message = new Message({
+            areaTag,
+            toUserName: 'All',
+            fromUserName: 'Local User',
+            subject: `local post ${seq}`,
+            message: `body ${seq}`,
+        });
+        await new Promise((resolve, reject) =>
+            message.persist(err => (err ? reject(err) : resolve()))
+        );
+        return message;
+    }
+
+    function relayScanId(areaTag) {
+        const row = testDb
+            .prepare(
+                `SELECT message_id FROM message_area_last_scan
+                 WHERE scan_toss = 'ftn_bso_relay' AND area_tag = ?;`
+            )
+            .get(areaTag);
+        return row ? row.message_id : undefined;
+    }
+
+    //  Flow files are named for their destination, so the set of them is the
+    //  set of uplinks that actually got mail. A point's lands one level down in
+    //  an NNNNnnnn.pnt directory (FTS-5005.003), which is exactly the case one
+    //  of these tests is about -- so walk, do not just list.
+    async function flowFilesIn(root) {
+        const base = path.join(root, 'outbound', 'outbound');
+        const found = [];
+        async function walk(dir, prefix) {
+            const entries = await fsp
+                .readdir(dir, { withFileTypes: true })
+                .catch(() => []);
+            for (const entry of entries) {
+                const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+                if (entry.isDirectory()) {
+                    await walk(path.join(dir, entry.name), rel);
+                } else if (entry.name.endsWith('.clo')) {
+                    found.push(rel);
+                }
+            }
+        }
+        await walk(base, '');
+        return found.sort();
+    }
+
+    async function runRelay(root) {
+        const mod = makeModule(root);
+        return new Promise(resolve =>
+            mod.performEchoMailRelayExport(err => resolve(err))
+        );
+    }
+
+    async function freshRoot(name) {
+        const root = path.join(tmpDir, name);
+        await fsp.mkdir(path.join(root, 'temp'), { recursive: true });
+        return root;
+    }
+
+    // ─── where it starts ─────────────────────────────────────────────────────
+
+    it('starts from current mail rather than relaying the whole history', async () => {
+        //  The failure this guards against: getAreaLastScanId() returns 0 both
+        //  for "never scanned" and "nothing seen yet". A relay watermark that
+        //  starts at 0 selects every imported message in the area -- on an
+        //  established board, years of mail shipped to a link that never asked
+        //  for it, and enough bundles to exhaust a destination's 36 names for
+        //  the day.
+        const root = await freshRoot('seed');
+        const older = await addImported({});
+        await addImported({});
+        const newest = await addImported({});
+        assert.ok(newest.messageId > older.messageId);
+
+        const err = await runRelay(root);
+
+        assert.ok(!err, err && err.message);
+        assert.deepEqual(
+            await flowFilesIn(root),
+            [],
+            'the first scan of an area should export nothing'
+        );
+        assert.equal(
+            relayScanId('relay_area'),
+            newest.messageId,
+            'the watermark should be seeded to where the area is now'
+        );
+    });
+
+    it('relays mail imported after the seed', async () => {
+        const root = await freshRoot('after-seed');
+        await addImported({});
+
+        //  First pass seeds and sends nothing.
+        await runRelay(root);
+        assert.deepEqual(await flowFilesIn(root), []);
+
+        //  Now mail arrives.
+        const fresh = await addImported({});
+        const err = await runRelay(root);
+
+        assert.ok(!err, err && err.message);
+        assert.ok(
+            (await flowFilesIn(root)).length > 0,
+            'mail imported after the seed should be relayed'
+        );
+        assert.equal(relayScanId('relay_area'), fresh.messageId);
+    });
+
+    // ─── who it goes to ──────────────────────────────────────────────────────
+
+    it('does not offer a message back to the node that sent it', async () => {
+        //  A sender usually adds itself to SEEN-BY, but not always, and a
+        //  malformed or absent line must not be the only thing standing between
+        //  us and echoing mail straight back at its source. So this fixture
+        //  deliberately carries *no* SEEN-BY: the decision has to come from the
+        //  packet header origin recorded at import.
+        //
+        //  (Written the other way round -- SEEN-BY naming the hub -- this test
+        //  passed with the origin check removed entirely, because the SEEN-BY
+        //  rule covered it. It was proving nothing.)
+        const root = await freshRoot('no-echo-back');
+        await addImported({});
+        await runRelay(root); //  seed
+
+        await addImported({ origin: HUB });
+        await runRelay(root);
+
+        const files = await flowFilesIn(root);
+        assert.ok(
+            !files.includes(flowName(HUB)),
+            `should not have queued anything for ${HUB}, got ${files.join(', ')}`
+        );
+        assert.ok(
+            files.includes(flowName(PEER)),
+            'the other peer should still have been relayed to'
+        );
+    });
+
+    it('skips a peer already in SEEN-BY, and relays to one that is not', async () => {
+        const root = await freshRoot('seen-by');
+        await addImported({});
+        await runRelay(root); //  seed
+
+        //  PEER has seen it; the message came from HUB. Neither should be sent
+        //  to -- HUB because it is the origin, PEER because of SEEN-BY.
+        await addImported({ origin: HUB, seenBy: '218/701 702' });
+        await runRelay(root);
+        let files = await flowFilesIn(root);
+        assert.ok(
+            !files.includes(flowName(PEER)),
+            'an uplink already in SEEN-BY should be skipped'
+        );
+
+        //  Same setup, but PEER has not seen it.
+        await addImported({ origin: HUB, seenBy: '218/701' });
+        await runRelay(root);
+        files = await flowFilesIn(root);
+        assert.ok(
+            files.includes(flowName(PEER)),
+            `a peer not in SEEN-BY should be relayed to; got ${files.join(', ')}`
+        );
+    });
+
+    it('relays to our own point even though SEEN-BY names its net/node', async () => {
+        //  FTS-1027: SEEN-BY has no point component, and a point's net/node are
+        //  its boss's. An upstream sender adds the boss to SEEN-BY as ordinary
+        //  routing courtesy, so a plain SEEN-BY test reads "I have already seen
+        //  this" -- true by definition once imported -- and a point would never
+        //  be relayed to at all.
+        const root = await freshRoot('point');
+        await addImported({});
+        await runRelay(root); //  seed
+
+        //  218/700 is us, and therefore also our point's net/node.
+        await addImported({ origin: HUB, seenBy: '218/700 701 702' });
+        const err = await runRelay(root);
+
+        assert.ok(!err, err && err.message);
+        const files = await flowFilesIn(root);
+        assert.ok(
+            files.some(f => f.includes('.pnt/') && f.endsWith('00000001.clo')),
+            `our point should have been relayed to; got ${files.join(', ')}`
+        );
+    });
+
+    it('leaves locally composed messages to the export scan', async () => {
+        const root = await freshRoot('local-only');
+        await addImported({});
+        await runRelay(root); //  seed
+
+        await addLocal();
+        const err = await runRelay(root);
+
+        assert.ok(!err, err && err.message);
+        assert.deepEqual(
+            await flowFilesIn(root),
+            [],
+            'a local post carries no Imported flag and is not ours to relay'
+        );
+    });
+
+    it('ignores an area that has not opted in', async () => {
+        const root = await freshRoot('opt-in');
+        await addImported({ areaTag: 'quiet_area' });
+        await addImported({ areaTag: 'quiet_area' });
+
+        const err = await runRelay(root);
+
+        assert.ok(!err, err && err.message);
+        assert.deepEqual(await flowFilesIn(root), []);
+        assert.equal(
+            relayScanId('quiet_area'),
+            undefined,
+            'an area without relay:true should not even be watermarked'
+        );
+    });
+
+    // ─── the watermark ───────────────────────────────────────────────────────
+
+    it('advances past messages every uplink had already seen', async () => {
+        //  Otherwise they are re-read and re-judged on every scan forever.
+        const root = await freshRoot('filtered-advance');
+        await addImported({});
+        await runRelay(root); //  seed
+
+        const filtered = await addImported({
+            origin: HUB,
+            seenBy: '218/700 701 702',
+        });
+        //  ...but the point still gets it, so use an area whose only uplinks
+        //  are ordinary peers to make "nothing to send" the real case.
+        await runRelay(root);
+
+        assert.equal(
+            relayScanId('relay_area'),
+            filtered.messageId,
+            'the decision has been made for that message; do not weigh it again'
+        );
+    });
+
+    it('holds the watermark back when an uplink fails', async () => {
+        //  A destination with no node configuration is skipped by
+        //  exportEchoMailMessagesToUplinks rather than failing, so provoke a
+        //  real failure: make the outbound directory unwritable.
+        const root = await freshRoot('fail-hold');
+        await addImported({});
+        await runRelay(root); //  seed
+
+        const pending = await addImported({ origin: HUB, seenBy: '218/701' });
+        const outbound = path.join(root, 'outbound');
+        await fsp.mkdir(outbound, { recursive: true });
+        await fsp.chmod(outbound, 0o500);
+
+        let err;
+        try {
+            err = await runRelay(root);
+        } finally {
+            await fsp.chmod(outbound, 0o700);
+        }
+
+        assert.ok(!err, 'the pass itself should not throw');
+        assert.notEqual(
+            relayScanId('relay_area'),
+            pending.messageId,
+            'mail that did not get out must come round again'
+        );
+        assert.ok(
+            logged.some(entry =>
+                JSON.stringify(entry).includes('EchoMail relay incomplete')
+            ),
+            'the failure should be reported, not swallowed'
+        );
+    });
+
+    function flowName(address) {
+        const m = /^\d+:(\d+)\/(\d+)$/.exec(address);
+        return (
+            Number(m[1]).toString(16).padStart(4, '0') +
+            Number(m[2]).toString(16).padStart(4, '0') +
+            '.clo'
+        );
+    }
+});

--- a/test/ftn_export_multi_uplink.test.js
+++ b/test/ftn_export_multi_uplink.test.js
@@ -212,7 +212,12 @@ describe('ftn_bso — EchoMail export to multiple uplinks (issue #746)', functio
 
         const mod = makeModule(root);
         const err = await new Promise(resolve =>
-            mod.exportEchoMailMessagesToUplinks([message.messageUuid], AREA, resolve)
+            mod.exportEchoMailMessagesToUplinks(
+                [message.messageUuid],
+                AREA,
+                AREA.uplinks,
+                resolve
+            )
         );
 
         assert.equal(err, null, err && err.message);
@@ -241,7 +246,12 @@ describe('ftn_bso — EchoMail export to multiple uplinks (issue #746)', functio
 
         const mod = makeModule(root);
         await new Promise(resolve =>
-            mod.exportEchoMailMessagesToUplinks([message.messageUuid], AREA, resolve)
+            mod.exportEchoMailMessagesToUplinks(
+                [message.messageUuid],
+                AREA,
+                AREA.uplinks,
+                resolve
+            )
         );
 
         //  Three uplinks, one row each: the writes are per-uplink but the
@@ -300,7 +310,7 @@ describe('ftn_bso — EchoMail export to multiple uplinks (issue #746)', functio
         };
 
         const err = await new Promise(resolve =>
-            mod.exportEchoMailMessagesToUplinks(['uuid-1'], AREA, resolve)
+            mod.exportEchoMailMessagesToUplinks(['uuid-1'], AREA, AREA.uplinks, resolve)
         );
 
         assert.equal(err, null, err && err.message);
@@ -335,7 +345,7 @@ describe('ftn_bso — EchoMail export to multiple uplinks (issue #746)', functio
 
         warnings.length = 0;
         const err = await new Promise(resolve =>
-            mod.exportEchoMailMessagesToUplinks(['uuid-1'], AREA, resolve)
+            mod.exportEchoMailMessagesToUplinks(['uuid-1'], AREA, AREA.uplinks, resolve)
         );
 
         assert.ok(err, 'a failed uplink must not be reported as success');

--- a/test/ftn_mail_packet.test.js
+++ b/test/ftn_mail_packet.test.js
@@ -160,6 +160,100 @@ function processBody(buf) {
     });
 }
 
+// -------------------------------------------------------------------------
+// Packet header origin -> message meta
+// -------------------------------------------------------------------------
+
+describe('parsePacketMessages — packet header origin recorded on the message', () => {
+    //
+    //  A packed message: fixed header fields, a 20 byte date, then four
+    //  null terminated strings. See MessageHeaderParser.
+    //
+    function packedMessage() {
+        const head = Buffer.alloc(14);
+        head.writeUInt16LE(2, 0); //  messageType
+        head.writeUInt16LE(700, 2); //  ftn_msg_orig_node
+        head.writeUInt16LE(100, 4); //  ftn_msg_dest_node
+        head.writeUInt16LE(218, 6); //  ftn_msg_orig_net
+        head.writeUInt16LE(218, 8); //  ftn_msg_dest_net
+        head.writeUInt16LE(0, 10); //  ftn_attr_flags
+        head.writeUInt16LE(0, 12); //  ftn_cost
+
+        const date = Buffer.alloc(20);
+        date.write('01 Jan 26  00:00:00\x00', 'ascii');
+
+        const strings = Buffer.from('All\x00Someone\x00Subject\x00Body\r\x00', 'ascii');
+
+        //  The trailing 0x0000 is the packet's end-of-messages marker, and it
+        //  is not optional here: parsePacketMessages only hands a message to
+        //  the iterator when there is more buffer after it, so without the
+        //  terminator the message is parsed and silently never emitted.
+        const terminator = Buffer.from([0x00, 0x00]);
+        return Buffer.concat([head, date, strings, terminator]);
+    }
+
+    function headerFor(version, origPoint) {
+        const ph = new PacketHeader();
+        ph.version = version;
+        ph.origNode = 700;
+        ph.destNode = 100;
+        ph.origNet = 218;
+        ph.destNet = 218;
+        ph.origPoint = origPoint;
+        return ph;
+    }
+
+    function firstMessage(header) {
+        return new Promise((resolve, reject) => {
+            let seen = null;
+            new Packet().parsePacketMessages(
+                header,
+                packedMessage(),
+                (what, msg, next) => {
+                    if ('message' === what) {
+                        seen = msg;
+                    }
+                    next(null);
+                },
+                err => (err ? reject(err) : resolve(seen))
+            );
+        });
+    }
+
+    it('records ftn_orig_point from a type 2+ packet', async () => {
+        //  Without this a point's mail reads as coming from its boss -- the two
+        //  share net and node, and the point number is the only thing telling
+        //  them apart. EchoMail relay needs it to avoid handing a point back
+        //  the message it just sent.
+        const msg = await firstMessage(headerFor('2+', 1));
+        assert.equal(msg.meta.FtnProperty.ftn_orig_point, 1);
+    });
+
+    it('records ftn_orig_point from a type 2.2 packet', async () => {
+        const msg = await firstMessage(headerFor('2.2', 3));
+        assert.equal(msg.meta.FtnProperty.ftn_orig_point, 3);
+    });
+
+    it('ignores the point field on a plain type-2 packet', async () => {
+        //  origPoint is a fill field there, so a stray value would make the
+        //  message look like it came from a point that does not exist -- and
+        //  the origin would then stop being recognised at all.
+        const msg = await firstMessage(headerFor('2', 7));
+        assert.equal(msg.meta.FtnProperty.ftn_orig_point, undefined);
+    });
+
+    it('omits the point entirely when the packet carries none', async () => {
+        const msg = await firstMessage(headerFor('2+', 0));
+        assert.equal(msg.meta.FtnProperty.ftn_orig_point, undefined);
+    });
+
+    it('always records the header origin node and net', async () => {
+        const msg = await firstMessage(headerFor('2+', 1));
+        assert.equal(msg.meta.FtnProperty.ftn_orig_node, 700);
+        assert.equal(msg.meta.FtnProperty.ftn_orig_network, 218);
+    });
+});
+
 describe('processMessageBody — kludge line parsing', () => {
     it('parses a standard Via kludge (mixed case)', async () => {
         const buf = makeMessageBody(['\x01Via 2:123/456.0 19960101.120000 ENiGMA 0.0']);

--- a/website/src/content/docs/messageareas/ftn.md
+++ b/website/src/content/docs/messageareas/ftn.md
@@ -55,6 +55,66 @@ When ENiGMA½ imports messages, they will be placed in the local area that match
 | `network`   | Yes     | Associated network from the `networks` section above |
 | `tag`       | Yes     | FTN area tag (ie: `FSX_GEN`) |
 | `uplinks`   | Yes     | An array of FTN address uplink(s) for this network |
+| `relay`     | No      | Set `true` to pass imported EchoMail on to the area's other uplinks. See [Relaying EchoMail](#relaying-echomail-points-and-sub-hubs). |
+
+### Relaying EchoMail (points and sub-hubs)
+
+By default ENiGMA½ exports only the messages written by users on *this* system.
+Mail that arrives from an area's upstream source is imported and stops there.
+
+That is the right behaviour for an ordinary node, and the wrong one as soon as
+something downstream of you is configured as a second uplink — a point, or a
+sub-hub. Such a link would receive only local chatter and none of the echo it
+actually subscribed to.
+
+Set `relay: true` on an area to pass imported mail on:
+
+```hjson
+fsx_general: {
+    network: fsxnet
+    tag: FSX_GEN
+    uplinks: [ "21:1/100", "21:1/121.1" ]    //  hub, and our own point
+    relay: true
+}
+```
+
+It is opt-in per area on purpose: relaying is visible to the rest of the
+network, and a board that configured a second uplink for some other reason
+should not silently start feeding it.
+
+#### What gets relayed where
+
+For each imported message, every uplink of the area is considered in turn:
+
+- **Never back to the system that sent it.** The packet header origin recorded
+  at import decides this, so it holds even when a sender omits itself from
+  SEEN-BY.
+- **Always to your own points.** SEEN-BY has no point component (FTS-1027): a
+  point's net/node are its boss's, and an upstream sender routinely lists the
+  boss before the message ever reaches you. A plain SEEN-BY test would therefore
+  read "already seen" for every point, every time, and nothing would ever be
+  relayed to one.
+- **Otherwise, only if the uplink is not already in SEEN-BY**, which is the
+  ordinary loop guard for a genuine peer relationship.
+
+SEEN-BY and `^aPATH` are updated on the way out exactly as they are for locally
+written mail, and the original `MSGID` is preserved rather than regenerated.
+
+:::note[Where relaying starts]
+The first time a relay-enabled area is scanned, ENiGMA½ records where the area
+currently is and exports nothing. Mail imported from that point on is relayed;
+anything already in the message base is treated as history.
+
+This matters on an established board, where the whole message base is imported
+mail: without it, the first scan would offer years of traffic to a link that
+never asked for it.
+:::
+
+:::caution
+Relaying to a genuine second *peer* — another hub rather than a point — is
+supported by the SEEN-BY rule above, but it is far less exercised than the point
+case. Watch your uplink's tosser log the first time round.
+:::
 
 Example:
 ```hjson

--- a/website/src/content/docs/messageareas/ftn.md
+++ b/website/src/content/docs/messageareas/ftn.md
@@ -101,13 +101,20 @@ SEEN-BY and `^aPATH` are updated on the way out exactly as they are for locally
 written mail, and the original `MSGID` is preserved rather than regenerated.
 
 :::note[Where relaying starts]
-The first time a relay-enabled area is scanned, ENiGMA½ records where the area
-currently is and exports nothing. Mail imported from that point on is relayed;
-anything already in the message base is treated as history.
+The first time a relay-enabled area is scanned for a given uplink, ENiGMA½
+records where the area currently is and exports nothing. Mail imported from that
+point on is relayed; anything already in the message base is treated as history.
 
 This matters on an established board, where the whole message base is imported
 mail: without it, the first scan would offer years of traffic to a link that
-never asked for it.
+never asked for it. It is also what makes adding an uplink to a busy area safe —
+the new link starts from the present, not the beginning.
+:::
+
+:::note[Each uplink tracks its own progress]
+Delivery is recorded per uplink, not per area. An uplink that cannot be reached
+is retried with its own backlog and does not hold up — or re-send to — the ones
+that are working.
 :::
 
 :::caution


### PR DESCRIPTION
Closes #748. Built from @jriethoven's analysis and field notes on that issue — the design decisions they raised are answered below, with two additions.

## The gap

`performEchoMailExport` excludes any message carrying a `System/state_flags0` row, and import always writes one. The condition tests for a row's *presence*, not a value, so every imported message is permanently ineligible regardless of how many uplinks an area has.

Configure a second uplink on an echo — a downstream point, or a sub-hub — and it receives only messages composed by a user at a terminal on this system. It never sees the echomail that flowed in from the area's own source, which for a point is the entire reason it exists.

## What this adds

A second scan pass, `performEchoMailRelayExport`, in the same dispatch.

Most of what it needs already existed: `exportEchoMailMessagesToUplinks` has always looped every configured uplink, and `prepareMessage` already updates SEEN-BY and `^aPATH` for any exported EchoMail regardless of origin, while preserving the original MSGID rather than regenerating it. (That last point answers @streaps' 2017 concern on #108.) What was missing was a way for imported mail to reach it.

**Opt-in per area** via `relay: true`. Relaying is visible to the rest of the network; a board that configured a second uplink for another reason should not silently start feeding it. This was listed as an open question on the issue — I think opt-in is the only safe default.

## Where a message goes

Three rules, in order:

1. **Never back to the system that sent it.** Read from the packet header origin recorded at import (`ftn_orig_*`), which export does not overwrite in the database. This is the addition I'd most want reviewed: it's exact, and it holds when a sender omits itself from SEEN-BY, which the SEEN-BY rule alone does not.
2. **Always to our own points.** SEEN-BY has no point component (FTS-1027) — a point's net/node are its boss's, and an upstream sender routinely lists the boss before the message arrives, so a plain SEEN-BY test reads "already seen" for every point, every time.
3. **Otherwise only when the uplink is not already in SEEN-BY** — the ordinary loop guard for a genuine peer.

## Two things worth a close look

**The relay watermark is seeded, not started at zero.** `getAreaLastScanId` returns 0 both for "never scanned" and "nothing seen yet". A relay scan beginning at 0 selects every imported message in the area — on an established board, the entire message base offered to a link that never asked for it, and enough bundles to exhaust a destination's 36 daily names (`getOutgoingBundleFileName`) and stall. On first sight of an area we record where it is and export nothing. This wasn't in the issue and is the failure I'd most expect in the field.

**Grouped by `(network, uplink)` across areas**, not per area — same bundle-name reason, one export call per destination per run. Safe across areas because `exportMessagesByUuid` loads each message individually and the AREA kludge comes from the message's own `area_tag`; only the network must match, since that supplies the local address.

## API change

`exportEchoMailMessagesToUplinks` now takes its uplink list as a parameter, since relay sends a given message to a subset. The SEEN-BY line still names *every* configured uplink — `prepareMessage` builds it from config — which is correct FTN practice and helps a downlink we skipped avoid sending it back to us.

## Testing

Nine new tests (`test/ftn_echomail_relay.test.js`); suite goes 2528 → 2537, no failures.

Each test was checked against a mutation of the behaviour it covers — removing the seeding, the origin check, the point carve-out, the SEEN-BY guard, the opt-in gate, or the failure hold-back each fails its own test and no others.

That pass found a real problem: **the first version of the origin test passed with the origin check removed entirely.** Its fixture named the hub in SEEN-BY, so rule 3 covered the case and rule 1 was never exercised. It is now written with no SEEN-BY line at all, which is the case that actually distinguishes them.

## Still open

- **Genuine peer-to-peer relay** (another hub, not a point) rests on rule 3 and is far less exercised than the point path — flagged in the docs.
- Per-*network* opt-in, rather than per-area, if a hub with 40 echoes finds the per-area flag tedious.