### PR TITLE
build(docker): build native modules in a stage that does not ship (#814)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,9 @@
-node_modules
+#  A local build copies the whole checkout in with COPY . -- nothing here is
+#  needed at runtime, and a developer's tree can carry hundreds of megabytes
+#  of it (.git, the website's own node_modules and build output). CI checks
+#  out fresh, so this mostly protects `docker build` on a working copy.
+.git
+**/node_modules
 yarn.lock
 
 filebase
@@ -9,3 +14,5 @@ logs
 mail
 docs/_site
 docs/.sass-cache
+website/dist
+website/.astro

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -63,11 +63,17 @@ jobs:
           #  not compile -- so building only amd64 would check the half that
           #  rarely fails.
           push: ${{ github.event_name != 'pull_request' }}
-          #  The arm legs rebuild node-pty, cpu-features and dtrace-provider
+          #  The arm legs rebuild node-pty, better-sqlite3 and cpu-features
           #  under QEMU every run. A pull request reads master's cache but
           #  writes none of its own: master cannot read a branch cache back,
           #  so the write would only evict from the shared 10 GB that every
           #  pull request's `cache: npm` comes out of.
+          #
+          #  mode=max, not min. min exports only the layers of the final
+          #  image, and since #814 the npm ci layer -- the one the QEMU
+          #  rebuilds live in -- belongs to the discarded build stage. With
+          #  min it would be recompiled on every master push and the cache
+          #  would hold only the cheap half.
           cache-from: type=gha
-          cache-to: ${{ github.event_name != 'pull_request' && 'type=gha,mode=min' || '' }}
+          cache-to: ${{ github.event_name != 'pull_request' && 'type=gha,mode=max' || '' }}
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,19 +1,24 @@
-#  No --platform here on purpose. Pinning this to BUILDPLATFORM builds every
-#  target on the builder's own architecture, which is only correct if the rest
-#  of the file then cross compiles -- and it does not, it just runs npm install
-#  and copies the tree. The result was four tags whose contents were all amd64.
-FROM node:22-bookworm-slim
+#  Two stages. The first installs a compiler toolchain and runs npm ci; the
+#  second is what ships, and it copies node_modules out of the first rather
+#  than building it in place. A single-stage image that installs the toolchain
+#  and then apt-get removes it does not get smaller -- a layer can only add to
+#  an image, and a later delete records a whiteout over bytes that are still
+#  pulled. That was #814: four fifths of the published image was the layer
+#  that installed the toolchain.
+#
+#  No --platform on either FROM, on purpose. Pinning it to BUILDPLATFORM builds
+#  every target on the builder's own architecture, which is only correct if the
+#  rest of the file then cross compiles -- and it does not, it just runs npm ci
+#  and copies the tree. The result was four tags whose contents were all amd64
+#  (#794). Both stages must also name the *same* base image: see the comment
+#  on the COPY --from below.
+FROM node:22-bookworm-slim AS build
 
-LABEL maintainer="dave@force9.org"
+ENV DEBIAN_FRONTEND=noninteractive
 
-ENV NVM_DIR /root/.nvm
-ENV DEBIAN_FRONTEND noninteractive
-
-
-# Just copy the manifest and its lockfile so it only needs to build once
-COPY package.json package-lock.json /enigma-bbs/
-
-# Install APT and NPM packages
+#  git is not optional here: package-lock.json resolves one dependency from a
+#  git URL, so npm ci clones it. None of this stage's packages reach the
+#  final image, so what is installed here costs nothing at pull time.
 RUN apt-get update \
     && apt-get install -y \
     git \
@@ -21,18 +26,44 @@ RUN apt-get update \
     build-essential \
     python3 \
     libssl-dev \
+    && npm set progress=false
+
+#  Just the manifest and its lockfile, so the native modules only rebuild when
+#  a dependency changes rather than on every source change.
+COPY package.json package-lock.json /enigma-bbs/
+
+RUN cd /enigma-bbs && npm ci
+
+
+FROM node:22-bookworm-slim
+
+LABEL maintainer="dave@force9.org"
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+#  Runtime packages only: the archivers and lrzsz are executed by the BBS,
+#  the toolchain is not. pm2 is pure JavaScript, so it needs no compiler.
+RUN apt-get update \
+    && apt-get install -y \
     lrzsz \
     arj \
     lhasa \
     unrar-free \
     p7zip-full \
-    dos2unix \
-    && npm set progress=false && npm config set depth 0 \
+    && rm -rf /var/lib/apt/lists/* \
+    && npm set progress=false \
     && npm install -g pm2 \
-    && cd /enigma-bbs && npm ci
+    && npm cache clean --force
 
+#  node_modules carries compiled native modules -- node-pty, better-sqlite3,
+#  cpu-features, ssh2's crypto binding. Copying them between stages is sound
+#  only because both stages run on the same base image and the build is
+#  native per platform rather than cross compiled (#794). A move to cross
+#  compilation, or a different base image in either stage, breaks this copy.
+COPY --from=build /enigma-bbs/node_modules /enigma-bbs/node_modules
 
-# Do this after npm ci to avoid cache-miss on every code change
+#  Do this after node_modules so a source change does not invalidate it.
+#  node_modules is in .dockerignore, so this cannot overwrite the copy above.
 COPY . /enigma-bbs
 
 #  Supplied by BuildKit for each target of the arch matrix. One sexyz is built
@@ -43,9 +74,17 @@ COPY . /enigma-bbs
 #  arm we publish, so it maps to the armv7 build.
 ARG TARGETARCH
 
-# Then run post source copy steps that have to happen every time
-RUN dos2unix /enigma-bbs/docker/bin/docker-entrypoint.sh \
-    && apt-get remove dos2unix -y \
+#  Post source copy steps that have to happen every time. The entrypoint may
+#  arrive with CRLF line endings from a Windows checkout; sed strips them
+#  rather than installing dos2unix for one file.
+#
+#  Nothing here starts the BBS. The old image ran `pm2 start main.js` at this
+#  point, which really did launch main.js during the build: it left a pm2
+#  daemon's state under /root/.pm2 and, on a checkout that had a config, a
+#  set of freshly created sqlite databases under /enigma-bbs/db -- all of it
+#  shipped in the image. The entrypoint runs pm2-runtime, which needs none
+#  of it.
+RUN sed -i 's/\r$//' /enigma-bbs/docker/bin/docker-entrypoint.sh \
     && chmod +x /enigma-bbs/docker/bin/docker-entrypoint.sh \
     && case "$TARGETARCH" in \
         amd64) sexyz_build=amd64 ;; \
@@ -57,17 +96,12 @@ RUN dos2unix /enigma-bbs/docker/bin/docker-entrypoint.sh \
     && chmod +x /usr/local/bin/sexyz \
     && sexyz v \
     && cd /enigma-bbs \
-    && pm2 start main.js \
     && mkdir -p /enigma-bbs-pre/art \
     && mkdir /enigma-bbs-pre/mods \
     && mkdir /enigma-bbs-pre/config \
     && cp -rp art/* ../enigma-bbs-pre/art/ \
     && cp -rp mods/* ../enigma-bbs-pre/mods/ \
-    && cp -rp config/* ../enigma-bbs-pre/config/ \
-    && apt-get remove build-essential python3 libssl-dev git curl -y \
-    && apt-get autoremove -y \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-    && apt-get clean
+    && cp -rp config/* ../enigma-bbs-pre/config/
 
 # enigma storage mounts
 VOLUME /enigma-bbs/art

--- a/test/docker_image.test.js
+++ b/test/docker_image.test.js
@@ -1,0 +1,268 @@
+'use strict';
+
+//
+//  Structural checks on docker/Dockerfile and the workflow that builds it.
+//
+//  #814: the image installed a compiler toolchain, ran npm ci, and then
+//  apt-get removed the toolchain in a later RUN. That removal reclaims
+//  nothing -- a layer can only add to an image, and a later delete is a
+//  whiteout over bytes that are still pulled -- so four fifths of the
+//  published image was the layer that installed the toolchain. The fix is a
+//  builder stage that keeps the toolchain and a runtime stage that copies
+//  node_modules out of it. These tests pin the shape of that fix without
+//  needing Docker: they parse the Dockerfile into stages and check what each
+//  one installs, copies and removes.
+//
+//  test/live/docker_image.live.js builds the image for real, when asked to.
+//
+
+const { strict: assert } = require('assert');
+const fs = require('fs');
+const paths = require('path');
+
+const REPO_ROOT = paths.join(__dirname, '..');
+const DOCKERFILE = paths.join(REPO_ROOT, 'docker', 'Dockerfile');
+const DOCKERIGNORE = paths.join(REPO_ROOT, '.dockerignore');
+const WORKFLOW = paths.join(REPO_ROOT, '.github', 'workflows', 'docker.yml');
+
+const BUILD_ONLY_PACKAGES = ['build-essential', 'python3', 'libssl-dev', 'git', 'curl'];
+const RUNTIME_PACKAGES = ['lrzsz', 'arj', 'lhasa', 'unrar-free', 'p7zip-full'];
+
+//  Reduce a Dockerfile to its instructions: comments dropped, backslash
+//  continuations joined, each instruction as { name, args } with |args| being
+//  the whole remainder of the line, whitespace collapsed.
+function parseInstructions(text) {
+    const instructions = [];
+    let pending = '';
+    for (const rawLine of text.split('\n')) {
+        const line = rawLine.replace(/\r$/, '');
+        if (!pending && /^\s*(#|$)/.test(line)) {
+            continue;
+        }
+        if (pending && /^\s*#/.test(line)) {
+            //  A comment inside a continued RUN is allowed and ignored.
+            continue;
+        }
+        if (/\\\s*$/.test(line)) {
+            pending += line.replace(/\\\s*$/, '') + ' ';
+            continue;
+        }
+        const whole = (pending + line).replace(/\s+/g, ' ').trim();
+        pending = '';
+        if (!whole) {
+            continue;
+        }
+        const m = whole.match(/^(\S+)\s*(.*)$/);
+        instructions.push({ name: m[1].toUpperCase(), args: m[2] });
+    }
+    assert.equal(pending, '', 'Dockerfile ends inside a line continuation');
+    return instructions;
+}
+
+//  Group instructions by stage. Each stage records the image it starts FROM
+//  and the name given with AS, if any.
+function parseStages(text) {
+    const stages = [];
+    for (const inst of parseInstructions(text)) {
+        if (inst.name === 'FROM') {
+            const m = inst.args.match(/^(?:--platform=\S+\s+)?(\S+)(?:\s+AS\s+(\S+))?$/i);
+            assert(m, `unparseable FROM: ${inst.args}`);
+            stages.push({ image: m[1], name: m[2] || null, instructions: [] });
+            continue;
+        }
+        assert(stages.length, `instruction before first FROM: ${inst.name}`);
+        stages[stages.length - 1].instructions.push(inst);
+    }
+    return stages;
+}
+
+const aptInstalls = stage =>
+    stage.instructions
+        .filter(i => i.name === 'RUN')
+        .flatMap(i => i.args.split('&&'))
+        .filter(cmd => /apt-get\s+install\b/.test(cmd))
+        .flatMap(cmd => cmd.replace(/.*apt-get\s+install\b/, '').split(' '))
+        .filter(tok => tok && !tok.startsWith('-'));
+
+const aptRemoves = stage =>
+    stage.instructions
+        .filter(i => i.name === 'RUN')
+        .flatMap(i => i.args.split('&&'))
+        .filter(cmd => /apt-get\s+(remove|purge)\b/.test(cmd))
+        .flatMap(cmd => cmd.replace(/.*apt-get\s+(remove|purge)\b/, '').split(' '))
+        .filter(tok => tok && !tok.startsWith('-'));
+
+describe('docker/Dockerfile (#814)', () => {
+    let stages;
+    let build;
+    let runtime;
+
+    before(() => {
+        stages = parseStages(fs.readFileSync(DOCKERFILE, 'utf8'));
+        runtime = stages[stages.length - 1];
+        build = stages.find(s => s.name === 'build');
+    });
+
+    it('is a multi-stage build with a stage named "build" and a final runtime stage', () => {
+        assert(
+            stages.length >= 2,
+            `expected at least two stages, found ${stages.length}`
+        );
+        assert(build, 'no stage named "build"');
+        assert.notEqual(build, runtime, 'the build stage must not be the final stage');
+    });
+
+    it('runs both stages on the same base image, so compiled native modules can be copied across', () => {
+        assert(build, 'no stage named "build"');
+        //  node-pty, better-sqlite3, cpu-features and ssh2's crypto binding
+        //  are compiled in the build stage against its libc and node ABI.
+        //  Copying them is only sound when the runtime stage is the same
+        //  image, and neither stage pins --platform (#794).
+        assert.equal(runtime.image, build.image);
+        assert.doesNotMatch(build.image, /\$\{?BUILDPLATFORM/);
+    });
+
+    it('does not pin --platform on either FROM (#794)', () => {
+        const text = fs.readFileSync(DOCKERFILE, 'utf8');
+        for (const inst of parseInstructions(text).filter(i => i.name === 'FROM')) {
+            assert.doesNotMatch(inst.args, /--platform/, `FROM ${inst.args}`);
+        }
+    });
+
+    it('installs the toolchain and runs npm ci in the build stage', () => {
+        assert(build, 'no stage named "build"');
+        const installed = aptInstalls(build);
+        for (const pkg of ['build-essential', 'python3', 'git']) {
+            assert(installed.includes(pkg), `build stage does not install ${pkg}`);
+        }
+        const runs = build.instructions.filter(i => i.name === 'RUN').map(i => i.args);
+        assert(
+            runs.some(r => /\bnpm ci\b/.test(r)),
+            'build stage does not run npm ci'
+        );
+    });
+
+    it('copies only the lockfile inputs before npm ci, so a source change does not rebuild native modules', () => {
+        assert(build, 'no stage named "build"');
+        const copies = build.instructions.filter(
+            i => i.name === 'COPY' || i.name === 'ADD'
+        );
+        assert.equal(
+            copies.length,
+            1,
+            `expected exactly one COPY in the build stage, got ${copies.length}`
+        );
+        const files = copies[0].args.split(' ').slice(0, -1);
+        assert.deepEqual(files.sort(), ['package-lock.json', 'package.json']);
+    });
+
+    it('never installs the toolchain in the runtime stage', () => {
+        const installed = aptInstalls(runtime);
+        for (const pkg of BUILD_ONLY_PACKAGES) {
+            assert(!installed.includes(pkg), `runtime stage installs ${pkg}`);
+        }
+    });
+
+    it('never apt-get removes anything in the runtime stage (a remove reclaims nothing)', () => {
+        //  This is the exact anti-pattern the issue is about. If something has
+        //  to go, it has to not be installed in this stage in the first place.
+        assert.deepEqual(aptRemoves(runtime), []);
+    });
+
+    it('installs the runtime archivers and lrzsz in the runtime stage', () => {
+        const installed = aptInstalls(runtime);
+        for (const pkg of RUNTIME_PACKAGES) {
+            assert(installed.includes(pkg), `runtime stage does not install ${pkg}`);
+        }
+    });
+
+    it('copies node_modules out of the build stage, before the source tree', () => {
+        const copies = runtime.instructions.filter(i => i.name === 'COPY');
+        const fromBuild = copies.findIndex(c => /^--from=build\b/.test(c.args));
+        assert(fromBuild >= 0, 'runtime stage has no COPY --from=build');
+        assert.match(
+            copies[fromBuild].args,
+            /\/enigma-bbs\/node_modules \/enigma-bbs\/node_modules$/
+        );
+
+        const source = copies.findIndex(c => /^\. \/enigma-bbs$/.test(c.args));
+        assert(source >= 0, 'runtime stage does not COPY . /enigma-bbs');
+        assert(fromBuild < source, 'node_modules must be copied before the source tree');
+    });
+
+    it('excludes node_modules from the build context, so COPY . cannot overwrite the compiled tree', () => {
+        const patterns = fs
+            .readFileSync(DOCKERIGNORE, 'utf8')
+            .split('\n')
+            .map(l => l.trim())
+            .filter(l => l && !l.startsWith('#'));
+        assert(
+            patterns.includes('node_modules') || patterns.includes('**/node_modules'),
+            '.dockerignore does not exclude node_modules'
+        );
+    });
+
+    it('selects the per-platform sexyz and verifies it in the runtime stage (#797)', () => {
+        const runs = runtime.instructions.filter(i => i.name === 'RUN').map(i => i.args);
+        assert(runs.some(r => /TARGETARCH/.test(r) && /sexyz v\b/.test(r)));
+        assert(
+            runtime.instructions.some(i => i.name === 'ARG' && i.args === 'TARGETARCH')
+        );
+    });
+
+    it('never starts the BBS while building the image', () => {
+        //  The old file ran `pm2 start main.js` in the post-copy RUN. That
+        //  actually launched main.js at build time and shipped whatever it
+        //  wrote -- pm2 daemon state, and sqlite databases if the checkout
+        //  had a config -- inside the image.
+        for (const stage of stages) {
+            for (const inst of stage.instructions.filter(i => i.name === 'RUN')) {
+                assert.doesNotMatch(
+                    inst.args,
+                    /\bpm2 start\b/,
+                    `${stage.name || 'runtime'}: ${inst.args}`
+                );
+                assert.doesNotMatch(
+                    inst.args,
+                    /\bnode main\.js\b/,
+                    `${stage.name || 'runtime'}: ${inst.args}`
+                );
+            }
+        }
+    });
+
+    it('keeps the staging copy of art, mods and config that the entrypoint seeds volumes from', () => {
+        const runs = runtime.instructions
+            .filter(i => i.name === 'RUN')
+            .map(i => i.args)
+            .join(' && ');
+        for (const dir of ['art', 'mods', 'config']) {
+            assert(
+                new RegExp(`cp -rp ${dir}/\\* \\.\\./enigma-bbs-pre/${dir}/`).test(runs),
+                `runtime stage does not stage ${dir}`
+            );
+        }
+    });
+});
+
+describe('.github/workflows/docker.yml cache (#814)', () => {
+    let text;
+
+    before(() => {
+        text = fs.readFileSync(WORKFLOW, 'utf8');
+    });
+
+    it('exports the build stage layers with mode=max, since mode=min drops discarded stages', () => {
+        //  mode=min exports only the layers of the final image. With a
+        //  builder stage that is exactly the wrong half: the npm ci layer
+        //  that holds the QEMU native rebuilds lives in the discarded stage.
+        const m = text.match(/cache-to:\s*(.*)/);
+        assert(m, 'no cache-to in docker.yml');
+        assert.match(m[1], /type=gha,mode=max/);
+    });
+
+    it('still writes no cache from a pull request', () => {
+        const m = text.match(/cache-to:\s*(.*)/);
+        assert.match(m[1], /github\.event_name != 'pull_request'/);
+    });
+});

--- a/test/live/docker_image.live.js
+++ b/test/live/docker_image.live.js
@@ -1,0 +1,173 @@
+'use strict';
+
+//
+//  Build the Docker image for real and look inside it.
+//
+//  test/docker_image.test.js pins the shape of docker/Dockerfile -- a build
+//  stage with the toolchain, a runtime stage without it -- but only a built
+//  image can show that the copied node_modules actually loads, that sexyz
+//  runs, and that gcc is really gone (#814). A build takes minutes and needs
+//  a Docker daemon, so this only runs when asked:
+//
+//      ENIGMA_DOCKER_LIVE=1 npm run test:live
+//
+//  Set ENIGMA_DOCKER_IMAGE to probe an image that is already built instead of
+//  building one -- the published tag, say -- and ENIGMA_DOCKER_KEEP=1 to leave
+//  the image behind for a look.
+//
+
+const { strict: assert } = require('assert');
+const paths = require('path');
+const { execFileSync, spawnSync } = require('child_process');
+
+const REPO_ROOT = paths.join(__dirname, '..', '..');
+const DOCKERFILE = paths.join(REPO_ROOT, 'docker', 'Dockerfile');
+
+const enabled = process.env.ENIGMA_DOCKER_LIVE === '1';
+const prebuilt = process.env.ENIGMA_DOCKER_IMAGE;
+const keep = process.env.ENIGMA_DOCKER_KEEP === '1' || !!prebuilt;
+
+const IMAGE = prebuilt || `enigma-bbs-live-test:${process.pid}`;
+
+function haveDocker() {
+    const r = spawnSync('docker', ['info'], { stdio: 'ignore' });
+    return r.status === 0;
+}
+
+//  Run a shell snippet inside the image. --entrypoint is overridden because
+//  the real one wants a config volume and then execs pm2-runtime.
+function inImage(script) {
+    return spawnSync(
+        'docker',
+        ['run', '--rm', '--entrypoint', '/bin/sh', IMAGE, '-c', script],
+        { encoding: 'utf8' }
+    );
+}
+
+function inImageOk(script) {
+    const r = inImage(script);
+    assert.equal(r.status, 0, `in image: ${script}\n${r.stdout}${r.stderr}`);
+    return r.stdout;
+}
+
+(enabled ? describe : describe.skip)('docker image (live, #814)', function () {
+    this.timeout(30 * 60 * 1000);
+
+    before(function () {
+        if (!haveDocker()) {
+            this.skip();
+        }
+        if (prebuilt) {
+            return;
+        }
+        execFileSync('docker', ['build', '-t', IMAGE, '-f', DOCKERFILE, REPO_ROOT], {
+            stdio: 'inherit',
+        });
+    });
+
+    after(() => {
+        if (!keep && haveDocker()) {
+            spawnSync('docker', ['rmi', '-f', IMAGE], { stdio: 'ignore' });
+        }
+    });
+
+    it('was never given a compiler toolchain in any shipped layer', () => {
+        //  The filesystem probes below cannot tell the old image from the
+        //  new one: apt-get remove hides gcc from a running container just
+        //  fine, it only fails to reclaim the bytes. What shows the
+        //  difference is the layer history of what ships -- a single-stage
+        //  build carries the RUN that installed build-essential, and the
+        //  RUN that removed it, as layers of the final image. A builder
+        //  stage's layers never appear here.
+        //  docker history lists newest first, so the layers this Dockerfile
+        //  added are everything above the LABEL that opens the runtime
+        //  stage. The node base image's own history has an apt-get purge in
+        //  it, which is its business.
+        const lines = execFileSync(
+            'docker',
+            ['history', '--no-trunc', '--format', '{{.CreatedBy}}', IMAGE],
+            { encoding: 'utf8' }
+        ).split('\n');
+        const label = lines.findIndex(l => /LABEL maintainer=/.test(l));
+        assert(label > 0, 'no LABEL maintainer layer in the image history');
+        const history = lines.slice(0, label).join('\n');
+        for (const pkg of ['build-essential', 'libssl-dev', 'python3']) {
+            assert.doesNotMatch(
+                history,
+                new RegExp(`apt-get install[^&]*\\b${pkg}\\b`),
+                `a shipped layer installs ${pkg}`
+            );
+        }
+        assert.doesNotMatch(
+            history,
+            /apt-get (remove|purge)/,
+            'a shipped layer removes packages'
+        );
+        assert.doesNotMatch(history, /\bnpm ci\b/, 'npm ci ran in a shipped layer');
+    });
+
+    it('does not ship a compiler toolchain', () => {
+        for (const tool of ['gcc', 'g++', 'make', 'python3', 'git', 'curl']) {
+            const r = inImage(`command -v ${tool}`);
+            assert.notEqual(
+                r.status,
+                0,
+                `${tool} is present in the image: ${r.stdout.trim()}`
+            );
+        }
+        for (const pkg of ['build-essential', 'libssl-dev', 'python3']) {
+            const r = inImage(
+                `dpkg -s ${pkg} 2>/dev/null | grep -q '^Status: install ok'`
+            );
+            assert.notEqual(r.status, 0, `${pkg} is installed in the image`);
+        }
+    });
+
+    it('ships the runtime archivers and lrzsz', () => {
+        for (const tool of ['sz', 'rz', 'arj', 'lha', 'unrar-free', '7z']) {
+            inImageOk(`command -v ${tool}`);
+        }
+    });
+
+    it('loads the native modules copied out of the build stage', () => {
+        //  This is the claim the multi-stage copy rests on: modules compiled
+        //  in the build stage must load in the runtime stage.
+        const script = [
+            "require('node-pty')",
+            "require('better-sqlite3')(':memory:').prepare('select 1 as one').get()",
+            "require('cpu-features')()",
+            "require('ssh2')",
+        ].join('; ');
+        inImageOk(`cd /enigma-bbs && node -e "${script}"`);
+    });
+
+    it('starts far enough to reach the config check', () => {
+        //  No config is mounted, so oputil must run and main.js is never
+        //  reached -- but getting here proves the dependency tree resolves.
+        const out = inImageOk('cd /enigma-bbs && node oputil.js 2>&1 | head -3');
+        assert.match(out, /oputil|usage/i);
+    });
+
+    it('runs the sexyz selected for the platform', () => {
+        //  A binary for the wrong architecture fails to exec (#797). sexyz
+        //  writes its banner to stderr, so fold it in.
+        const out = inImageOk('sexyz v 2>&1');
+        assert.match(out, /Synchronet External X\/Y\/ZMODEM/);
+    });
+
+    it('has pm2-runtime for the entrypoint', () => {
+        inImageOk('command -v pm2-runtime');
+    });
+
+    it('has an executable entrypoint with LF line endings', () => {
+        inImageOk('test -x /enigma-bbs/docker/bin/docker-entrypoint.sh');
+        const r = inImage("grep -c $'\\r' /enigma-bbs/docker/bin/docker-entrypoint.sh");
+        assert.notEqual(r.status, 0, 'entrypoint still has CR line endings');
+    });
+
+    it('stages art, mods and config for the entrypoint to seed empty volumes', () => {
+        for (const dir of ['art', 'mods', 'config']) {
+            inImageOk(`test -n "$(ls -A /enigma-bbs-pre/${dir})"`);
+        }
+    });
+});

--- a/website/src/content/docs/installation/docker.md
+++ b/website/src/content/docs/installation/docker.md
@@ -100,6 +100,19 @@ Customising the Docker image is easy!
 ```bash
 docker build -t enigmabbs -f ./docker/Dockerfile .
 ```
+
+The Dockerfile has two stages. A `build` stage installs a compiler toolchain and runs
+`npm ci`, which is where the native modules (node-pty, better-sqlite3 and friends) are
+compiled. The stage that ships installs only the runtime packages -- the archivers and
+`lrzsz` -- and copies `node_modules` out of the build stage, so no compiler reaches the
+published image ([#814](https://github.com/NuSkooler/enigma-bbs/issues/814)). Because the
+compiled modules are copied rather than rebuilt, both stages must start from the same base
+image; keep them in step if you change one.
+
+`ENIGMA_DOCKER_LIVE=1 npm run test:live` builds the image and checks it from the inside:
+that the toolchain is absent, the archivers and `sexyz` are present, and the copied native
+modules load. Point `ENIGMA_DOCKER_IMAGE` at a tag to check an image you already have.
+
 3. Run the image
 ```bash
 docker run -it -p 8888:8888 --name "ENiGMABBS" -v "$(pwd)/config:/enigma-bbs/config" -v "$(pwd)/db:/enigma-bbs/db" -v "$(pwd)/logs:/enigma-bbs/logs" -v "$(pwd)/filebase:/enigma-bbs/filebase" -v "$(pwd)/art:/enigma-bbs/art" -v "$(pwd)/mods:/enigma-bbs/mods" -v "$(pwd)/mail:/mail" enigmabbs


### PR DESCRIPTION
Fixes #814.

The image installed `build-essential`, `python3`, `libssl-dev`, `git` and `curl`, ran `npm ci`, and then `apt-get remove`d the toolchain in a later `RUN`. A layer can only add to an image, so the removal recorded a whiteout over bytes that were still pulled. Building the old file locally on amd64, the install layer alone was 885 MB.

### What changes

**A two-stage Dockerfile.** A `build` stage owns the toolchain and `npm ci`. The runtime stage installs only the archivers, `lrzsz` and pm2, and copies `node_modules` out of the build stage before the source tree. Both stages start from the same base image and neither pins `--platform`, which is what makes copying the compiled native modules sound (#794); the file says so where the `COPY --from` lands. `git` stays in the build stage because the lockfile resolves one dependency from a git URL.

**Two things the old file did on the side are gone.** It ran `pm2 start main.js` at build time, which really launched the BBS: the image carried a pm2 daemon's state under `/root/.pm2` and, on a checkout with a config, sqlite databases under `/enigma-bbs/db`. The entrypoint runs `pm2-runtime` and needs neither. It also installed `dos2unix` to fix one file's line endings and removed it again; `sed` does that now.

**`cache-to` moves from `mode=min` to `mode=max`.** `min` exports only the final image's layers, and the `npm ci` layer -- where the QEMU native rebuilds live -- now belongs to the discarded build stage, so with `min` it would be rebuilt on every master push. This is the question #800 left open. Pull requests still write no cache.

**`.dockerignore` now excludes `.git`, nested `node_modules` and the website build output** (separate commit). CI checks out fresh, but a local build on a working copy was shipping around 460 MB of that.

### Measured locally, amd64

| Image | Size |
| --- | --- |
| Old Dockerfile, local build | 1.70 GB |
| Old Dockerfile, without the context leak | ~1.1 GB |
| New Dockerfile | 686 MB |

### Tests

- `test/docker_image.test.js` parses the Dockerfile into stages and pins the shape: toolchain only in the build stage, no `apt-get remove` in the runtime stage, `node_modules` copied before the source, no BBS started during the build, `mode=max` on master and no cache written from a pull request. It fails on the old file with seven assertions.
- `test/live/docker_image.live.js` builds the image when `ENIGMA_DOCKER_LIVE=1` and checks it from inside: the copied native modules load, `sexyz` runs, the archivers are present. It also reads the layer history, because `apt-get remove` hides `gcc` from a running container just fine and only the history shows whether the toolchain layer shipped. Verified failing on the old image and passing on the new one. `ENIGMA_DOCKER_IMAGE=<tag>` probes an image that already exists.

### Not in this PR

The review on #800 noted `build-push-action@v3` and `login-action@v2` are old. The cache worked with them there, so they are left alone. The first real proof of the `mode=max` change is the master run after merge, since pull requests cannot write the cache.