### PR TITLE
fix(binkp): answer an inbound resume offset instead of ignoring it (#760)

### DIFF
--- a/core/binkp/session.js
+++ b/core/binkp/session.js
@@ -907,6 +907,36 @@ class BinkpSession extends EventEmitter {
             return;
         }
 
+        //
+        //  A sender resuming a file offers the offset it is resuming from, and
+        //  FTS-1026 allows it to do so unprompted. We keep no inbound partials
+        //  -- _destroy unlinks everything in _inboundTempPaths -- so there is
+        //  never anything here to resume against, and accepting the offer would
+        //  write the remainder from the start of a fresh file while waiting for
+        //  |size| bytes that are not coming.
+        //
+        //  Zero is always where we are, so say so and wait for the
+        //  re-announcement, which FTS-1026 requires of the sender under M_GET.
+        //  This is the shape binkd's start_file_recv uses when the offered
+        //  offset does not match where its own file is.
+        //
+        if (offset > 0) {
+            //  Unlike the NR case, this sender has already put the remainder
+            //  on the wire. Those bytes are in flight behind our M_GET and are
+            //  not an answer to it, so _onDataFrame must not adopt them -- doing
+            //  so writes the remainder as though it were the whole file, which
+            //  is the bug being fixed. Wait for the re-announcement.
+            this._pendingOffsetReq = {
+                name,
+                size,
+                timestamp,
+                useGZ,
+                awaitReannounce: true,
+            };
+            this._sendCmd(Commands.M_GET, `${name} ${size} ${timestamp} 0`);
+            return;
+        }
+
         this._beginReceive({ name, size, timestamp, useGZ });
     }
 
@@ -987,7 +1017,17 @@ class BinkpSession extends EventEmitter {
         //  not following FTS-1026, but the bytes are on the wire and
         //  discarding them would hang the batch. Adopt the outstanding
         //  offset request as the active receive instead.
+        //
+        //  Except when we asked in order to refuse a resume offer: there the
+        //  sender had already begun sending the remainder before it saw our
+        //  M_GET, so these bytes are the tail of the old stream rather than an
+        //  answer, and adopting them would assemble a partial file under the
+        //  full file's name. Drop them and wait for the re-announcement, which
+        //  FTS-1026 requires of the sender.
         if (!this._currentRecv && this._pendingOffsetReq) {
+            if (this._pendingOffsetReq.awaitReannounce) {
+                return;
+            }
             this._beginReceive(this._pendingOffsetReq);
         }
 

--- a/test/binkp_nr_mode.test.js
+++ b/test/binkp_nr_mode.test.js
@@ -331,6 +331,96 @@ describe('BinkpSession — NR mode receiving', function () {
     });
 });
 
+// ── Inbound resume offsets — issue #760 ──────────────────────────────────────
+
+describe('BinkpSession — inbound resume offset (issue #760)', function () {
+    this.timeout(10000);
+
+    //  M_GET frames the session sent, as [name, size, timestamp, offset].
+    function getRequests(peer) {
+        return peer.framesIn
+            .filter(f => f.cmd === Commands.M_GET)
+            .map(f => f.arg.split(' '));
+    }
+
+    it('asks for the whole file when the sender offers a resume offset', async () => {
+        //  _onFile parsed the offset and then dropped it, so the receive was
+        //  built against a fresh temp file with bytesReceived 0 while the
+        //  sender sent only the remainder. Before #745 the trailing frame
+        //  finalised it anyway and we acknowledged a truncated file with M_GOT,
+        //  telling the sender to delete its copy. After #745 the size check
+        //  refused it -- safe, but the file simply never transferred.
+        //
+        //  We keep no inbound partials (_destroy unlinks everything in
+        //  _inboundTempPaths), so zero is always where we are: say so, and let
+        //  the sender re-announce.
+        const body = Buffer.alloc(8192, 0x41);
+        const { session, peer } = await makeScriptedPair({
+            filesToSend: [
+                {
+                    name: 'resumed.pkt',
+                    size: body.length,
+                    timestamp: 1700000000,
+                    data: body,
+                    resumeFrom: 3000,
+                },
+            ],
+        });
+
+        let tempPath = null;
+        let receivedSize = null;
+        session.on('file-received', (name, size, ts, p) => {
+            tempPath = p;
+            receivedSize = size;
+        });
+
+        await runSession(session);
+
+        const gets = getRequests(peer);
+        assert.equal(gets.length, 1, 'exactly one M_GET should have been sent');
+        assert.deepEqual(
+            gets[0],
+            ['resumed.pkt', String(body.length), '1700000000', '0'],
+            'the M_GET must name offset 0 and the full size'
+        );
+
+        assert.ok(tempPath, 'the file must transfer after the re-announcement');
+        assert.equal(receivedSize, body.length);
+        const onDisk = await fsp.readFile(tempPath);
+        assert.equal(onDisk.length, body.length, 'the whole file, not the remainder');
+        assert.ok(onDisk.equals(body), 'contents must match');
+        await fsp.unlink(tempPath).catch(() => {});
+    });
+
+    it('still starts at zero for an ordinary offer', async () => {
+        //  Guard against answering M_GET for every file: offset 0 is the normal
+        //  case and must go straight into the receive.
+        const body = Buffer.from('ORDINARY-OFFER');
+        const { session, peer } = await makeScriptedPair({
+            filesToSend: [
+                {
+                    name: 'plain.pkt',
+                    size: body.length,
+                    timestamp: 1700000000,
+                    data: body,
+                },
+            ],
+        });
+
+        let tempPath = null;
+        session.on('file-received', (name, size, ts, p) => {
+            tempPath = p;
+        });
+
+        await runSession(session);
+
+        assert.ok(tempPath, 'the file must have been received');
+        assert.equal((await fsp.readFile(tempPath)).toString(), body.toString());
+        await fsp.unlink(tempPath).catch(() => {});
+        assert.deepEqual(getRequests(peer), [], 'no M_GET for a plain offer');
+    });
+});
+
 // ── Negotiation ───────────────────────────────────────────────────────────────
 
 describe('BinkpSession — NR negotiation (FTS-1028)', function () {

--- a/test/binkp_peer.js
+++ b/test/binkp_peer.js
@@ -364,6 +364,14 @@ class ScriptedPeer {
             this._sendFileHeader(file, -1, this._encode(file, 0).gz);
             return;
         }
+        //  A sender resuming unprompted: announce a non-zero offset and send
+        //  only the remainder, as FTS-1026 permits. |resumeFrom| models that.
+        if (file.resumeFrom > 0) {
+            const resumed = this._encode(file, file.resumeFrom);
+            this._sendFileHeader(file, file.resumeFrom, resumed.gz);
+            this._pump(resumed.body);
+            return;
+        }
         const { body, gz } = this._encode(file, 0);
         this._sendFileHeader(file, 0, gz);
         this._pump(body);


### PR DESCRIPTION
Closes #760.

## The bug

`_onFile` parsed the offset out of an inbound `M_FILE` and then dropped it — only the `-1` (NR) case ever looked at it. Every inbound transfer began at zero into a fresh temp file, so a sender resuming (announcing a non-zero offset and sending only the remainder, which FTS-1026 permits unprompted) had its bytes written from the start of a new file while we waited for `size` of them.

- **Before #745** the file was *accepted*: the trailing zero-length frame finalised the receive regardless of how much had arrived, so a fragment was handed to the tosser under the full file's name and acknowledged with `M_GOT` — telling the sender to delete its copy. Silent truncation.
- **After #745** the size check refuses it. Safe, but the file simply never transfers.

## The fix

We keep no inbound partials (`_destroy` unlinks everything in `_inboundTempPaths`), so zero is always where we are. Answer `M_GET <name> <size> <ts> 0` and wait for the re-announcement, which FTS-1026 requires of the sender under `M_GET`. Same shape as binkd's `start_file_recv` when the offset it is given doesn't match where its own file is.

Honouring a resume *properly* — keeping partials across sessions and naming a real offset — is a much larger piece of work and isn't attempted here.

## The part worth reviewing

The reuse wasn't quite free. The NR path already parks an offset request in `_pendingOffsetReq`, and `_onDataFrame` adopts it when a sender answers `M_GET` with data but no fresh `M_FILE`. **That leniency is wrong for this case**: a resuming sender has already put the remainder on the wire, so those bytes are the tail of the old stream rather than an answer — and adopting them assembles a partial file under the full file's name, which is the bug being fixed.

So the request is marked `awaitReannounce` and `_onDataFrame` drops in-flight bytes instead of adopting them. A fresh `M_FILE` clears it as before.

I found this by running it, not by reading it: the first version of the fix looked right and hung, because the adoption path quietly reassembled the 5192-byte remainder and then postponed it on the size check.

## Testing

`test/binkp_peer.js` gains a `resumeFrom` option so the harness can model a sender that resumes unprompted. The peer already honours `M_GET`, so the test covers the whole round trip and asserts the full **8192 bytes** arrive rather than the 5192-byte remainder. A second test guards against answering `M_GET` for ordinary offers.

Three mutations checked — dropping the branch, echoing the offered offset back instead of `0`, and adopting the in-flight data anyway — each fails the new tests and nothing else.

`npm test`: 2566 passing. Note `test/binkp_nr_mode.test.js` run *standalone* shows 6 failures both with and without this change (20→22 passing, 6 failing either way) — the known "only the default mocha order is green" behaviour, verified against a clean worktree at master.

## One thing I did not do

I initially added a `Log.debug` on the new path and it crashed the tests: `session.js` captures `const Log = require('../logger').log` at module load, and the binkp tests never initialise the logger, so `Log` is `undefined`. All 35 `Log.*` sites in that file share the fragility — the existing tests just never reach them. I dropped my line rather than expand scope, but it's worth knowing.