### PR TITLE
fix(qwk): read reply packets

### DIFF
--- a/core/qwk_mail_packet.js
+++ b/core/qwk_mail_packet.js
@@ -10,7 +10,11 @@ const {
     getAllAvailableMessageAreaTags,
 } = require('./message_area');
 const StatLog = require('./stat_log');
-const Config = require('./config').get;
+const configModule = require('./config');
+//  Late bound for the same reason as message_area.js: configModule.get is
+//  replaced by the Config bootstrapper, so capturing it here would freeze
+//  whichever getter happened to be installed when this file was required.
+const Config = (...args) => configModule.get(...args);
 const SysProps = require('./system_property');
 const UserProps = require('./user_property');
 const { numToMbf32 } = require('./mbf');
@@ -182,6 +186,62 @@ const replaceCharInBuffer = (buffer, search, replace) => {
     }
 };
 
+//
+//  areaTag -> conference number.
+//
+//  - A conference the sysop configured is used as configured.
+//  - In User mode the rest are numbered from 1000, which works around what
+//    seems to be a bug in some readers.
+//  - In Network mode an area with no configuration is not mapped, and so is
+//    skipped.
+//
+//  A reply packet names the conference and nothing else, so an import has to
+//  reproduce this exactly to find its way back to an area.
+//
+const buildConferenceMap = (areaTags, { autoNumber = true, onWarning } = {}) => {
+    const map = {};
+
+    const configuredAreas = _.get(Config(), 'messageNetworks.qwk.areas');
+    if (configuredAreas) {
+        Object.keys(configuredAreas).forEach(areaTag => {
+            const confNumber = configuredAreas[areaTag].conference;
+            if (confNumber) {
+                map[areaTag] = confNumber;
+            }
+        });
+    }
+
+    if (!autoNumber) {
+        return map;
+    }
+
+    let confNumber = 1000;
+    const usedConfNumbers = new Set(Object.values(map));
+
+    areaTags.forEach(areaTag => {
+        if (map[areaTag]) {
+            return;
+        }
+
+        while (confNumber < 10001 && usedConfNumbers.has(confNumber)) {
+            ++confNumber;
+        }
+
+        //  we can go up to 65535 for some things, but NDX files are limited to 9999
+        if (confNumber === 10000) {
+            //  sanity...
+            if (onWarning) {
+                onWarning(Errors.General('To many conferences (over 9999)'));
+            }
+        } else {
+            map[areaTag] = confNumber;
+            ++confNumber;
+        }
+    });
+
+    return map;
+};
+
 class QWKPacketReader extends EventEmitter {
     constructor(
         packetPath,
@@ -278,22 +338,6 @@ class QWKPacketReader extends EventEmitter {
                                         }
                                         break;
 
-                                    case 'ID.MSG':
-                                        if (
-                                            this.options.mode ===
-                                            QWKPacketReader.Modes.Guess
-                                        ) {
-                                            this.options.mode = QWKPacketReader.Modes.REP;
-                                        }
-
-                                        if (
-                                            this.options.mode ===
-                                            QWKPacketReader.Modes.REP
-                                        ) {
-                                            out.messages = { filename };
-                                        }
-                                        break;
-
                                     case 'HEADERS.DAT': //  Synchronet
                                         out.headers = { filename };
                                         break;
@@ -342,6 +386,29 @@ class QWKPacketReader extends EventEmitter {
                                             };
                                             out.pointers.filenames.push(filename);
                                         } else {
+                                            //
+                                            //  A reply packet carries its
+                                            //  messages in a single file named
+                                            //  for the BBS it came from, so the
+                                            //  name is whatever ID the host
+                                            //  chose -- not a fixed one.
+                                            //
+                                            if (key.endsWith('.MSG')) {
+                                                if (
+                                                    this.options.mode ===
+                                                    QWKPacketReader.Modes.Guess
+                                                ) {
+                                                    this.options.mode =
+                                                        QWKPacketReader.Modes.REP;
+                                                }
+
+                                                if (
+                                                    this.options.mode ===
+                                                    QWKPacketReader.Modes.REP
+                                                ) {
+                                                    out.messages = { filename };
+                                                }
+                                            }
                                             out[key] = { filename };
                                         }
                                         break;
@@ -401,6 +468,14 @@ class QWKPacketReader extends EventEmitter {
         //  References:
         //  -   http://fileformats.archiveteam.org/wiki/QWK
         //
+        //
+        //  A reply packet carries no CONTROL.DAT: it is written by the
+        //  reader, which has nothing to say about the BBS it is going to.
+        //
+        if (this.options.mode === QWKPacketReader.Modes.REP) {
+            return cb(null);
+        }
+
         if (!this.packetInfo.control) {
             return cb(Errors.DoesNotExist('No control file found within QWK packet'));
         }
@@ -1013,55 +1088,13 @@ class QWKPacketWriter extends EventEmitter {
                     });
                 },
                 callback => {
-                    //
-                    //  Prepare areaTag -> conference number mapping:
-                    //  - In User mode, areaTags's that are not explicitly configured
-                    //    will have their conference number auto-generated.
-                    //  - In Network mode areaTags's missing a configuration will not
-                    //    be mapped, and thus skipped.
-                    //
-                    const configuredAreas = _.get(Config(), 'messageNetworks.qwk.areas');
-                    if (configuredAreas) {
-                        Object.keys(configuredAreas).forEach(areaTag => {
-                            const confNumber = configuredAreas[areaTag].conference;
-                            if (confNumber) {
-                                this.areaTagConfMap[areaTag] = confNumber;
-                            }
-                        });
-                    }
-
-                    if (this.options.mode === QWKPacketWriter.Modes.User) {
-                        //  All the rest
-                        //  Start at 1000 to work around what seems to be a bug with some readers
-                        let confNumber = 1000;
-                        const usedConfNumbers = new Set(
-                            Object.values(this.areaTagConfMap)
-                        );
-                        getAllAvailableMessageAreaTags().forEach(areaTag => {
-                            if (this.areaTagConfMap[areaTag]) {
-                                return;
-                            }
-
-                            while (
-                                confNumber < 10001 &&
-                                usedConfNumbers.has(confNumber)
-                            ) {
-                                ++confNumber;
-                            }
-
-                            //  we can go up to 65535 for some things, but NDX files are limited to 9999
-                            if (confNumber === 10000) {
-                                //  sanity...
-                                this.emit(
-                                    'warning',
-                                    Errors.General('To many conferences (over 9999)')
-                                );
-                            } else {
-                                this.areaTagConfMap[areaTag] = confNumber;
-                                ++confNumber;
-                            }
-                        });
-                    }
+                    this.areaTagConfMap = buildConferenceMap(
+                        getAllAvailableMessageAreaTags(),
+                        {
+                            autoNumber: this.options.mode === QWKPacketWriter.Modes.User,
+                            onWarning: warning => this.emit('warning', warning),
+                        }
+                    );
 
                     return callback(null);
                 },
@@ -1699,6 +1732,7 @@ class QWKPacketWriter extends EventEmitter {
 }
 
 module.exports = {
+    buildConferenceMap,
     QWKPacketReader,
     QWKPacketWriter,
 };

--- a/test/qwk_reply.test.js
+++ b/test/qwk_reply.test.js
@@ -1,0 +1,221 @@
+'use strict';
+
+const { strict: assert } = require('assert');
+const fs = require('fs');
+const os = require('os');
+const paths = require('path');
+
+const ArchiveUtil = require('../core/archive_util.js');
+const configModule = require('../core/config.js');
+const { QWKPacketReader, buildConferenceMap } = require('../core/qwk_mail_packet.js');
+
+//
+//  A QWK reply packet: a single file named for the BBS it is going to,
+//  holding 128 byte blocks -- one packet ID block, then a header block and
+//  its text blocks per message.
+//
+//  Reference: http://fileformats.archiveteam.org/wiki/QWK
+//
+const BlockSize = 128;
+const QWKLF = 0xe3; //  what a line ending becomes inside a block
+
+const pad = (value, length) => `${value}`.padEnd(length).substr(0, length);
+
+const messageHeader = ({
+    confNumber,
+    to = 'SYSOP',
+    from = 'ANNE',
+    subject = 'Re: testing',
+    blocks = 2,
+    replyToNum = 0,
+}) => {
+    const b = Buffer.alloc(BlockSize, 0x20);
+    b.write(' ', 0, 'ascii'); //  status: public
+    b.write(pad(confNumber, 7), 1, 'ascii'); //  a reply names its conference here
+    b.write(pad('01-01-2601:00', 13), 8, 'ascii');
+    b.write(pad(to, 25), 21, 'ascii');
+    b.write(pad(from, 25), 46, 'ascii');
+    b.write(pad(subject, 25), 71, 'ascii');
+    b.write(pad('', 12), 96, 'ascii'); //  password
+    b.write(pad(replyToNum, 8), 108, 'ascii');
+    b.write(pad(blocks, 6), 116, 'ascii'); //  counting this header
+    b.writeUInt8(0xe1, 122); //  active
+    b.writeUInt16LE(confNumber, 123);
+    return b;
+};
+
+const textBlocks = text => {
+    const encoded = Buffer.from(text.replace(/\n/g, String.fromCharCode(QWKLF)), 'ascii');
+    const blocks = Math.ceil(encoded.length / BlockSize) || 1;
+    const b = Buffer.alloc(blocks * BlockSize, 0x20);
+    encoded.copy(b);
+    return b;
+};
+
+//
+//  The reader opens an archive; these tests hand it the members directly, so
+//  what is under test is the parsing rather than the archiver.
+//
+const readReplyPacket = (members, cb) => {
+    const sourceDir = fs.mkdtempSync(paths.join(os.tmpdir(), 'enig-qwkrep-'));
+    Object.keys(members).forEach(name =>
+        fs.writeFileSync(paths.join(sourceDir, name), members[name])
+    );
+
+    const realGetInstance = ArchiveUtil.getInstance;
+    ArchiveUtil.getInstance = () => ({
+        detectType: (path, done) => done(null, 'application/zip'),
+        extractTo: (path, destDir, type, done) => {
+            fs.readdirSync(sourceDir).forEach(f =>
+                fs.copyFileSync(paths.join(sourceDir, f), paths.join(destDir, f))
+            );
+            done(null);
+        },
+    });
+
+    const reader = new QWKPacketReader(sourceDir, {
+        mode: QWKPacketReader.Modes.REP,
+    });
+
+    const messages = [];
+    reader.on('message', message => messages.push(message));
+    reader.on('error', err => {
+        ArchiveUtil.getInstance = realGetInstance;
+        cb(err);
+    });
+    reader.on('done', () => {
+        ArchiveUtil.getInstance = realGetInstance;
+        cb(null, messages);
+    });
+
+    reader.read();
+};
+
+describe('QWK reply packets', () => {
+    //
+    //  A reply packet is written by the reader, which has nothing to say
+    //  about the BBS it is going to, so it carries no CONTROL.DAT. Requiring
+    //  one rejected every reply packet that has ever been written.
+    //
+    it('reads a reply packet, which carries no CONTROL.DAT', done => {
+        readReplyPacket(
+            {
+                'ENIGMA.MSG': Buffer.concat([
+                    Buffer.alloc(BlockSize, 0x20), //  packet ID block
+                    messageHeader({ confNumber: 1000 }),
+                    textBlocks('A reply typed offline.'),
+                ]),
+            },
+            (err, messages) => {
+                assert.equal(err, null);
+                assert.equal(messages.length, 1);
+                assert.equal(messages[0].fromUserName, 'ANNE');
+                assert.equal(messages[0].toUserName, 'SYSOP');
+                assert.equal(messages[0].subject, 'Re: testing');
+                assert.match(messages[0].message, /A reply typed offline\./);
+                assert.equal(messages[0].meta.QwkProperty.qwk_conf_num, 1000);
+                done();
+            }
+        );
+    });
+
+    //
+    //  The file is named for the host, so its name is whatever ID that board
+    //  chose. Matching a fixed name found the messages in no real packet.
+    //
+    it('finds the messages file whatever the host is called', done => {
+        readReplyPacket(
+            {
+                'SOMEBBS.MSG': Buffer.concat([
+                    Buffer.alloc(BlockSize, 0x20),
+                    messageHeader({ confNumber: 1007 }),
+                    textBlocks('From a board with another name.'),
+                ]),
+            },
+            (err, messages) => {
+                assert.equal(err, null);
+                assert.equal(messages.length, 1);
+                assert.equal(messages[0].meta.QwkProperty.qwk_conf_num, 1007);
+                done();
+            }
+        );
+    });
+
+    it('reads every message in the packet', done => {
+        readReplyPacket(
+            {
+                'ENIGMA.MSG': Buffer.concat([
+                    Buffer.alloc(BlockSize, 0x20),
+                    messageHeader({ confNumber: 1000, subject: 'First' }),
+                    textBlocks('One.'),
+                    messageHeader({ confNumber: 1001, subject: 'Second' }),
+                    textBlocks('Two.'),
+                ]),
+            },
+            (err, messages) => {
+                assert.equal(err, null);
+                assert.deepEqual(
+                    messages.map(m => m.subject),
+                    ['First', 'Second']
+                );
+                assert.deepEqual(
+                    messages.map(m => m.meta.QwkProperty.qwk_conf_num),
+                    [1000, 1001]
+                );
+                done();
+            }
+        );
+    });
+});
+
+//
+//  A reply names a conference number and nothing else, so an import has to
+//  reproduce the numbering the export used to find its way back to an area.
+//
+describe('QWK conference numbering', () => {
+    let previousConfig;
+
+    afterEach(() => configModule._popTestConfig(previousConfig));
+
+    it('numbers unconfigured areas from 1000', () => {
+        previousConfig = configModule._pushTestConfig({});
+
+        const map = buildConferenceMap(['general', 'another_area']);
+        assert.equal(map.general, 1000);
+        assert.equal(map.another_area, 1001);
+    });
+
+    it('uses the conference the sysop pinned, and steps around it', () => {
+        previousConfig = configModule._pushTestConfig({
+            messageNetworks: {
+                qwk: {
+                    areas: {
+                        another_area: { conference: 1000 },
+                    },
+                },
+            },
+        });
+
+        const map = buildConferenceMap(['general', 'another_area']);
+        assert.equal(map.another_area, 1000);
+        assert.equal(map.general, 1001);
+    });
+
+    //  Network mode: an area with no conference configured is not exported
+    it('maps only configured areas when not numbering automatically', () => {
+        previousConfig = configModule._pushTestConfig({
+            messageNetworks: {
+                qwk: {
+                    areas: {
+                        general: { conference: 5 },
+                    },
+                },
+            },
+        });
+
+        const map = buildConferenceMap(['general', 'another_area'], {
+            autoNumber: false,
+        });
+        assert.deepEqual(map, { general: 5 });
+    });
+});


### PR DESCRIPTION
QWK reply mode has never worked. It required a CONTROL.DAT, which a reply packet does not carry -- the reader writes it, and has nothing to say about the BBS it is going to -- and it looked for the messages under the fixed name ID.MSG rather than the <BBSID>.MSG a reply packet actually uses. Every reply packet handed to it failed with "No control file found".

Conference numbering moves out of the writer into buildConferenceMap(), so an import can reproduce the numbering an export used: a reply names a conference and nothing else. Config access is late bound, as in message_area.js, so that numbering can be tested at all.

> Written by Claude (Opus 5), an LLM made by Anthropic, at andy5995's
> direction.