### PR TITLE
fix(doors): preserve DOOR.SYS call times

### DIFF
--- a/WHATSNEW.md
+++ b/WHATSNEW.md
@@ -3,6 +3,8 @@ This document attempts to track **major** changes and additions in ENiGMA½. For
 
 ## 0.5.1-beta
 
+* **DOOR.SYS reports distinct call times** ([#824](https://github.com/NuSkooler/enigma-bbs/issues/824)) — the current and previous login times now occupy their respective fields in 24-hour format. First-time callers leave the previous-call field blank instead of repeating the current time.
+
 * **Post from a message list** ([#213](https://github.com/NuSkooler/enigma-bbs/issues/213)) — <kbd>P</kbd> on the message list, or the personal message list, starts a new message where before you had to back out to the message menu to reach its own <kbd>P</kbd>. The post goes to the area the highlighted message is in, so it does the right thing on a list that spans areas. An existing board keeps the menus it has, so see [UPGRADE.md](UPGRADE.md) for the binding to add.
 
 * **Doors can be handed a [`BBSDEV.DRP`](https://github.com/RealDeuce/bbsdev.drp) drop file** — set `dropFileType: BBSDEV` on an `abracadabra` door. The older formats are CP437, so a user whose name ENiGMA½ stores fine reaches the door mangled, and they leave the terminal's character set, the caller's language and the meaning of the comm field to convention. The new format is UTF-8 and states all three.

--- a/core/dropfile.js
+++ b/core/dropfile.js
@@ -348,8 +348,11 @@ module.exports = class DropFile {
         );
 
         const timeOfCall = moment(prop[UserProps.LastLoginTs] || moment()).format(
-            'hh:mm'
+            'HH:mm'
         );
+        const timeOfLastCall = prop[UserProps.PrevLoginTs]
+            ? moment(prop[UserProps.PrevLoginTs]).format('HH:mm')
+            : '';
 
         //  :TODO: fix time remaining
         //  :TODO: fix default protocol -- user prop: transfer_protocol
@@ -401,7 +404,7 @@ module.exports = class DropFile {
                 '256', //  "Time Credits In Minutes (positive/negative)"
                 '07/07/90', //  "Last New Files Scan Date          (mm/dd/yy)"
                 timeOfCall, //  "Time of This Call"
-                timeOfCall, //  "Time of Last Call                 (hh:mm)"
+                timeOfLastCall, //  "Time of Last Call                 (hh:mm)"
                 '9999', //  "Maximum daily files available"
                 '0', //  "Files d/led so far today"
                 upK.toString(), //  "Total "K" Bytes Uploaded"

--- a/core/user_login.js
+++ b/core/user_login.js
@@ -231,6 +231,7 @@ function recordLogin(client, cb) {
 
     const user = client.user;
     const loginTimestamp = StatLog.now;
+    const previousLoginTimestamp = user.getProperty(UserProps.LastLoginTs);
 
     //  Snapshot streak values now, before the parallel block updates LastLoginTs.
     const now = moment();
@@ -249,6 +250,17 @@ function recordLogin(client, cb) {
                     loginTimestamp,
                     callback
                 );
+            },
+            callback => {
+                if (previousLoginTimestamp) {
+                    return StatLog.setUserStat(
+                        user,
+                        UserProps.PrevLoginTs,
+                        previousLoginTimestamp,
+                        callback
+                    );
+                }
+                return callback(null);
             },
             callback => {
                 return StatLog.incrementUserStat(user, UserProps.LoginCount, 1, callback);

--- a/core/user_property.js
+++ b/core/user_property.js
@@ -26,6 +26,7 @@ module.exports = {
     ThemeId: 'theme_id',
     AccountCreated: 'account_created',
     LastLoginTs: 'last_login_timestamp',
+    PrevLoginTs: 'previous_login_timestamp',
     LoginCount: 'login_count',
     UserComment: 'user_comment', //  NYI
     AutoSignature: 'auto_signature',

--- a/test/dropfile_comm_type.test.js
+++ b/test/dropfile_comm_type.test.js
@@ -4,29 +4,33 @@ const { strict: assert } = require('assert');
 const os = require('os');
 
 const DropFile = require('../core/dropfile.js');
+const UserProps = require('../core/user_property.js');
 
-function makeClient() {
+function makeClient(properties = {}) {
     return {
         node: 1,
         term: { termHeight: 25 },
         user: {
             userId: 1,
-            properties: {
-                login_count: '5',
-                location: 'Anywhere',
-            },
+            properties: Object.assign(
+                {
+                    login_count: '5',
+                    location: 'Anywhere',
+                },
+                properties
+            ),
             getSanitizedName: which => ('real' === which ? 'Test User' : 'testuser'),
             getLegacySecurityLevel: () => 30,
         },
     };
 }
 
-function dropFileLines(fileType, commType) {
+function dropFileLines(fileType, commType, properties) {
     const opts = { fileType, baseDir: os.tmpdir() };
     if (commType) {
         opts.commType = commType;
     }
-    const dropFile = new DropFile(makeClient(), opts);
+    const dropFile = new DropFile(makeClient(properties), opts);
     return dropFile.getContents().toString('latin1').split('\r\n');
 }
 
@@ -88,6 +92,27 @@ describe('DOOR.SYS comm port', () => {
     it('reports a port for serial and socket doors', () => {
         assert.equal(dropFileLines('DOOR', 'serial')[0], 'COM1:');
         assert.equal(dropFileLines('DOOR', 'socket')[0], 'COM1:');
+    });
+});
+
+describe('DOOR.SYS call times', () => {
+    it('writes distinct current and previous call times in 24-hour format', () => {
+        const lines = dropFileLines('DOOR', undefined, {
+            [UserProps.LastLoginTs]: '2026-09-12T14:32:00',
+            [UserProps.PrevLoginTs]: '2026-09-11T08:05:00',
+        });
+
+        assert.equal(lines[43], '14:32');
+        assert.equal(lines[44], '08:05');
+    });
+
+    it('leaves the previous call time blank for a first-time caller', () => {
+        const lines = dropFileLines('DOOR', undefined, {
+            [UserProps.LastLoginTs]: '2026-09-12T14:32:00',
+        });
+
+        assert.equal(lines[43], '14:32');
+        assert.equal(lines[44], '');
     });
 });
 

--- a/test/record_login.test.js
+++ b/test/record_login.test.js
@@ -206,6 +206,25 @@ describe('recordLogin() — AccountDaysOld', function () {
     });
 });
 
+// ─── recordLogin(): previous login timestamp ────────────────────────────────
+
+describe('recordLogin() — previous login timestamp', function () {
+    it('preserves LastLoginTs before updating it for the current login', done => {
+        const previousLogin = '2026-09-11T08:05:00.000Z';
+        const user = makeUser({ [UserProps.LastLoginTs]: previousLogin });
+
+        runRecordLogin(user, (err, calls) => {
+            assert.ifError(err);
+            const previousLoginCall = calls.find(
+                c => c.statName === UserProps.PrevLoginTs
+            );
+            assert.ok(previousLoginCall, 'setUserStat should preserve PrevLoginTs');
+            assert.equal(previousLoginCall.value, previousLogin);
+            done();
+        });
+    });
+});
+
 // ─── recordLogin(): LoginStreakDays / LoginStreakLastDate ─────────────────────
 
 describe('recordLogin() — login streak parallel branches', function () {


### PR DESCRIPTION
## Summary

Fixes #824.

Write the current and previous login times to their respective DOOR.SYS fields
using the format's required 24-hour representation. First-time callers now
leave the previous-call field blank instead of repeating the current time.

## Changes

- Preserve the prior login timestamp before updating `LastLoginTs`.
- Render the two DOOR.SYS call-time fields independently in 24-hour format.
- Add focused regression coverage and a `WHATSNEW.md` entry.

## Testing

- `npx mocha test/record_login.test.js test/dropfile_comm_type.test.js --timeout 5000 --require test/setup.js --exit`
- `npm run lint`
- `npm run pretty:check`

`npm test` reached 2,453 passing tests but exited with 122 unrelated failures
in the BinkP/socket, shared-config, case-sensitive filesystem, and TTY-dependent
suites. The focused suites above pass independently.